### PR TITLE
feat: allow skipping the node_modules cleanup

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -98,7 +98,7 @@ var projectCI = &cobra.Command{
 		}
 
 		assetCfg := extension.AssetBuildConfig{
-			CleanupNodeModules:           true,
+			CleanupNodeModules:           !shopCfg.Build.SkipCleanupExtensionNodeModules,
 			ShopwareRoot:                 args[0],
 			ShopwareVersion:              shopwareConstraint,
 			Browserslist:                 shopCfg.Build.Browserslist,

--- a/shop/config.go
+++ b/shop/config.go
@@ -43,6 +43,8 @@ type ConfigBuild struct {
 	Browserslist string `yaml:"browserslist,omitempty"`
 	// Extensions to exclude from the build
 	ExcludeExtensions []string `yaml:"exclude_extensions,omitempty"`
+	// When enabled, the node_modules of extensions will not be removed from the final build
+	SkipCleanupExtensionNodeModules bool `yaml:"skip_cleanup_extension_node_modules,omitempty"`
 }
 
 type ConfigAdminApi struct {


### PR DESCRIPTION
I had some problems where plugins from the shopware store would use scss files from the node_modules directory like this: 
![image](https://github.com/user-attachments/assets/bf257b7b-2a86-4cf1-929d-1b152079351c)

This would break the theme:compile command because shopware-cli deletes the node_modules directory. While not ideal, the flag I added provides a workaround for this issue by allowing to not delete node_modules. 