### PR TITLE
Fix ci for go 1.18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
       - v*
     branches:
       - main
+      - fix-lint-hints
     paths:
       - '*.go'
       - '**/*.go'
@@ -25,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - misspell
     - nakedret
     - noctx
-    - nolintlint
     - rowserrcheck
     - staticcheck
     - structcheck
@@ -44,6 +43,8 @@ linters:
     - errname
     - nilnil
     - tenv
+  # Fails with go 1.18 until https://github.com/golangci/golangci-lint/issues/2649 is resolved
+  #    - nolintlint
 
   # don't enable:
   # - ireturn


### PR DESCRIPTION
Some lints get disabled automatically. This upsets the nolint lint.
Solution is to disable nolint lint for now