### PR TITLE
feat: use esbuild when possible for project builds

### DIFF
--- a/cmd/extension/extension_build.go
+++ b/cmd/extension/extension_build.go
@@ -17,9 +17,7 @@ var extensionAssetBundleCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		assetCfg := extension.AssetBuildConfig{
-			EnableESBuildForAdmin:      false,
-			EnableESBuildForStorefront: false,
-			ShopwareRoot:               os.Getenv("SHOPWARE_PROJECT_ROOT"),
+			ShopwareRoot: os.Getenv("SHOPWARE_PROJECT_ROOT"),
 		}
 		validatedExtensions := make([]extension.Extension, 0)
 
@@ -35,13 +33,6 @@ var extensionAssetBundleCmd = &cobra.Command{
 			}
 
 			validatedExtensions = append(validatedExtensions, ext)
-		}
-
-		if len(args) == 1 {
-			extCfg := validatedExtensions[0].GetExtensionConfig()
-
-			assetCfg.EnableESBuildForAdmin = extCfg.Build.Zip.Assets.EnableESBuildForAdmin
-			assetCfg.EnableESBuildForStorefront = extCfg.Build.Zip.Assets.EnableESBuildForStorefront
 		}
 
 		constraint, err := validatedExtensions[0].GetShopwareVersionConstraint()

--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -137,11 +137,9 @@ var extensionZipCmd = &cobra.Command{
 			}
 
 			assetBuildConfig := extension.AssetBuildConfig{
-				EnableESBuildForAdmin:      extCfg.Build.Zip.Assets.EnableESBuildForAdmin,
-				EnableESBuildForStorefront: extCfg.Build.Zip.Assets.EnableESBuildForStorefront,
-				CleanupNodeModules:         true,
-				ShopwareRoot:               os.Getenv("SHOPWARE_PROJECT_ROOT"),
-				ShopwareVersion:            shopwareConstraint,
+				CleanupNodeModules: true,
+				ShopwareRoot:       os.Getenv("SHOPWARE_PROJECT_ROOT"),
+				ShopwareVersion:    shopwareConstraint,
 			}
 
 			if err := extension.BuildAssetsForExtensions(cmd.Context(), extension.ConvertExtensionsToSources(cmd.Context(), []extension.Extension{tempExt}), assetBuildConfig); err != nil {

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -74,8 +74,6 @@ var projectCI = &cobra.Command{
 		}
 
 		assetCfg := extension.AssetBuildConfig{
-			EnableESBuildForAdmin:        false,
-			EnableESBuildForStorefront:   false,
 			CleanupNodeModules:           true,
 			ShopwareRoot:                 args[0],
 			ShopwareVersion:              constraint,

--- a/extension/asset.go
+++ b/extension/asset.go
@@ -20,8 +20,10 @@ func ConvertExtensionsToSources(ctx context.Context, extensions []Extension) []a
 		}
 
 		sources = append(sources, asset.Source{
-			Name: name,
-			Path: ext.GetRootDir(),
+			Name:                        name,
+			Path:                        ext.GetRootDir(),
+			AdminEsbuildCompatible:      ext.GetExtensionConfig().Build.Zip.Assets.EnableESBuildForAdmin,
+			StorefrontEsbuildCompatible: ext.GetExtensionConfig().Build.Zip.Assets.EnableESBuildForStorefront,
 		})
 
 		extConfig := ext.GetExtensionConfig()
@@ -35,8 +37,10 @@ func ConvertExtensionsToSources(ctx context.Context, extensions []Extension) []a
 				}
 
 				sources = append(sources, asset.Source{
-					Name: bundleName,
-					Path: path.Join(ext.GetRootDir(), bundle.Path),
+					Name:                        bundleName,
+					Path:                        path.Join(ext.GetRootDir(), bundle.Path),
+					AdminEsbuildCompatible:      ext.GetExtensionConfig().Build.Zip.Assets.EnableESBuildForAdmin,
+					StorefrontEsbuildCompatible: ext.GetExtensionConfig().Build.Zip.Assets.EnableESBuildForStorefront,
 				})
 			}
 		}

--- a/extension/asset_platform.go
+++ b/extension/asset_platform.go
@@ -27,8 +27,6 @@ const (
 )
 
 type AssetBuildConfig struct {
-	EnableESBuildForAdmin        bool
-	EnableESBuildForStorefront   bool
 	CleanupNodeModules           bool
 	DisableAdminBuild            bool
 	DisableStorefrontBuild       bool

--- a/extension/asset_platform_test.go
+++ b/extension/asset_platform_test.go
@@ -90,5 +90,5 @@ func TestGenerateConfigDoesNotAddExtensionWithoutName(t *testing.T) {
 
 	config := buildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "", Path: dir}}, AssetBuildConfig{})
 
-	assert.Len(t, config, 1)
+	assert.Len(t, config, 0)
 }

--- a/extension/asset_test.go
+++ b/extension/asset_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestConvertPlugin(t *testing.T) {
 	plugin := PlatformPlugin{
-		path: t.TempDir(),
+		path:   t.TempDir(),
+		config: &Config{},
 		composer: platformComposerJson{
 			Extra: platformComposerJsonExtra{
 				ShopwarePluginClass: "FroshTools\\FroshTools",
@@ -28,7 +29,8 @@ func TestConvertPlugin(t *testing.T) {
 
 func TestConvertApp(t *testing.T) {
 	app := App{
-		path: t.TempDir(),
+		path:   t.TempDir(),
+		config: &Config{},
 		manifest: appManifest{
 			Meta: appManifestMeta{
 				Name: "TestApp",

--- a/extension/project.go
+++ b/extension/project.go
@@ -66,9 +66,18 @@ func FindAssetSourcesOfProject(ctx context.Context, project string) []asset.Sour
 
 		logging.FromContext(ctx).Infof("Found bundle in project: %s (path: %s)", name, bundlePath)
 
+		bundleConfig, err := readExtensionConfig(bundlePath)
+
+		if err != nil {
+			logging.FromContext(ctx).Errorf("Cannot read bundle config: %s", err.Error())
+			continue
+		}
+
 		sources = append(sources, asset.Source{
-			Name: name,
-			Path: path.Join(project, bundlePath),
+			Name:                        name,
+			Path:                        path.Join(project, bundlePath),
+			AdminEsbuildCompatible:      bundleConfig.Build.Zip.Assets.EnableESBuildForAdmin,
+			StorefrontEsbuildCompatible: bundleConfig.Build.Zip.Assets.EnableESBuildForStorefront,
 		})
 	}
 

--- a/internal/asset/source.go
+++ b/internal/asset/source.go
@@ -1,6 +1,8 @@
 package asset
 
 type Source struct {
-	Name string
-	Path string
+	Name                        string
+	Path                        string
+	AdminEsbuildCompatible      bool
+	StorefrontEsbuildCompatible bool
 }


### PR DESCRIPTION
Right now `shopware-cli project ci` uses the traditional steps like `build-administration.sh` and `build-storefront.sh`

Since a while we support esbuild for building extensions much faster without access to the Shopware source code. To adopt this for building multiple extensions, we know split the extensions:

- ESBuild compatible admin/storefront now will always be build with esbuild.
- Any non-compatible extension will use the regular complication

So we have the best of both worlds. Some extensions build faster and which are not compatible use the regular setup.

Some benchmarks:

Project: All extensions have esbuild support. 

- `shopware project ci` (current version): 1 minute build time.
- `shopware project ci` (this branch): 29 seconds build time.

I think the improvement can be better seen in CI like GitHub Actions with limited amount of resources. My machine has 16 cores, 128gb memory, little bit overkill to compare, but still 2x faster than the previous version.
