### PR TITLE
ci: Use go version 1.21 in codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,16 +27,17 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
-
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
https://github.com/FriendsOfShopware/shopware-cli/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BOPFWWY/8995f414fa6b8c81d8ea10d32456beb0e9c9ce19415f181c174a3cccfaaec44e