### PR TITLE
Use symfony CLI for running PHP when available

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -12,6 +12,7 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/FriendsOfShopware/shopware-cli/extension"
+	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
 	"github.com/FriendsOfShopware/shopware-cli/logging"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
 	"github.com/spf13/cobra"
@@ -55,7 +56,7 @@ var projectCI = &cobra.Command{
 
 		logging.FromContext(cmd.Context()).Infof("Installing dependencies using Composer")
 
-		composer := exec.CommandContext(cmd.Context(), "composer", "install", "--no-dev", "--no-interaction", "--no-progress", "--optimize-autoloader", "--classmap-authoritative")
+		composer := phpexec.ComposerCommand(cmd.Context(), "install", "--no-dev", "--no-interaction", "--no-progress", "--optimize-autoloader", "--classmap-authoritative")
 		composer.Dir = args[0]
 		composer.Stdin = os.Stdin
 		composer.Stdout = os.Stdout
@@ -107,7 +108,7 @@ var projectCI = &cobra.Command{
 
 		logging.FromContext(cmd.Context()).Infof("Warmup container cache")
 
-		if err := runTransparentCommand(exec.CommandContext(cmd.Context(), "php", path.Join(args[0], "bin", "ci"), "--version")); err != nil { //nolint: gosec
+		if err := runTransparentCommand(phpexec.PHPCommand(cmd.Context(), path.Join(args[0], "bin", "ci"), "--version")); err != nil { //nolint: gosec
 			return fmt.Errorf("failed to warmup container cache (php bin/ci --version): %w", err)
 		}
 
@@ -122,7 +123,7 @@ var projectCI = &cobra.Command{
 				}
 			}
 
-			if err := runTransparentCommand(exec.CommandContext(cmd.Context(), "php", path.Join(args[0], "bin", "ci"), "asset:install")); err != nil { //nolint: gosec
+			if err := runTransparentCommand(phpexec.PHPCommand(cmd.Context(), path.Join(args[0], "bin", "ci"), "asset:install")); err != nil { //nolint: gosec
 				return fmt.Errorf("failed to install assets (php bin/ci asset:install): %w", err)
 			}
 		}

--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -1,8 +1,8 @@
 package project
 
 import (
+	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
-	"os/exec"
 
 	"github.com/FriendsOfShopware/shopware-cli/extension"
 	"github.com/FriendsOfShopware/shopware-cli/logging"
@@ -49,7 +49,7 @@ var projectAdminBuildCmd = &cobra.Command{
 			return nil
 		}
 
-		return runTransparentCommand(commandWithRoot(exec.CommandContext(cmd.Context(), "php", "bin/console", "assets:install"), projectRoot))
+		return runTransparentCommand(commandWithRoot(phpexec.ConsoleCommand(cmd.Context(), "assets:install"), projectRoot))
 	},
 }
 

--- a/cmd/project/project_admin_watch.go
+++ b/cmd/project/project_admin_watch.go
@@ -1,12 +1,14 @@
 package project
 
 import (
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
+	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
+	"github.com/FriendsOfShopware/shopware-cli/shop"
+	"github.com/spf13/cobra"
 )
 
 var projectAdminWatchCmd = &cobra.Command{
@@ -35,7 +37,7 @@ var projectAdminWatchCmd = &cobra.Command{
 			return err
 		}
 
-		if err := runTransparentCommand(commandWithRoot(exec.CommandContext(cmd.Context(), "php", "bin/console", "feature:dump"), projectRoot)); err != nil {
+		if err := runTransparentCommand(commandWithRoot(phpexec.ConsoleCommand(cmd.Context(), "feature:dump"), projectRoot)); err != nil {
 			return err
 		}
 
@@ -59,7 +61,7 @@ var projectAdminWatchCmd = &cobra.Command{
 				}
 			}
 
-			if err := runTransparentCommand(commandWithRoot(exec.CommandContext(cmd.Context(), "php", "bin/console", "-eprod", "framework:schema", "-s", "entity-schema", path.Join(mockDirectory, "entity-schema.json")), projectRoot)); err != nil {
+			if err := runTransparentCommand(commandWithRoot(phpexec.ConsoleCommand(cmd.Context(), "-eprod", "framework:schema", "-s", "entity-schema", path.Join(mockDirectory, "entity-schema.json")), projectRoot)); err != nil {
 				return err
 			}
 

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -1,8 +1,8 @@
 package project
 
 import (
+	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
-	"os/exec"
 
 	"github.com/FriendsOfShopware/shopware-cli/extension"
 	"github.com/FriendsOfShopware/shopware-cli/logging"
@@ -49,7 +49,7 @@ var projectStorefrontBuildCmd = &cobra.Command{
 			return nil
 		}
 
-		return runTransparentCommand(commandWithRoot(exec.CommandContext(cmd.Context(), "php", "bin/console", "theme:compile"), projectRoot))
+		return runTransparentCommand(commandWithRoot(phpexec.ConsoleCommand(cmd.Context(), "theme:compile"), projectRoot))
 	},
 }
 

--- a/cmd/project/project_storefront_watch.go
+++ b/cmd/project/project_storefront_watch.go
@@ -1,12 +1,14 @@
 package project
 
 import (
-	"github.com/FriendsOfShopware/shopware-cli/extension"
-	"github.com/FriendsOfShopware/shopware-cli/shop"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/FriendsOfShopware/shopware-cli/extension"
+	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
+	"github.com/FriendsOfShopware/shopware-cli/shop"
+	"github.com/spf13/cobra"
 )
 
 var projectStorefrontWatchCmd = &cobra.Command{
@@ -35,7 +37,7 @@ var projectStorefrontWatchCmd = &cobra.Command{
 			return err
 		}
 
-		if err := runTransparentCommand(commandWithRoot(exec.CommandContext(cmd.Context(), "php", "bin/console", "feature:dump"), projectRoot)); err != nil {
+		if err := runTransparentCommand(commandWithRoot(phpexec.ConsoleCommand(cmd.Context(), "feature:dump"), projectRoot)); err != nil {
 			return err
 		}
 
@@ -45,11 +47,11 @@ var projectStorefrontWatchCmd = &cobra.Command{
 			activeOnly = "-v"
 		}
 
-		if err := runTransparentCommand(commandWithRoot(exec.CommandContext(cmd.Context(), "php", "bin/console", "theme:compile", activeOnly), projectRoot)); err != nil {
+		if err := runTransparentCommand(commandWithRoot(phpexec.ConsoleCommand(cmd.Context(), "theme:compile", activeOnly), projectRoot)); err != nil {
 			return err
 		}
 
-		if err := runTransparentCommand(commandWithRoot(exec.CommandContext(cmd.Context(), "php", "bin/console", "theme:dump"), projectRoot)); err != nil {
+		if err := runTransparentCommand(commandWithRoot(phpexec.ConsoleCommand(cmd.Context(), "theme:dump"), projectRoot)); err != nil {
 			return err
 		}
 

--- a/cmd/project/project_worker.go
+++ b/cmd/project/project_worker.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 
+	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
 
 	"github.com/spf13/cobra"
@@ -54,7 +54,7 @@ var projectWorkerCmd = &cobra.Command{
 		cancelCtx, cancel := context.WithCancel(cobraCmd.Context())
 		cancelOnTermination(cancelCtx, cancel)
 
-		consumeArgs := []string{"bin/console", "messenger:consume", fmt.Sprintf("--memory-limit=%s", memoryLimit), fmt.Sprintf("--time-limit=%s", timeLimit)}
+		consumeArgs := []string{"messenger:consume", fmt.Sprintf("--memory-limit=%s", memoryLimit), fmt.Sprintf("--time-limit=%s", timeLimit)}
 
 		if queuesToConsume == "" {
 			if is, _ := shop.IsShopwareVersion(projectRoot, ">=6.5"); is {
@@ -73,7 +73,7 @@ var projectWorkerCmd = &cobra.Command{
 			wg.Add(1)
 			go func(ctx context.Context) {
 				for {
-					cmd := exec.CommandContext(cancelCtx, "php", consumeArgs...)
+					cmd := phpexec.ConsoleCommand(cancelCtx, consumeArgs...)
 					cmd.Dir = projectRoot
 					cmd.Stdout = os.Stdout
 					cmd.Stderr = os.Stderr

--- a/internal/phpexec/phpexec.go
+++ b/internal/phpexec/phpexec.go
@@ -1,0 +1,41 @@
+package phpexec
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+var pathToSymfonyCLI = sync.OnceValue[string](func() string {
+	path, err := exec.LookPath("symfony")
+	if err != nil {
+		return ""
+	}
+	return path
+})
+
+func symfonyCliAllowed() bool {
+	return os.Getenv("SHOPWARE_CLI_NO_SYMFONY_CLI") != "1"
+}
+
+func ConsoleCommand(ctx context.Context, args ...string) *exec.Cmd {
+	if path := pathToSymfonyCLI(); path != "" && symfonyCliAllowed() {
+		return exec.CommandContext(ctx, path, append([]string{"console"}, args...)...)
+	}
+	return exec.CommandContext(ctx, "php", append([]string{"bin/console"}, args...)...)
+}
+
+func ComposerCommand(ctx context.Context, args ...string) *exec.Cmd {
+	if path := pathToSymfonyCLI(); path != "" && symfonyCliAllowed() {
+		return exec.CommandContext(ctx, path, append([]string{"composer"}, args...)...)
+	}
+	return exec.CommandContext(ctx, "composer", args...)
+}
+
+func PHPCommand(ctx context.Context, args ...string) *exec.Cmd {
+	if path := pathToSymfonyCLI(); path != "" && symfonyCliAllowed() {
+		return exec.CommandContext(ctx, path, append([]string{"php"}, args...)...)
+	}
+	return exec.CommandContext(ctx, "php", args...)
+}

--- a/internal/phpexec/phpexec_test.go
+++ b/internal/phpexec/phpexec_test.go
@@ -1,0 +1,68 @@
+package phpexec
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSymfonyDetection(t *testing.T) {
+	testCases := []struct {
+		Name        string
+		Func        func(context.Context, ...string) *exec.Cmd
+		Args        []string
+		SymfonyArgs []string
+	}{
+		{
+			Name:        "Composer",
+			Func:        ComposerCommand,
+			Args:        []string{"composer"},
+			SymfonyArgs: []string{"/test/symfony", "composer"},
+		},
+		{
+			Name:        "Console",
+			Func:        ConsoleCommand,
+			Args:        []string{"php", "bin/console"},
+			SymfonyArgs: []string{"/test/symfony", "console"},
+		},
+		{
+			Name:        "PHP",
+			Func:        PHPCommand,
+			Args:        []string{"php"},
+			SymfonyArgs: []string{"/test/symfony", "php"},
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Run("Default", func(t *testing.T) {
+				pathToSymfonyCLI = func() string { return "" }
+
+				cmd := tc.Func(ctx, "some", "arguments")
+				assert.Equal(t, append(tc.Args, "some", "arguments"), cmd.Args)
+			})
+
+			t.Run("Symfony", func(t *testing.T) {
+				pathToSymfonyCLI = func() string { return "/test/symfony" }
+
+				cmd := tc.Func(ctx, "some", "arguments")
+				assert.Equal(t, append(tc.SymfonyArgs, "some", "arguments"), cmd.Args)
+			})
+
+			t.Run("Symfony disabled", func(t *testing.T) {
+				t.Setenv("SHOPWARE_CLI_NO_SYMFONY_CLI", "1")
+
+				pathToSymfonyCLI = func() string { return "/test/symfony" }
+
+				cmd := tc.Func(ctx, "some", "arguments")
+				assert.Equal(t, append(tc.Args, "some", "arguments"), cmd.Args)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Right now there is no easy way to choose a PHP version / installation for use by shopware-cli. This can be a problem when working on multiple projects with different required PHP versions.

Symfony's [CLI tool](https://github.com/symfony-cli/symfony-cli) can automatically detect the correct PHP version / installation to use for a project based on (among other things) a .php-version file or the required PHP version from composer.json files.

This PHP version can than be used by running `symfony php` instead of `php`. Similarly there is also a `symfony composer` command for running composer with the correct PHP version and even a `symfony console` command for running the `bin/console` tool.

We can use this to easily support different PHP versions.

This PR introduces a new `internal/phpexec` package for creating commands for running PHP, composer and bin/console which will automatically use the Symfony CLI if available.

It also updates the existing code to use the new package whenever possible.

The new logic can be disable by setting the `SHOPWARE_CLI_NO_SYMFONY_CLI` environment variable to `1`.

While it would also have been possible to directly import the logic from the symfony-cli repository (which is also written in Go), doing so would be more work as the logic is not in one place and it may end up introducing incompatibilities between the two implementations.

Also unlike the actual CLI interface (`symfony php`, etc.) the actual source packages are not guaranteed to be stable.