### PR TITLE
Ignore symlinks found in project directory when copying to /tmp

### DIFF
--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -2,10 +2,11 @@ package extension
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/extension"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 
 	"github.com/pkg/errors"
 
@@ -87,7 +88,7 @@ var extensionZipCmd = &cobra.Command{
 
 		// Extract files using strategy
 		if disableGit {
-			err = cp.Copy(path, extDir)
+			err = cp.Copy(path, extDir, copyOptions())
 			if err != nil {
 				return errors.Wrap(err, "copy files")
 			}
@@ -190,4 +191,12 @@ func executeHooks(ext extension.Extension, hooks []string, extDir string) error 
 	}
 
 	return nil
+}
+
+func copyOptions() cp.Options {
+	return cp.Options{
+		OnSymlink: func(string) cp.SymlinkAction {
+			return cp.Skip
+		},
+	}
 }


### PR DESCRIPTION
When executing `extension zip`, the contents of the extension directory get copied over to `/tmp`.

At the moment, this is done for symlinks as well using the [shallow strategy](https://github.com/otiai10/copy/blob/main/options.go#L73). The symlinks, however, can't be zipped and lead to errors like this:

```
msg="create zip file: could not zip file, sourcePath: \"/tmp/extension1393500189/SwagPluginTemplate/vendor/shopware/core\", zipPath: \"SwagPluginTemplate/vendor/shopware/core\", read /tmp/extension1393500189/SwagPluginTemplate/vendor/shopware/core: is a directory"
```

This particular error could be solved by ignoring `shopware/[core, ...]` dependencies. However, skipping symlinks is a sensible approach when creating an archive either way.