### PR TITLE
feat(ci): build admin assets only needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 /*.zip
 /FroshTools
 /result
+/project
 dump.sql*
 
 # Devenv

--- a/cmd/extension/extension_admin_watch.go
+++ b/cmd/extension/extension_admin_watch.go
@@ -22,6 +22,8 @@ import (
 	"github.com/FriendsOfShopware/shopware-cli/logging"
 )
 
+const schemeHostSeparator = "://"
+
 var (
 	hostRegExp              = regexp.MustCompile(`(?m)host:\s'.*,`)
 	portRegExp              = regexp.MustCompile(`(?m)port:\s.*,`)
@@ -147,9 +149,9 @@ var extensionAdminWatchCmd = &cobra.Command{
 				bodyStr = hostRegExp.ReplaceAllString(bodyStr, "host: '"+browserUrl.Host+"',")
 				bodyStr = portRegExp.ReplaceAllString(bodyStr, "port: "+browserPort+",")
 				bodyStr = schemeRegExp.ReplaceAllString(bodyStr, "scheme: '"+browserUrl.Scheme+"',")
-				bodyStr = schemeAndHttpHostRegExp.ReplaceAllString(bodyStr, "schemeAndHttpHost: '"+browserUrl.Scheme+"://"+browserUrl.Host+"',")
-				bodyStr = uriRegExp.ReplaceAllString(bodyStr, "uri: '"+browserUrl.Scheme+"://"+browserUrl.Host+targetShopUrl.Path+"/admin',")
-				bodyStr = assetPathRegExp.ReplaceAllString(bodyStr, "assetPath: '"+browserUrl.Scheme+"://"+browserUrl.Host+targetShopUrl.Path+"'")
+				bodyStr = schemeAndHttpHostRegExp.ReplaceAllString(bodyStr, "schemeAndHttpHost: '"+browserUrl.Scheme+schemeHostSeparator+browserUrl.Host+"',")
+				bodyStr = uriRegExp.ReplaceAllString(bodyStr, "uri: '"+browserUrl.Scheme+schemeHostSeparator+browserUrl.Host+targetShopUrl.Path+"/admin',")
+				bodyStr = assetPathRegExp.ReplaceAllString(bodyStr, "assetPath: '"+browserUrl.Scheme+schemeHostSeparator+browserUrl.Host+targetShopUrl.Path+"'")
 
 				bodyStr = assetRegExp.ReplaceAllStringFunc(bodyStr, func(s string) string {
 					firstPart := ""
@@ -194,7 +196,7 @@ var extensionAdminWatchCmd = &cobra.Command{
 			if req.URL.Path == targetShopUrl.Path+"/api/_info/config" {
 				logging.FromContext(cmd.Context()).Debugf("intercept plugins call")
 
-				proxyReq, _ := http.NewRequest("GET", targetShopUrl.Scheme+"://"+targetShopUrl.Host+req.URL.Path, nil)
+				proxyReq, _ := http.NewRequest("GET", targetShopUrl.Scheme+schemeHostSeparator+targetShopUrl.Host+req.URL.Path, nil)
 
 				proxyReq.Header.Set("Authorization", req.Header.Get("Authorization"))
 

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -74,12 +74,13 @@ var projectCI = &cobra.Command{
 		}
 
 		assetCfg := extension.AssetBuildConfig{
-			EnableESBuildForAdmin:      false,
-			EnableESBuildForStorefront: false,
-			CleanupNodeModules:         true,
-			ShopwareRoot:               args[0],
-			ShopwareVersion:            constraint,
-			Browserslist:               shopCfg.Build.Browserslist,
+			EnableESBuildForAdmin:        false,
+			EnableESBuildForStorefront:   false,
+			CleanupNodeModules:           true,
+			ShopwareRoot:                 args[0],
+			ShopwareVersion:              constraint,
+			Browserslist:                 shopCfg.Build.Browserslist,
+			SkipExtensionsWithBuildFiles: true,
 		}
 
 		if err := extension.BuildAssetsForExtensions(cmd.Context(), sources, assetCfg); err != nil {

--- a/extension/asset_platform_test.go
+++ b/extension/asset_platform_test.go
@@ -26,7 +26,7 @@ func TestGenerateConfigWithAdminAndStorefrontFiles(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(path.Join(dir, "Resources", "app", "storefront", "src"), os.ModePerm))
 	assert.NoError(t, os.WriteFile(path.Join(dir, "Resources", "app", "storefront", "src", "main.js"), []byte("test"), os.ModePerm))
 
-	config := buildAssetConfigFromExtensions([]asset.Source{{Name: "FroshTools", Path: dir}}, "")
+	config := buildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "FroshTools", Path: dir}}, AssetBuildConfig{})
 
 	assert.True(t, config.Has("FroshTools"))
 	assert.True(t, config.RequiresAdminBuild())
@@ -56,7 +56,7 @@ func TestGenerateConfigWithTypeScript(t *testing.T) {
 	assert.NoError(t, os.WriteFile(path.Join(dir, "Resources", "app", "storefront", "src", "main.ts"), []byte("test"), os.ModePerm))
 	assert.NoError(t, os.WriteFile(path.Join(dir, "Resources", "app", "storefront", "build", "webpack.config.js"), []byte("test"), os.ModePerm))
 
-	config := buildAssetConfigFromExtensions([]asset.Source{{Name: "FroshTools", Path: dir}}, "")
+	config := buildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "FroshTools", Path: dir}}, AssetBuildConfig{})
 
 	assert.True(t, config.Has("FroshTools"))
 	assert.True(t, config.RequiresAdminBuild())
@@ -71,7 +71,7 @@ func TestGenerateConfigWithTypeScript(t *testing.T) {
 }
 
 func TestGenerateConfigAddsStorefrontAlwaysAsEntrypoint(t *testing.T) {
-	config := buildAssetConfigFromExtensions([]asset.Source{}, "")
+	config := buildAssetConfigFromExtensions(getTestContext(), []asset.Source{}, AssetBuildConfig{})
 
 	assert.False(t, config.RequiresStorefrontBuild())
 	assert.False(t, config.RequiresAdminBuild())
@@ -80,7 +80,7 @@ func TestGenerateConfigAddsStorefrontAlwaysAsEntrypoint(t *testing.T) {
 func TestGenerateConfigDoesNotAddExtensionWithoutConfig(t *testing.T) {
 	dir := t.TempDir()
 
-	config := buildAssetConfigFromExtensions([]asset.Source{{Name: "FroshApp", Path: dir}}, "")
+	config := buildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "FroshApp", Path: dir}}, AssetBuildConfig{})
 
 	assert.False(t, config.Has("FroshApp"))
 }
@@ -88,7 +88,7 @@ func TestGenerateConfigDoesNotAddExtensionWithoutConfig(t *testing.T) {
 func TestGenerateConfigDoesNotAddExtensionWithoutName(t *testing.T) {
 	dir := t.TempDir()
 
-	config := buildAssetConfigFromExtensions([]asset.Source{{Name: "", Path: dir}}, "")
+	config := buildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "", Path: dir}}, AssetBuildConfig{})
 
 	assert.Len(t, config, 1)
 }


### PR DESCRIPTION
shopware-cli project ci builds right now all assets for any extension. The build system of the administration is stable, we can use the existing files of the extension. For the storefront we still need to do this.

Before: 46s

After: 18s