### PR TITLE
Make PHP and NodeJS versions configurable

### DIFF
--- a/.github/workflows/base-docker.yml
+++ b/.github/workflows/base-docker.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        php-version: ["8.1", "7.4", "7.2"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -19,7 +21,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build Image
-        run: docker build -t ghcr.io/friendsofshopware/shopware-cli-base:7.4 -f Dockerfile.base  .
+        run: docker build -t ghcr.io/friendsofshopware/shopware-cli-base:phpv${{ matrix.php-version }} -f Dockerfile.base --build-arg="PHP_VERSION=${{ matrix.php-version }}" .
 
       - name: Push Image
-        run: docker push ghcr.io/friendsofshopware/shopware-cli-base:7.4
+        run: docker push ghcr.io/friendsofshopware/shopware-cli-base:phpv${{ matrix.php-version }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,11 +43,31 @@ release:
     name: shopware-cli
 
 dockers:
-  - image_templates:
+  -
+    image_templates:
       - "ghcr.io/friendsofshopware/shopware-cli:{{ .Tag }}"
       - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}"
       - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/friendsofshopware/shopware-cli:{{ .Tag }}-phpv8.1"
+      - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}-phpv8.1"
+      - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}.{{ .Minor }}-phpv8.1"
       - "ghcr.io/friendsofshopware/shopware-cli:latest"
+    build_flag_templates:
+      - "--build-arg=PHP_VERSION=8.1"
+  -
+    image_templates:
+      - "ghcr.io/friendsofshopware/shopware-cli:{{ .Tag }}-phpv7.4"
+      - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}-phpv7.4"
+      - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}.{{ .Minor }}-phpv7.4"
+    build_flag_templates:
+      - "--build-arg=PHP_VERSION=7.4"
+  -
+    image_templates:
+      - "ghcr.io/friendsofshopware/shopware-cli:{{ .Tag }}-phpv7.2"
+      - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}-phpv7.2"
+      - "ghcr.io/friendsofshopware/shopware-cli:v{{ .Major }}.{{ .Minor }}-phpv7.2"
+    build_flag_templates:
+      - "--build-arg=PHP_VERSION=7.2"
 
 checksum:
   name_template: 'checksums.txt'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM ghcr.io/friendsofshopware/shopware-cli-base:7.4
+ARG PHP_VERSION
+
+FROM ghcr.io/friendsofshopware/shopware-cli-base:phpv${PHP_VERSION}
 
 COPY shopware-cli /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "shopware-cli"]
+CMD ["--help"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,11 +1,23 @@
-FROM php:7.4.33-cli
+ARG PHP_VERSION
+
+FROM php:${PHP_VERSION}-cli
 
 LABEL org.opencontainers.image.source https://github.com/FriendsOfShopware/shopware-cli
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
-    apt-get install -y git nodejs && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 soap zip gmp pcntl redis pcov imagick xsl calendar
+RUN apt-get update \
+    && apt-get install -y git \
+    && install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 soap zip gmp pcntl redis pcov imagick xsl calendar
 
-ENTRYPOINT ["/usr/local/bin/shopware-cli"]
+RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash - \
+    && . /root/.bashrc \
+    && nvm install 16 \
+    && nvm install 18 \
+    && nvm alias default 18 \
+    && nvm use default
+
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /root/.bashrc
+nvm use "${NODE_VERSION:-18}" > /dev/null
+
+exec "$@"


### PR DESCRIPTION
With this MR new base- and application images will be built for the PHP-versions v7.2, v7.4 and v8.1.
Also, the application image now contains the [node version manager](https://github.com/nvm-sh/nvm) as well as an entry point which utilizes it to set the node version in use according to `${NODE_VERSION}` (v18 by default).