### PR TITLE
fix: "skip for review result" flag on upload command

### DIFF
--- a/cmd/account/account_producer_extension_upload.go
+++ b/cmd/account/account_producer_extension_upload.go
@@ -179,5 +179,5 @@ var skipWaitingForCodereviewResult bool
 
 func init() {
 	accountCompanyProducerExtensionCmd.AddCommand(accountCompanyProducerExtensionUploadCmd)
-	accountCompanyProducerExtensionCmd.Flags().BoolVar(&skipWaitingForCodereviewResult, "skip-for-review-result", false, "Skips waiting for Code review result")
+	accountCompanyProducerExtensionUploadCmd.Flags().BoolVar(&skipWaitingForCodereviewResult, "skip-for-review-result", false, "Skips waiting for Code review result")
 }

--- a/wiki/docs/commands/account.md
+++ b/wiki/docs/commands/account.md
@@ -56,6 +56,10 @@ Parameters:
 
 * zipPath - Path to your zip file
 
+Options:
+
+* `--skip-for-review-result` - Skips waiting for Code review result
+
 ### shopware-cli account producer extension info pull
 
 Downloads the store page information to the given extension


### PR DESCRIPTION
Flag `skip-for-review-result` is part of the `upload` but has been added to the parent command instead of the `upload` command. Therefore it is unusable