### PR TITLE
Enable gci to fix the order of imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
     - nilnil
     - tenv
     - depguard
+    - gci
   # Fails with go 1.18 until https://github.com/golangci/golangci-lint/issues/2649 is resolved
   #    - nolintlint
 
@@ -72,6 +73,11 @@ linters-settings:
     list-type: denylist
     packages:
       - github.com/pkg/errors
+  gci:
+    sections:
+      - Standard
+      - Default
+      - "Prefix(github.com/FriendsOfShopware/shopware-cli)"
 
 issues:
   exclude-rules:

--- a/account-api/producer_extension.go
+++ b/account-api/producer_extension.go
@@ -9,8 +9,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/FriendsOfShopware/shopware-cli/version"
 	"github.com/microcosm-cc/bluemonday"
+
+	"github.com/FriendsOfShopware/shopware-cli/version"
 )
 
 type SoftwareVersionList []SoftwareVersion

--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -1,9 +1,10 @@
 package account
 
 import (
+	"github.com/spf13/cobra"
+
 	account_api "github.com/FriendsOfShopware/shopware-cli/account-api"
 	"github.com/FriendsOfShopware/shopware-cli/config"
-	"github.com/spf13/cobra"
 )
 
 var accountRootCmd = &cobra.Command{

--- a/cmd/account/account_company_use.go
+++ b/cmd/account/account_company_use.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"strconv"
 
-	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
-
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
+
+	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
 )
 
 var accountCompanyUseCmd = &cobra.Command{

--- a/cmd/account/account_login.go
+++ b/cmd/account/account_login.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
 	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
 )
 
 var loginCmd = &cobra.Command{

--- a/cmd/account/account_logout.go
+++ b/cmd/account/account_logout.go
@@ -3,10 +3,10 @@ package account
 import (
 	"fmt"
 
-	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
+
+	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
 )
 
 var logoutCmd = &cobra.Command{

--- a/cmd/account/account_producer_extension_create.go
+++ b/cmd/account/account_producer_extension_create.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
-
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
+
+	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
 )
 
 var accountCompanyProducerExtensionCreateCmd = &cobra.Command{

--- a/cmd/account/account_producer_extension_delete.go
+++ b/cmd/account/account_producer_extension_delete.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/account/account_producer_extension_info_pull.go
+++ b/cmd/account/account_producer_extension_info_pull.go
@@ -8,12 +8,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{

--- a/cmd/account/account_producer_extension_info_push.go
+++ b/cmd/account/account_producer_extension_info_push.go
@@ -7,16 +7,15 @@ import (
 	"path/filepath"
 	"strings"
 
-	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
 	"github.com/yuin/goldmark"
 	goldmarkExtension "github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer/html"
+
+	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 var accountCompanyProducerExtensionInfoPushCmd = &cobra.Command{

--- a/cmd/account/account_producer_extension_list.go
+++ b/cmd/account/account_producer_extension_list.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"strconv"
 
-	account_api "github.com/FriendsOfShopware/shopware-cli/account-api"
-
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+
+	account_api "github.com/FriendsOfShopware/shopware-cli/account-api"
 )
 
 var accountCompanyProducerExtensionListCmd = &cobra.Command{

--- a/cmd/account/account_producer_extension_upload.go
+++ b/cmd/account/account_producer_extension_upload.go
@@ -5,12 +5,11 @@ import (
 	"path/filepath"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	account_api "github.com/FriendsOfShopware/shopware-cli/account-api"
 	"github.com/FriendsOfShopware/shopware-cli/extension"
-
-	log "github.com/sirupsen/logrus"
-
-	"github.com/spf13/cobra"
 )
 
 var accountCompanyProducerExtensionUploadCmd = &cobra.Command{

--- a/cmd/extension/extension_admin_watch.go
+++ b/cmd/extension/extension_admin_watch.go
@@ -12,14 +12,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/FriendsOfShopware/shopware-cli/esbuild"
-	"github.com/FriendsOfShopware/shopware-cli/extension"
 	"github.com/NYTimes/gziphandler"
 	"github.com/evanw/esbuild/pkg/api"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/vulcand/oxy/forward"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/FriendsOfShopware/shopware-cli/esbuild"
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 var hostRegExp = regexp.MustCompile(`(?m)host:\s'.*,`)

--- a/cmd/extension/extension_build.go
+++ b/cmd/extension/extension_build.go
@@ -5,11 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 var extensionAssetBundleCmd = &cobra.Command{

--- a/cmd/extension/extension_create.go
+++ b/cmd/extension/extension_create.go
@@ -8,9 +8,10 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/FriendsOfShopware/shopware-cli/config"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/config"
 )
 
 var extensionCreateCmd = &cobra.Command{

--- a/cmd/extension/extension_prepare.go
+++ b/cmd/extension/extension_prepare.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/FriendsOfShopware/shopware-cli/extension"
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 var extensionPrepareCmd = &cobra.Command{

--- a/cmd/extension/extension_validate.go
+++ b/cmd/extension/extension_validate.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 var extensionValidateCmd = &cobra.Command{

--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -6,11 +6,11 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-
 	cp "github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 var (

--- a/cmd/project/config_sync.go
+++ b/cmd/project/config_sync.go
@@ -3,8 +3,10 @@ package project
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
+
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 func readSystemConfig(ctx adminSdk.ApiContext, client *adminSdk.Client, salesChannelId *string) (*adminSdk.SystemConfigCollection, error) {

--- a/cmd/project/config_sync_entity.go
+++ b/cmd/project/config_sync_entity.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
 
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 type EntitySync struct{}

--- a/cmd/project/config_sync_mail_template.go
+++ b/cmd/project/config_sync_mail_template.go
@@ -3,12 +3,13 @@ package project
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
 	"os"
 	"path/filepath"
 
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 type MailTemplateSync struct{}

--- a/cmd/project/config_sync_system_config.go
+++ b/cmd/project/config_sync_system_config.go
@@ -2,10 +2,11 @@ package project
 
 import (
 	"encoding/json"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
 
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 type SystemConfigSync struct{}

--- a/cmd/project/config_sync_theme.go
+++ b/cmd/project/config_sync_theme.go
@@ -2,9 +2,10 @@ package project
 
 import (
 	"encoding/json"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
 
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 type ThemeSync struct{}

--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -3,12 +3,14 @@ package project
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
 )
 
 func findClosestShopwareProject() (string, error) {

--- a/cmd/project/project_admin_api.go
+++ b/cmd/project/project_admin_api.go
@@ -6,9 +6,10 @@ import (
 	"path"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/FriendsOfShopware/shopware-cli/curl"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
-	"github.com/spf13/cobra"
 )
 
 var skipDefaultHeaders bool

--- a/cmd/project/project_clear_cache.go
+++ b/cmd/project/project_clear_cache.go
@@ -2,12 +2,13 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"os"
 
+	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectClearCacheCmd = &cobra.Command{

--- a/cmd/project/project_config_init.go
+++ b/cmd/project/project_config_init.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-
 	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectConfigInitCmd = &cobra.Command{

--- a/cmd/project/project_config_pull.go
+++ b/cmd/project/project_config_pull.go
@@ -1,13 +1,14 @@
 package project
 
 import (
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"os"
 
+	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectConfigPullCmd = &cobra.Command{

--- a/cmd/project/project_config_push.go
+++ b/cmd/project/project_config_push.go
@@ -2,12 +2,13 @@ package project
 
 import (
 	"encoding/json"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 
+	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectConfigPushCmd = &cobra.Command{

--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -2,16 +2,18 @@ package project
 
 import (
 	"fmt"
-	update_api "github.com/FriendsOfShopware/shopware-cli/update-api"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
 	"github.com/manifoldco/promptui"
 	"github.com/mholt/archiver/v3"
 	"github.com/schollz/progressbar/v3"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
+
+	update_api "github.com/FriendsOfShopware/shopware-cli/update-api"
 )
 
 var projectCreateCmd = &cobra.Command{

--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -6,14 +6,14 @@ import (
 	"os"
 	"strings"
 
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-
 	"github.com/doutorfinancas/go-mad/core"
 	"github.com/doutorfinancas/go-mad/database"
 	"github.com/doutorfinancas/go-mad/generator"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectDatabaseDumpCmd = &cobra.Command{

--- a/cmd/project/project_extension_activate.go
+++ b/cmd/project/project_extension_activate.go
@@ -2,10 +2,12 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
+
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionActivateCmd = &cobra.Command{

--- a/cmd/project/project_extension_deactivate.go
+++ b/cmd/project/project_extension_deactivate.go
@@ -2,10 +2,12 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
+
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionDeactivateCmd = &cobra.Command{

--- a/cmd/project/project_extension_delete.go
+++ b/cmd/project/project_extension_delete.go
@@ -2,10 +2,12 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
+
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionDeleteCmd = &cobra.Command{

--- a/cmd/project/project_extension_install.go
+++ b/cmd/project/project_extension_install.go
@@ -2,10 +2,12 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
+
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionInstallCmd = &cobra.Command{

--- a/cmd/project/project_extension_list.go
+++ b/cmd/project/project_extension_list.go
@@ -3,12 +3,13 @@ package project
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"os"
 
+	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionListCmd = &cobra.Command{

--- a/cmd/project/project_extension_outdated.go
+++ b/cmd/project/project_extension_outdated.go
@@ -3,13 +3,14 @@ package project
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"os"
 
+	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionOutdatedCmd = &cobra.Command{

--- a/cmd/project/project_extension_uninstall.go
+++ b/cmd/project/project_extension_uninstall.go
@@ -2,10 +2,12 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
+
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionUninstallCmd = &cobra.Command{

--- a/cmd/project/project_extension_update.go
+++ b/cmd/project/project_extension_update.go
@@ -2,10 +2,12 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
+
 	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectExtensionUpdateCmd = &cobra.Command{

--- a/cmd/project/project_extension_upload.go
+++ b/cmd/project/project_extension_upload.go
@@ -11,14 +11,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
+	cp "github.com/otiai10/copy"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/FriendsOfShopware/shopware-cli/extension"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
 	"github.com/FriendsOfShopware/shopware-cli/version"
-	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
-	cp "github.com/otiai10/copy"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 var projectExtensionUploadCmd = &cobra.Command{

--- a/cmd/project/project_proxy.go
+++ b/cmd/project/project_proxy.go
@@ -2,12 +2,14 @@ package project
 
 import (
 	"fmt"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"runtime"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/FriendsOfShopware/shopware-cli/shop"
 )
 
 var projectProxyCmd = &cobra.Command{

--- a/cmd/project/project_worker.go
+++ b/cmd/project/project_worker.go
@@ -2,14 +2,15 @@ package project
 
 import (
 	"context"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strconv"
 	"sync"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var projectWorkerCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,14 +2,15 @@ package cmd
 
 import (
 	"context"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	accountApi "github.com/FriendsOfShopware/shopware-cli/account-api"
 	"github.com/FriendsOfShopware/shopware-cli/cmd/account"
 	"github.com/FriendsOfShopware/shopware-cli/cmd/extension"
 	"github.com/FriendsOfShopware/shopware-cli/cmd/project"
 	"github.com/FriendsOfShopware/shopware-cli/config"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 var cfgFile string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path"
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseEnvConfig(t *testing.T) {

--- a/extension/asset_platform.go
+++ b/extension/asset_platform.go
@@ -9,9 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/FriendsOfShopware/shopware-cli/esbuild"
 	"github.com/FriendsOfShopware/shopware-cli/version"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/extension/asset_platform_test.go
+++ b/extension/asset_platform_test.go
@@ -1,13 +1,13 @@
 package extension
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {

--- a/extension/platform.go
+++ b/extension/platform.go
@@ -17,8 +17,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/FriendsOfShopware/shopware-cli/version"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/FriendsOfShopware/shopware-cli/version"
 )
 
 type PlatformPlugin struct {

--- a/extension/zip_test.go
+++ b/extension/zip_test.go
@@ -1,9 +1,11 @@
 package extension
 
 import (
-	"github.com/FriendsOfShopware/shopware-cli/version"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/FriendsOfShopware/shopware-cli/version"
 )
 
 func TestDetermineMinVersion(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/FriendsOfShopware/shopware-cli/cmd"
 )
 

--- a/shop/config.go
+++ b/shop/config.go
@@ -2,13 +2,13 @@ package shop
 
 import (
 	"fmt"
-	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
-	"gopkg.in/yaml.v3"
 	"os"
 	"strings"
 
 	"github.com/doutorfinancas/go-mad/core"
+	adminSdk "github.com/friendsofshopware/go-shopware-admin-api-sdk"
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {


### PR DESCRIPTION
Sorts the imports by:

- Stdlib
- 3rd party
- this repo

Run `golangci-lint run --fix` to automatically apply this again and again.