### PR TITLE
Keep OS environment intact for shell executions.

### DIFF
--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -172,8 +172,6 @@ func init() {
 
 func executeHooks(ext extension.Extension, hooks []string, extDir string) error {
 	env := []string{
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
-		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
 		fmt.Sprintf("EXTENSION_DIR=%s", extDir),
 		fmt.Sprintf("ORIGINAL_EXTENSION_DIR=%s", ext.GetPath()),
 	}
@@ -183,7 +181,7 @@ func executeHooks(ext extension.Extension, hooks []string, extDir string) error 
 		hookCmd.Stdout = os.Stdout
 		hookCmd.Stderr = os.Stderr
 		hookCmd.Dir = extDir
-		hookCmd.Env = env
+		hookCmd.Env = append(os.Environ(), env...)
 		err := hookCmd.Run()
 
 		if err != nil {

--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -96,13 +96,12 @@ func buildStorefront(projectRoot string, forceNpmInstall bool) error {
 	}
 
 	envs := []string{
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		fmt.Sprintf("PROJECT_ROOT=%s", projectRoot),
 		"PUPPETEER_SKIP_DOWNLOAD=1",
 	}
 
 	npmRun := exec.Command("npm", "--prefix", storefrontRoot, "run", "production")
-	npmRun.Env = envs
+	npmRun.Env = append(os.Environ(), envs...)
 	npmRun.Stdin = os.Stdin
 	npmRun.Stdout = os.Stdout
 	npmRun.Stderr = os.Stderr
@@ -144,13 +143,8 @@ func buildAdministration(projectRoot string, forceNpmInstall bool) error {
 		}
 	}
 
-	envs := []string{
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
-		fmt.Sprintf("PROJECT_ROOT=%s", projectRoot),
-	}
-
 	npmRun := exec.Command("npm", "--prefix", adminRoot, "run", "build")
-	npmRun.Env = envs
+	npmRun.Env = append(os.Environ(), fmt.Sprintf("PROJECT_ROOT=%s", projectRoot))
 	npmRun.Stdin = os.Stdin
 	npmRun.Stdout = os.Stdout
 	npmRun.Stderr = os.Stderr


### PR DESCRIPTION
Some version managers (in my case asdf) need a proper shell environment. This fixes the remaining environment replacements of command executions to keep the current environment.