### PR TITLE
Adjust version regex prefix

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -18,13 +18,13 @@ var (
 // The raw regular expression string used for testing the validity
 // of a version.
 const (
-	VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+	VersionRegexpRaw string = `[\^~v]?([0-9]+(\.[0-9]+)*?)` +
 		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|([-@]?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 		`?`
 
 	// SemverRegexpRaw requires a separator between version and prerelease
-	SemverRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+	SemverRegexpRaw string = `[\^~v]?([0-9]+(\.[0-9]+)*?)` +
 		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|([-@]([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 		`?`


### PR DESCRIPTION
And another one 😄 This allows version definitions for shopware packages to begin with any of `^ ~ v`, so `~6.4` would be valid then.

This is only useful for development purposes when working with a symlinked platform repository.

Before: https://regexr.com/76gc7
After: https://regexr.com/76gc1