### PR TITLE
feat: implement Vite configuration dumping for asset compilation

### DIFF
--- a/extension/asset_platform.go
+++ b/extension/asset_platform.go
@@ -86,6 +86,10 @@ func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, asset
 				return err
 			}
 
+			if err := esbuild.DumpViteConfig(options); err != nil {
+				return err
+			}
+
 			logging.FromContext(ctx).Infof("Building administration assets for %s using ESBuild", name)
 		}
 

--- a/internal/esbuild/util.go
+++ b/internal/esbuild/util.go
@@ -18,3 +18,10 @@ func ToKebabCase(str string) string {
 
 	return strings.TrimPrefix(converted, "-")
 }
+
+// @see https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php#L128
+func toBundleFolderName(name string) string {
+	assetDir := strings.ToLower(name)
+	assetDir = strings.TrimSuffix(assetDir, "bundle")
+	return assetDir
+}

--- a/internal/esbuild/util_test.go
+++ b/internal/esbuild/util_test.go
@@ -16,3 +16,11 @@ func TestKebabCase(t *testing.T) {
 	assert.Equal(t, "wwbla-bar-foo", ToKebabCase("wwblaBarFoo"))
 	assert.Equal(t, "with-underscore", ToKebabCase("with_underscore"))
 }
+
+func TestBundleFolderName(t *testing.T) {
+	assert.Equal(t, "myplugin", toBundleFolderName("MyPluginBundle"))
+	assert.Equal(t, "anotherplugin", toBundleFolderName("AnotherPluginBundle"))
+	assert.Equal(t, "simpleplugin", toBundleFolderName("SimplePlugin"))
+	assert.Equal(t, "plugin", toBundleFolderName("PluginBundle"))
+	assert.Equal(t, "plugin", toBundleFolderName("Plugin"))
+}

--- a/internal/esbuild/vite_config.go
+++ b/internal/esbuild/vite_config.go
@@ -1,0 +1,109 @@
+package esbuild
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+)
+
+type ViteManifestFile struct {
+	File    string   `json:"file"`
+	Name    string   `json:"name"`
+	Src     string   `json:"src"`
+	IsEntry bool     `json:"isEntry"`
+	Css     []string `json:"css"`
+}
+
+type ViteManifest struct {
+	MainJs ViteManifestFile `json:"main.js"`
+}
+
+func dumpViteManifest(options AssetCompileOptions, viteDir string) error {
+	m := ViteManifest{
+		MainJs: ViteManifestFile{
+			File:    options.OutputJSFile,
+			Name:    ToKebabCase(options.Name),
+			Src:     "main.js",
+			IsEntry: true,
+			Css:     []string{options.OutputCSSFile},
+		},
+	}
+
+	j, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path.Join(viteDir, "manifest.json"), j, os.ModePerm)
+}
+
+type ViteEntrypoint struct {
+	Css     []string `json:"css"`
+	Dynamic []string `json:"dynamic"`
+	Js      []string `json:"js"`
+	Legacy  bool     `json:"legacy"`
+	Preload []string `json:"preload"`
+}
+
+type ViteEntrypoints struct {
+	Base        string                    `json:"base"`
+	EntryPoints map[string]ViteEntrypoint `json:"entryPoints"`
+	Legacy      bool                      `json:"legacy"`
+	Metadata    interface{}               `json:"metadatas"`
+	Version     []interface{}             `json:"version"`
+	ViteServer  *interface{}              `json:"viteServer"`
+}
+
+func dumpViteEntrypoint(options AssetCompileOptions, viteDir string) error {
+	bundleFolderName := toBundleFolderName(options.Name)
+
+	e := ViteEntrypoints{
+		Base: fmt.Sprintf("/bundles/%s/administration/", bundleFolderName),
+		EntryPoints: map[string]ViteEntrypoint{
+			ToKebabCase(options.Name): {
+				Css: []string{
+					fmt.Sprintf("/bundles/%s/administration/%s", bundleFolderName, options.OutputCSSFile),
+				},
+				Dynamic: []string{},
+				Js: []string{
+					fmt.Sprintf("/bundles/%s/administration/%s", bundleFolderName, options.OutputJSFile),
+				},
+				Legacy:  false,
+				Preload: []string{},
+			},
+		},
+		Legacy:   false,
+		Metadata: map[string]interface{}{},
+		Version: []interface{}{
+			"7.0.4",
+			7,
+			0,
+			4,
+		},
+		ViteServer: nil,
+	}
+
+	j, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path.Join(viteDir, "entrypoints.json"), j, os.ModePerm)
+}
+
+func DumpViteConfig(options AssetCompileOptions) error {
+	viteDir := path.Join(path.Join(options.Path, options.OutputDir), ".vite")
+
+	if _, err := os.Stat(viteDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(viteDir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	if err := dumpViteManifest(options, viteDir); err != nil {
+		return err
+	}
+
+	return dumpViteEntrypoint(options, viteDir)
+}

--- a/internal/esbuild/vite_config.go
+++ b/internal/esbuild/vite_config.go
@@ -97,9 +97,7 @@ func DumpViteConfig(options AssetCompileOptions) error {
 
 	if _, err := os.Stat(viteDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(viteDir, 0o755); err != nil {
-			if err := os.MkdirAll(viteDir, 0o755); err != nil {
-				return fmt.Errorf("failed to create Vite directory: %w", err)
-			}
+			return fmt.Errorf("failed to create Vite directory: %w", err)
 		}
 	}
 

--- a/internal/esbuild/vite_config.go
+++ b/internal/esbuild/vite_config.go
@@ -97,7 +97,9 @@ func DumpViteConfig(options AssetCompileOptions) error {
 
 	if _, err := os.Stat(viteDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(viteDir, 0o755); err != nil {
-			if err := os.MkdirAll(viteDir, 0o755); err != nil { return fmt.Errorf("failed to create Vite directory: %w", err) }
+			if err := os.MkdirAll(viteDir, 0o755); err != nil {
+				return fmt.Errorf("failed to create Vite directory: %w", err)
+			}
 		}
 	}
 

--- a/internal/esbuild/vite_config.go
+++ b/internal/esbuild/vite_config.go
@@ -97,7 +97,7 @@ func DumpViteConfig(options AssetCompileOptions) error {
 
 	if _, err := os.Stat(viteDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(viteDir, 0o755); err != nil {
-			return err
+			if err := os.MkdirAll(viteDir, 0o755); err != nil { return fmt.Errorf("failed to create Vite directory: %w", err) }
 		}
 	}
 

--- a/internal/esbuild/vite_config_test.go
+++ b/internal/esbuild/vite_config_test.go
@@ -1,0 +1,140 @@
+package esbuild
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDumpViteManifest(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Define sample AssetCompileOptions
+	options := AssetCompileOptions{
+		OutputJSFile:  "main.js",
+		OutputCSSFile: "styles.css",
+		Name:          "TestName",
+		Path:          tempDir,
+		OutputDir:     "dist",
+	}
+
+	// Call dumpViteManifest
+	err := dumpViteManifest(options, tempDir)
+	assert.NoError(t, err)
+
+	// Verify that manifest.json is created
+	manifestPath := path.Join(tempDir, "manifest.json")
+	_, err = os.Stat(manifestPath)
+	assert.NoError(t, err)
+
+	// Read and unmarshal the content of manifest.json
+	content, err := os.ReadFile(manifestPath)
+	assert.NoError(t, err)
+
+	var manifest ViteManifest
+	err = json.Unmarshal(content, &manifest)
+	assert.NoError(t, err)
+
+	// Assert the content of manifest.json
+	expectedManifest := ViteManifest{
+		MainJs: ViteManifestFile{
+			File:    "main.js",
+			Name:    "test-name",
+			Src:     "main.js",
+			IsEntry: true,
+			Css:     []string{"styles.css"},
+		},
+	}
+	assert.Equal(t, expectedManifest, manifest)
+}
+
+func TestDumpViteEntrypoint(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Define sample AssetCompileOptions
+	options := AssetCompileOptions{
+		OutputJSFile:  "main.js",
+		OutputCSSFile: "styles.css",
+		Name:          "TestName",
+		Path:          tempDir,
+		OutputDir:     "dist",
+	}
+
+	// Call dumpViteEntrypoint
+	err := dumpViteEntrypoint(options, tempDir)
+	assert.NoError(t, err)
+
+	// Verify that entrypoints.json is created
+	entrypointsPath := path.Join(tempDir, "entrypoints.json")
+	_, err = os.Stat(entrypointsPath)
+	assert.NoError(t, err)
+
+	// Read and unmarshal the content of entrypoints.json
+	content, err := os.ReadFile(entrypointsPath)
+	assert.NoError(t, err)
+
+	var entrypoints ViteEntrypoints
+	err = json.Unmarshal(content, &entrypoints)
+	assert.NoError(t, err)
+
+	// Assert the content of entrypoints.json
+	expectedEntrypoints := ViteEntrypoints{
+		Base: "/bundles/testname/administration/",
+		EntryPoints: map[string]ViteEntrypoint{
+			"test-name": {
+				Css:     []string{"/bundles/testname/administration/styles.css"},
+				Dynamic: []string{},
+				Js:      []string{"/bundles/testname/administration/main.js"},
+				Legacy:  false,
+				Preload: []string{},
+			},
+		},
+		Legacy:   false,
+		Metadata: map[string]interface{}{},
+		Version: []interface{}{
+			"7.0.4",
+			float64(7),
+			float64(0),
+			float64(4),
+		},
+		ViteServer: nil,
+	}
+
+	assert.Equal(t, expectedEntrypoints, entrypoints)
+}
+
+func TestDumpViteConfig(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Define sample AssetCompileOptions
+	options := AssetCompileOptions{
+		OutputJSFile:  "main.js",
+		OutputCSSFile: "styles.css",
+		Name:          "TestName",
+		Path:          tempDir,
+		OutputDir:     "dist",
+	}
+
+	// Call DumpViteConfig
+	err := DumpViteConfig(options)
+	assert.NoError(t, err)
+
+	// Verify that .vite directory is created
+	viteDir := path.Join(tempDir, "dist", ".vite")
+	stat, err := os.Stat(viteDir)
+	assert.NoError(t, err)
+	assert.True(t, stat.IsDir())
+
+	// Verify that both manifest.json and entrypoints.json exist
+	_, err = os.Stat(path.Join(viteDir, "manifest.json"))
+	assert.NoError(t, err)
+
+	_, err = os.Stat(path.Join(viteDir, "entrypoints.json"))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Dump expected vite config files for 6.7, so we can build forward compatible JavaScript files