### PR TITLE
docs: install for docker without apt

### DIFF
--- a/wiki/docs/install.md
+++ b/wiki/docs/install.md
@@ -136,10 +136,18 @@ go install github.com/FriendsOfShopware/shopware-cli@latest
 
 Add a file `.ddev/web-build/Dockerfile.shopware-cli`
 
-```bash
+```Dockerfile
 # .ddev/web-build/Dockerfile.shopware-cli
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash \
-  && apt install shopware-cli
+COPY --from=ghcr.io/friendsofshopware/shopware-cli /usr/local/bin/shopware-cli /usr/local/bin/shopware-cli
+```
+
+### Docker Image
+
+Add the following line to your docker image to copy the binary into your image. 
+
+```Dockerfile
+# Dockerfile
+COPY --from=ghcr.io/friendsofshopware/shopware-cli /usr/local/bin/shopware-cli /usr/local/bin/shopware-cli
 ```
 
 ## manually


### PR DESCRIPTION
In my experience, it's more stable to just copy the binary from the upstream docker image. 

I also added a note about how to do it in a custom Docker image - even tho it's the same as in DDEV, I thought it makes sense to separate them due to the special file path in DDEV which.