### PR TITLE
Allow @stability flags

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -19,13 +19,13 @@ var (
 // of a version.
 const (
 	VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|([-@]?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 		`?`
 
 	// SemverRegexpRaw requires a separator between version and prerelease
 	SemverRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|([-@]([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 		`?`
 )


### PR DESCRIPTION
This allows extensions to use [`@stability` flags](https://getcomposer.org/doc/articles/versions.md#stability-constraints). Version constraints like `6.4-dev` are working already. This change should extend the capability to version constraints like `6.4@dev`.

Currently, when the `extension zip` subcommand encounters such a constraint in a `require` section of the `composer.json`, it throws this error:
```
FATA[0000] prepare package: add composer replacements: get shopware version constraint: Malformed constraint: 6.4@dev
```

I don't know, whether this was left out deliberately, so this PR might or might not make sense 😄