### PR TITLE
Fix changelog generation with default template

### DIFF
--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -37,6 +37,10 @@ type Commit struct {
 func GenerateChangelog(ctx context.Context, repository string, cfg Config) (string, error) {
 	var err error
 
+	if cfg.Template == "" {
+		cfg.Template = defaultChangelogTpl
+	}
+
 	if strings.Contains(cfg.Template, "Config.VCSURL") {
 		cfg.VCSURL, err = git.GetPublicVCSURL(ctx, repository)
 	}
@@ -54,10 +58,6 @@ func GenerateChangelog(ctx context.Context, repository string, cfg Config) (stri
 }
 
 func renderChangelog(commits []git.GitCommit, cfg Config) (string, error) {
-	if cfg.Template == "" {
-		cfg.Template = defaultChangelogTpl
-	}
-
 	var matcher *regexp.Regexp
 	if cfg.Pattern != "" {
 		matcher = regexp.MustCompile(cfg.Pattern)

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -16,7 +16,10 @@ func TestGenerateWithoutConfig(t *testing.T) {
 		},
 	}
 
-	changelog, err := renderChangelog(commits, Config{VCSURL: "https://github.com/FriendsOfShopware/FroshTools/commit"})
+	changelog, err := renderChangelog(commits, Config{
+		VCSURL:   "https://github.com/FriendsOfShopware/FroshTools/commit",
+		Template: defaultChangelogTpl,
+	})
 
 	assert.NoError(t, err)
 
@@ -57,13 +60,14 @@ func TestIncludeFilters(t *testing.T) {
 	}
 
 	cfg := Config{
-		Pattern: "^(NEXT-[0-9]+)",
+		Pattern:  "^(NEXT-[0-9]+)",
+		Template: defaultChangelogTpl,
 	}
 
 	changelog, err := renderChangelog(commits, cfg)
 
 	assert.NoError(t, err)
-	assert.Equal(t, changelog, "- [NEXT-1234 - Fooo](/1234567890)")
+	assert.Equal(t, "- [NEXT-1234 - Fooo](/1234567890)", changelog)
 }
 
 func TestLetAiGenerateText(t *testing.T) {
@@ -88,6 +92,7 @@ func TestLetAiGenerateText(t *testing.T) {
 
 	cfg := Config{
 		AiEnabled: true,
+		Template:  defaultChangelogTpl,
 	}
 
 	changelog, err := renderChangelog(commits, cfg)


### PR DESCRIPTION
This PR fixes changelog generation when no changelog template is specified. Previously it would set the default template too late in the process, resulting in broken links because the `VCSURL` variable was not set. 

This should resolve #438 