### PR TITLE
fix: incorrect zip timestamp

### DIFF
--- a/extension/zip.go
+++ b/extension/zip.go
@@ -213,7 +213,6 @@ func PrepareFolderForZipping(ctx context.Context, path string, ext Extension, ex
 
 	var composer map[string]interface{}
 	err = json.Unmarshal(content, &composer)
-
 	if err != nil {
 		return fmt.Errorf(errorFormat, err)
 	}
@@ -286,17 +285,29 @@ func PrepareFolderForZipping(ctx context.Context, path string, ext Extension, ex
 func addFileToZip(zipWriter *zip.Writer, sourcePath string, zipPath string) error {
 	zipErrorFormat := "could not zip file, sourcePath: %q, zipPath: %q, %w"
 
-	dat, err := os.ReadFile(sourcePath)
+	file, err := os.Open(sourcePath)
 	if err != nil {
 		return fmt.Errorf(zipErrorFormat, sourcePath, zipPath, err)
 	}
 
-	f, err := zipWriter.Create(zipPath)
+	fileInfo, err := file.Stat()
 	if err != nil {
 		return fmt.Errorf(zipErrorFormat, sourcePath, zipPath, err)
 	}
 
-	if _, err := f.Write(dat); err != nil {
+	header, err := zip.FileInfoHeader(fileInfo)
+	if err != nil {
+		return fmt.Errorf(zipErrorFormat, sourcePath, zipPath, err)
+	}
+	header.Name = zipPath
+	header.Method = zip.Deflate
+
+	f, err := zipWriter.CreateHeader(header)
+	if err != nil {
+		return fmt.Errorf(zipErrorFormat, sourcePath, zipPath, err)
+	}
+
+	if _, err := io.Copy(f, file); err != nil {
 		return fmt.Errorf(zipErrorFormat, sourcePath, zipPath, err)
 	}
 


### PR DESCRIPTION
The timestamp of the built zip file was always 01.01.1980, 0:00, which may lead to opcache issues, because it caches also based on timestamps. Now current time is taken.