### PR TITLE
Replace wrong method call Base() -> Dir()

### DIFF
--- a/account-api/client.go
+++ b/account-api/client.go
@@ -141,7 +141,7 @@ func saveApiTokenToTokenCache(client *Client) error {
 		return err
 	}
 
-	tokenFileDirectory := filepath.Base(tokenFilePath)
+	tokenFileDirectory := filepath.Dir(tokenFilePath)
 	if _, err := os.Stat(tokenFileDirectory); os.IsNotExist(err) {
 		err := os.MkdirAll(tokenFileDirectory, 0o750)
 		if err != nil {


### PR DESCRIPTION
Replace wrong method call Base() with Dir() while checking if the cache directory exists. :see_no_evil: 