### PR TITLE
Fix webpack build with project dir argument

### DIFF
--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"path/filepath"
+
 	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
 
@@ -17,7 +19,11 @@ var projectAdminBuildCmd = &cobra.Command{
 		var err error
 
 		if len(args) == 1 {
-			projectRoot = args[0]
+			// We need an absolute path for webpack
+			projectRoot, err = filepath.Abs(args[0])
+			if err != nil {
+				return err
+			}
 		} else if projectRoot, err = findClosestShopwareProject(); err != nil {
 			return err
 		}

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"path/filepath"
+
 	"github.com/FriendsOfShopware/shopware-cli/internal/phpexec"
 	"github.com/FriendsOfShopware/shopware-cli/shop"
 
@@ -17,7 +19,11 @@ var projectStorefrontBuildCmd = &cobra.Command{
 		var err error
 
 		if len(args) == 1 {
-			projectRoot = args[0]
+			// We need an absolute path for webpack
+			projectRoot, err = filepath.Abs(args[0])
+			if err != nil {
+				return err
+			}
 		} else if projectRoot, err = findClosestShopwareProject(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Using a relative directory for the PROJECT_ROOT given to node/webpack does not work. When manually specifying the path for `admin-build` or `project-build` this caused webpack to fail _for some of our developers_.

Not sure exactly why only for some, but using an absolute path always works. 