### PR TITLE
feat: add support for environment variables in the project configuration

### DIFF
--- a/shop/config.go
+++ b/shop/config.go
@@ -101,7 +101,8 @@ func ReadConfig(fileName string, allowFallback bool) (*Config, error) {
 		return nil, fmt.Errorf("ReadConfig: %v", err)
 	}
 
-	err = yaml.Unmarshal(fileHandle, &config)
+	substitutedConfig := os.ExpandEnv(string(fileHandle))
+	err = yaml.Unmarshal([]byte(substitutedConfig), &config)
 
 	if err != nil {
 		return nil, fmt.Errorf("ReadConfig: %v", err)


### PR DESCRIPTION
This would be nice e.g. for secrets that should not be committed in the configuration file. This would allow deploying configurations from github actions etc. via a secret store (e.g. github action secrets).

You could access them like this:
```
admin_api:
    username: ${SHOPWARE_API_USERNAME}
    password: ${SHOPWARE_API_PASSWORD}
```

Possible side effects are:
- Environment strings are now parsed and this could be problematic with some configurations where such strings or part of them (`${}`, `${SOME_VAR}`, `$SOME_VAR`) are willingly used as values
