### PR TITLE
Extension create - command

### DIFF
--- a/cmd/project/project_config_init.go
+++ b/cmd/project/project_config_init.go
@@ -2,8 +2,9 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
 	"os"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"

--- a/cmd/project/project_extension_create.go
+++ b/cmd/project/project_extension_create.go
@@ -1,0 +1,233 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/FriendsOfShopware/shopware-cli/config"
+	"github.com/manifoldco/promptui"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var projectExtensionCreateCmd = &cobra.Command{
+	Use:   "create [name]",
+	Short: "Create an extension boilerplate",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		rootPath, err := findClosestShopwareProject()
+		if err != nil {
+			return err
+		}
+
+		var extensionConfig config.ExtensionConfig = config.ExtensionConfig{
+			Name:      args[0],
+			Namespace: args[0],
+			License:   "MIT",
+		}
+
+		namespace, _ := cmd.PersistentFlags().GetString("namespace")
+
+		if namespace != "" {
+			extensionConfig.Namespace = namespace
+		}
+
+		fmt.Printf("Using namespace: %s\n", extensionConfig.Namespace)
+
+		pluginPath := fmt.Sprintf("%s/custom/plugins/%s", rootPath, extensionConfig.Name)
+
+		if _, err := os.Stat(pluginPath); err == nil {
+			return fmt.Errorf("the directory '%s' already exists", pluginPath)
+		}
+
+		extensionConfig.ComposerPackage = askExtension(promptui.Prompt{
+			Label:    "Composer package",
+			Validate: validComposerPackage,
+		})
+
+		extensionConfig.Label = askExtension(promptui.Prompt{
+			Label:    "Plugin label",
+			Validate: emptyValidator,
+		})
+
+		extensionConfig.Description = askExtension(promptui.Prompt{
+			Label:    "Plugin description",
+			Validate: emptyValidator,
+		})
+
+		extensionConfig.License = askExtension(promptui.Prompt{
+			Label:    "License",
+			Validate: emptyValidator,
+			Default:  extensionConfig.License,
+		})
+
+		extensionConfig.ManufacturerLink = askExtension(promptui.Prompt{
+			Label:    "Manufacturer link",
+			Validate: emptyValidator,
+		})
+
+		extensionConfig.SupportLink = askExtension(promptui.Prompt{
+			Label:    "Support link",
+			Validate: emptyValidator,
+			Default:  extensionConfig.ManufacturerLink,
+		})
+
+		err = os.MkdirAll(fmt.Sprintf("%s/src/Resources/config", pluginPath), 0755)
+		if err != nil {
+			return err
+		}
+
+		err = createComposerJson(fmt.Sprintf("%s/composer.json", pluginPath), extensionConfig)
+		if err != nil {
+			return err
+		}
+
+		err = makeBootstrap(pluginPath, extensionConfig)
+		if err != nil {
+			return err
+		}
+
+		err = makeChangelog(pluginPath)
+		if err != nil {
+			return err
+		}
+
+		err = makeDefaultServices(pluginPath)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	projectExtensionCmd.AddCommand(projectExtensionCreateCmd)
+	projectExtensionCreateCmd.PersistentFlags().String("namespace", "", "Namespace for the plugin")
+}
+
+func askExtension(inputPrompt promptui.Prompt) string {
+	if id, err := inputPrompt.Run(); err != nil {
+		panic(err)
+	} else {
+		return id
+	}
+}
+
+func validComposerPackage(s string) error {
+	validComposerPackageRegExp := regexp.MustCompile("^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$")
+
+	if !validComposerPackageRegExp.MatchString(s) {
+		return errors.New(fmt.Sprintf("'%s' is not a valid composer package", s))
+	}
+	return nil
+}
+
+func createComposerJson(composerFile string, extensionConfig config.ExtensionConfig) error {
+
+	type composerExtra struct {
+		ShopwarePluginClass string            `json:"shopware-plugin-class"`
+		Label               map[string]string `json:"label"`
+		Description         map[string]string `json:"description"`
+		ManufacturerLink    map[string]string `json:"manufacturerLink"`
+		SupportLink         map[string]string `json:"supportLink"`
+	}
+
+	type composerStruct struct {
+		Name        string         `json:"name"`
+		Version     string         `json:"version"`
+		Description string         `json:"description"`
+		Type        string         `json:"type"`
+		License     string         `json:"license"`
+		Autoload    map[string]any `json:"autoload"`
+		Extra       composerExtra  `json:"extra"`
+	}
+
+	composerData := composerStruct{
+		Name:        extensionConfig.Name,
+		Version:     "1.0.0",
+		Description: extensionConfig.Description,
+		Type:        "shopware-platform-plugin",
+		License:     extensionConfig.License,
+		Autoload: map[string]any{
+			"psr-4": map[string]string{
+				fmt.Sprintf("%s\\", extensionConfig.Namespace): "src/",
+			},
+		},
+		Extra: composerExtra{
+			ShopwarePluginClass: fmt.Sprintf("%s\\%s", extensionConfig.Namespace, extensionConfig.Name),
+			Label: map[string]string{
+				"en_GB": extensionConfig.Label,
+			},
+			Description: map[string]string{
+				"en-GB": extensionConfig.Description,
+			},
+			ManufacturerLink: map[string]string{
+				"en-GB": extensionConfig.ManufacturerLink,
+			},
+			SupportLink: map[string]string{
+				"en-GB": extensionConfig.SupportLink,
+			},
+		},
+	}
+
+	jsonContent, err := json.MarshalIndent(composerData, "", " ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(composerFile, jsonContent, 0644)
+}
+
+func makeDefaultServices(pluginPath string) error {
+	xml := `<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+
+    </services>
+</container>
+`
+
+	servicesFilename := fmt.Sprintf("%s/src/Resources/config/services.xml", pluginPath)
+	return os.WriteFile(servicesFilename, []byte(xml), 0644)
+}
+
+func makeChangelog(pluginPath string) error {
+	changelogContent := `# Changelog
+
+	All notable changes to this project will be documented in this file.
+
+	The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+	and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+	## [Unreleased]
+
+	## [1.0.0]
+
+	### Added
+
+	- Initial version
+`
+
+	changelogFilename := fmt.Sprintf("%s/CHANGELOG_en-GB.md", pluginPath)
+	return os.WriteFile(changelogFilename, []byte(changelogContent), 0644)
+}
+
+func makeBootstrap(pluginPath string, extensionConfig config.ExtensionConfig) error {
+
+	fileContentTemplate := `<?php declare(strict_types=1);
+namespace %s;
+use Shopware\Core\Framework\Plugin;
+class %s extends Plugin
+{
+}
+`
+	bootStrapFilename := fmt.Sprintf("%s/src/%s.php", pluginPath, extensionConfig.Name)
+	fileContent := fmt.Sprintf(fileContentTemplate, extensionConfig.Namespace, extensionConfig.Name)
+	return os.WriteFile(bootStrapFilename, []byte(fileContent), 0644)
+}

--- a/cmd/project/project_extension_create.go
+++ b/cmd/project/project_extension_create.go
@@ -211,18 +211,18 @@ func makeDefaultServices(pluginPath string) error {
 func makeChangelog(pluginPath string) error {
 	changelogContent := `# Changelog
 
-	All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file.
 
-	The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-	and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-	## [Unreleased]
+## [Unreleased]
 
-	## [1.0.0]
+## [1.0.0]
 
-	### Added
+### Added
 
-	- Initial version
+- Initial version
 `
 
 	changelogFilename := fmt.Sprintf("%s/CHANGELOG_en-GB.md", pluginPath)

--- a/config/config.go
+++ b/config/config.go
@@ -140,15 +140,14 @@ func createNewConfig(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+
 	encoder := yaml.NewEncoder(f)
 	err = encoder.Encode(defaultConfig())
 	if err != nil {
 		return err
 	}
 
-	return f.Sync()
-
+	return f.Close()
 }
 
 func (Config) GetAccountEmail() string {

--- a/config/config.go
+++ b/config/config.go
@@ -142,7 +142,13 @@ func createNewConfig(path string) error {
 	}
 	defer f.Close()
 	encoder := yaml.NewEncoder(f)
-	return encoder.Encode(defaultConfig())
+	err = encoder.Encode(defaultConfig())
+	if err != nil {
+		return err
+	}
+
+	return f.Sync()
+
 }
 
 func (Config) GetAccountEmail() string {

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type ExtensionConfig struct {
 	Name             string
 	Namespace        string
 	ComposerPackage  string
+	ShopwareVersion  string
 	Description      string
 	License          string
 	Label            string

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/caarlos0/env/v6"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 	"os"
 	"strconv"
 	"sync"
+
+	"github.com/caarlos0/env/v6"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
 var state *configState
@@ -28,6 +29,17 @@ type configData struct {
 		Password string `env:"SHOPWARE_CLI_ACCOUNT_PASSWORD" yaml:"password"`
 		Company  int    `env:"SHOPWARE_CLI_ACCOUNT_COMPANY" yaml:"company"`
 	} `yaml:"account"`
+}
+
+type ExtensionConfig struct {
+	Name             string
+	Namespace        string
+	ComposerPackage  string
+	Description      string
+	License          string
+	Label            string
+	ManufacturerLink string
+	SupportLink      string
 }
 
 type Config struct{}


### PR DESCRIPTION
Replicated the frosh:make:plugin command from FroshDevelopmentHelper to be able to create a new plugin skeleton without having the FroshDevelopmentHelper installed.