### PR TITLE
fix: determine shopware project version regardless of setup

### DIFF
--- a/extension/project_test.go
+++ b/extension/project_test.go
@@ -1,0 +1,164 @@
+package extension
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetShopwareProjectConstraintComposerJson(t *testing.T) {
+	testCases := []struct {
+		Name       string
+		Files      map[string]string
+		Constraint string
+		Error      string
+	}{
+		{
+			Name: "Get constraint from composer.json",
+			Files: map[string]string{
+				"composer.json": `{
+		"require": {
+			"shopware/core": "~6.5.0"
+	}}`,
+			},
+			Constraint: "~6.5.0",
+		},
+		{
+			Name: "Get constraint from composer.lock",
+			Files: map[string]string{
+				"composer.json": `{
+		"require": {
+			"shopware/core": "6.5.*"
+	}}`,
+				"composer.lock": `{
+		"packages": [
+{
+"name": "shopware/core",
+"version": "6.5.0"
+}
+]}`,
+			},
+			Constraint: "6.5.0",
+		},
+		{
+			Name: "Branch installed, determine by Kernel.php",
+			Files: map[string]string{
+				"composer.json": `{
+		"require": {
+			"shopware/core": "6.5.*"
+	}}`,
+				"composer.lock": `{
+		"packages": [
+{
+"name": "shopware/core",
+"version": "dev-trunk"
+}
+]}`,
+				"src/Core/composer.json": `{}`,
+				"src/Core/Kernel.php": `<?php
+final public const SHOPWARE_FALLBACK_VERSION = '6.6.9999999.9999999-dev';
+`,
+			},
+			Constraint: "~6.6.0",
+		},
+		{
+			Name: "Get constraint from kernel (shopware/shopware case)",
+			Files: map[string]string{
+				"composer.json":          `{}`,
+				"src/Core/composer.json": `{}`,
+				"src/Core/Kernel.php": `<?php
+final public const SHOPWARE_FALLBACK_VERSION = '6.6.9999999.9999999-dev';
+`,
+			},
+			Constraint: "~6.6.0",
+		},
+
+		// error cases
+		{
+			Name:  "no composer.json",
+			Files: map[string]string{},
+			Error: "could not read composer.json",
+		},
+
+		{
+			Name: "composer.json broken",
+			Files: map[string]string{
+				"composer.json": `broken`,
+			},
+			Error: "could not parse composer.json",
+		},
+
+		{
+			Name: "composer.json with no shopware package",
+			Files: map[string]string{
+				"composer.json": `{}`,
+			},
+			Error: "missing shopware/core requirement in composer.json",
+		},
+
+		{
+			Name: "composer.json malformed version, without lock, so we cannot fall down",
+			Files: map[string]string{
+				"composer.json": `{
+		"require": {
+			"shopware/core": "6.5.*"
+	}}`,
+			},
+			Error: "malformed constraint: 6.5.*",
+		},
+
+		{
+			Name: "composer.json malformed version, with broken lock",
+			Files: map[string]string{
+				"composer.json": `{
+		"require": {
+			"shopware/core": "6.5.*"
+	}}`,
+				"composer.lock": `broken`,
+			},
+			Error: "could not parse composer.lock",
+		},
+
+		{
+			Name: "composer.json malformed version, lock does not contain shopware/core",
+			Files: map[string]string{
+				"composer.json": `{
+		"require": {
+			"shopware/core": "6.5.*"
+	}}`,
+				"composer.lock": `{"packages": []}`,
+			},
+			Error: "malformed constraint: 6.5.*",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			for file, content := range tc.Files {
+				tmpFile := tmpDir + "/" + file
+				parentDir := filepath.Dir(tmpFile)
+
+				if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+					assert.NoError(t, os.MkdirAll(parentDir, os.ModePerm))
+				}
+
+				assert.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
+			}
+
+			constraint, err := GetShopwareProjectConstraint(tmpDir)
+
+			if tc.Constraint == "" {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), tc.Error)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.Constraint, constraint.String())
+		})
+	}
+}

--- a/version/constraint_test.go
+++ b/version/constraint_test.go
@@ -31,3 +31,12 @@ func TestConstraintParsingWhitespaceAndOr(t *testing.T) {
 	assert.True(t, c.Check(Must(NewVersion("6.5.0"))))
 	assert.False(t, c.Check(Must(NewVersion("6.4.0.0"))))
 }
+
+func TestConstraintVersionNumber(t *testing.T) {
+	c, err := NewConstraint("1.0.0")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "1.0.0", c.String())
+	assert.True(t, c.Check(Must(NewVersion("1.0.0"))))
+	assert.False(t, c.Check(Must(NewVersion("1.0.1"))))
+}


### PR DESCRIPTION
This should cover all edge cases to determine somehow with which Shopware version we are interacting. We want to have a Version Constraint so we try:

- is `shopware/core` required, take that constraint
	- If we cannot parse it (we don't support any composer version stuff), look into composer.lock for an exact version
	- If we cannot find Shopware in `composer.lock`, use `Kernel.php` of Shopware to get the fallback version.
	- When even that does not work, throw exception
- If `shopware/core` is not required,
  - Check for `Kernel.php` for the fallback version 