### PR TITLE
Detect and use package manger based on lock file

### DIFF
--- a/extension/asset_platform.go
+++ b/extension/asset_platform.go
@@ -69,7 +69,7 @@ func BuildAssetsForExtensions(ctx context.Context, shopwareRoot string, extensio
 		// Install also shared node_modules
 		if _, err := os.Stat(filepath.Join(entry.BasePath, "Resources", "app", "package.json")); err == nil {
 			npmPath := filepath.Join(entry.BasePath, "Resources", "app")
-			if err := npmInstall(npmPath); err != nil {
+			if err := installDependencies(npmPath); err != nil {
 				return err
 			}
 
@@ -80,7 +80,7 @@ func BuildAssetsForExtensions(ctx context.Context, shopwareRoot string, extensio
 
 		if _, err := os.Stat(filepath.Join(entry.BasePath, "Resources", "app", "administration", "package.json")); err == nil {
 			npmPath := filepath.Join(entry.BasePath, "Resources", "app", "administration")
-			if err := npmInstall(npmPath); err != nil {
+			if err := installDependencies(npmPath); err != nil {
 				return err
 			}
 
@@ -91,7 +91,7 @@ func BuildAssetsForExtensions(ctx context.Context, shopwareRoot string, extensio
 
 		if _, err := os.Stat(filepath.Join(entry.BasePath, "Resources", "app", "storefront", "package.json")); err == nil {
 			npmPath := filepath.Join(entry.BasePath, "Resources", "app", "storefront")
-			err := npmInstall(npmPath)
+			err := installDependencies(npmPath)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ func BuildAssetsForExtensions(ctx context.Context, shopwareRoot string, extensio
 			}
 		} else {
 			administrationRoot := PlatformPath(shopwareRoot, "Administration", "Resources/app/administration")
-			err := npmInstallAndBuild(
+			err := npmRunBuild(
 				administrationRoot,
 				"build",
 				[]string{fmt.Sprintf("PROJECT_ROOT=%s", shopwareRoot), "SHOPWARE_ADMIN_BUILD_ONLY_EXTENSIONS=1"},
@@ -150,7 +150,7 @@ func BuildAssetsForExtensions(ctx context.Context, shopwareRoot string, extensio
 			}
 		} else {
 			storefrontRoot := PlatformPath(shopwareRoot, "Storefront", "Resources/app/storefront")
-			err := npmInstallAndBuild(
+			err := npmRunBuild(
 				storefrontRoot,
 				"production",
 				[]string{fmt.Sprintf("PROJECT_ROOT=%s", shopwareRoot), fmt.Sprintf("STOREFRONT_ROOT=%s", storefrontRoot)},
@@ -176,8 +176,8 @@ func deletePath(ctx context.Context, path string) {
 	}
 }
 
-func npmInstallAndBuild(path string, buildCmd string, buildEnvVariables []string) error {
-	if err := npmInstall(path); err != nil {
+func npmRunBuild(path string, buildCmd string, buildEnvVariables []string) error {
+	if err := installDependencies(path); err != nil {
 		return err
 	}
 
@@ -194,14 +194,26 @@ func npmInstallAndBuild(path string, buildCmd string, buildEnvVariables []string
 	return nil
 }
 
-func npmInstall(path string) error {
-	npmInstallCmd := exec.Command("npm", "--prefix", path, "install", "--no-audit", "--no-fund", "--prefer-offline") //nolint:gosec
-	npmInstallCmd.Stdout = os.Stdout
-	npmInstallCmd.Stderr = os.Stderr
-	npmInstallCmd.Env = os.Environ()
-	npmInstallCmd.Env = append(npmInstallCmd.Env, "PUPPETEER_SKIP_DOWNLOAD=1")
+func getInstallCommand(path string) *exec.Cmd {
+	if _, err := os.Stat(filepath.Join(path, "pnpm-lock.yaml")); err == nil {
+		return exec.Command("pnpm", "--prefix", path, "install")
+	}
 
-	if err := npmInstallCmd.Run(); err != nil {
+	if _, err := os.Stat(filepath.Join(path, "yarn.lock")); err == nil {
+		return exec.Command("yarn", "--prefix", path, "install")
+	}
+
+	return exec.Command("npm", "--prefix", path, "install", "--no-audit", "--no-fund", "--prefer-offline")
+}
+
+func installDependencies(path string) error {
+	InstallCmd := getInstallCommand(path)
+	InstallCmd.Stdout = os.Stdout
+	InstallCmd.Stderr = os.Stderr
+	InstallCmd.Env = os.Environ()
+	InstallCmd.Env = append(InstallCmd.Env, "PUPPETEER_SKIP_DOWNLOAD=1")
+
+	if err := InstallCmd.Run(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR lets `shopware-cli` detect what package manager was used based on the lock file. To then use that package manager to install dependencies. Currently, supported are `pnpm`, `yarn` and `npm` as a fallback.