### PR TITLE
fix: add more defaultNotAllowedPaths for zip command

### DIFF
--- a/extension/zip.go
+++ b/extension/zip.go
@@ -40,7 +40,7 @@ var (
 		"src/Resources/app/storefront/node_modules",
 		"src/Resources/app/administration/node_modules",
 		"src/Resources/app/node_modules",
-		"var"
+		"var",
 	}
 
 	defaultNotAllowedFiles = []string{

--- a/extension/zip.go
+++ b/extension/zip.go
@@ -39,6 +39,8 @@ var (
 		".shopware-extension.yml",
 		"src/Resources/app/storefront/node_modules",
 		"src/Resources/app/administration/node_modules",
+		"src/Resources/app/node_modules",
+		"var"
 	}
 
 	defaultNotAllowedFiles = []string{


### PR DESCRIPTION
We are using a shared node_modules folder without splitting into administration and storefront - sounds legit, doesn't it?
Additionally, the folder `var` can just contain stuff you may not want :-) for example cs_fixer-cache.