### PR TITLE
feat(validate): add --exclude flag for validation, implement ToolList.Exclude and tests

### DIFF
--- a/cmd/extension/extension_validate.go
+++ b/cmd/extension/extension_validate.go
@@ -26,6 +26,7 @@ var extensionValidateCmd = &cobra.Command{
 		checkAgainst, _ := cmd.Flags().GetString("check-against")
 		tmpDir, err := os.MkdirTemp(os.TempDir(), "analyse-extension-*")
 		only, _ := cmd.Flags().GetString("only")
+		exclude, _ := cmd.Flags().GetString("exclude")
 
 		// If the user does not want to run full validation, only run shopware-cli
 		if !isFull {
@@ -107,6 +108,11 @@ var extensionValidateCmd = &cobra.Command{
 			return err
 		}
 
+		tools, err = tools.Exclude(exclude)
+		if err != nil {
+			return err
+		}
+
 		for _, tool := range tools {
 			tool := tool
 			gr.Go(func() error {
@@ -129,6 +135,7 @@ func init() {
 	extensionValidateCmd.PersistentFlags().String("reporter", "", "Reporting format (summary, json, github, junit, markdown)")
 	extensionValidateCmd.PersistentFlags().String("check-against", "highest", "Check against Shopware Version (highest, lowest)")
 	extensionValidateCmd.PersistentFlags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
+	extensionValidateCmd.PersistentFlags().String("exclude", "", "Exclude specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	extensionValidateCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		reporter, _ := cmd.Flags().GetString("reporter")
 		if reporter != "summary" && reporter != "json" && reporter != "github" && reporter != "junit" && reporter != "markdown" && reporter != "" {

--- a/cmd/project/project_validate.go
+++ b/cmd/project/project_validate.go
@@ -23,6 +23,7 @@ var projectValidateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		reportingFormat, _ := cmd.Flags().GetString("reporter")
 		only, _ := cmd.Flags().GetString("only")
+		exclude, _ := cmd.Flags().GetString("exclude")
 		tmpDir, err := os.MkdirTemp(os.TempDir(), "analyse-project-*")
 		noCopy, _ := cmd.Flags().GetBool("no-copy")
 		if err != nil {
@@ -79,6 +80,11 @@ var projectValidateCmd = &cobra.Command{
 			return err
 		}
 
+		tools, err = tools.Exclude(exclude)
+		if err != nil {
+			return err
+		}
+
 		for _, tool := range tools {
 			tool := tool
 			gr.Go(func() error {
@@ -100,5 +106,6 @@ func init() {
 	projectRootCmd.AddCommand(projectValidateCmd)
 	projectValidateCmd.PersistentFlags().String("reporter", "", "Reporting format (summary, json, github, junit, markdown)")
 	projectValidateCmd.PersistentFlags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
+	projectValidateCmd.PersistentFlags().String("exclude", "", "Exclude specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	projectValidateCmd.PersistentFlags().Bool("no-copy", false, "Do not copy project files to temporary directory")
 }

--- a/internal/verifier/tool.go
+++ b/internal/verifier/tool.go
@@ -82,6 +82,54 @@ func (tl ToolList) Only(only string) (ToolList, error) {
 	return filteredTools, nil
 }
 
+// Exclude filters out tools listed in the comma-separated exclude string.
+// Returns an error if any specified tool name does not exist in the current list.
+func (tl ToolList) Exclude(exclude string) (ToolList, error) {
+	if exclude == "" {
+		return tl, nil
+	}
+
+	requested := strings.Split(exclude, ",")
+
+	// Validate all requested excludes exist
+	for _, name := range requested {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		found := false
+		for _, t := range tl {
+			if t.Name() == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("tool with name %q not found, possible tools: %s", name, tl.PossibleString())
+		}
+	}
+
+	// Build filtered list excluding requested names
+	excludeSet := map[string]struct{}{}
+	for _, name := range requested {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		excludeSet[name] = struct{}{}
+	}
+
+	var filtered ToolList
+	for _, t := range tl {
+		if _, ok := excludeSet[t.Name()]; ok {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+
+	return filtered, nil
+}
+
 func (tl ToolList) PossibleString() string {
 	var possibleTools []string
 	for _, t := range tl {

--- a/internal/verifier/tool_test.go
+++ b/internal/verifier/tool_test.go
@@ -1,0 +1,65 @@
+package verifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testTool struct{ name string }
+
+func (t testTool) Name() string                                                     { return t.name }
+func (t testTool) Check(ctx context.Context, check *Check, config ToolConfig) error { return nil }
+func (t testTool) Fix(ctx context.Context, config ToolConfig) error                 { return nil }
+func (t testTool) Format(ctx context.Context, config ToolConfig, dryRun bool) error { return nil }
+
+func toolNames(list ToolList) []string {
+	out := make([]string, 0, len(list))
+	for _, t := range list {
+		out = append(out, t.Name())
+	}
+	return out
+}
+
+func TestExclude_EmptyString_NoChange(t *testing.T) {
+	base := ToolList{testTool{"phpstan"}, testTool{"eslint"}, testTool{"sw-cli"}}
+	res, err := base.Exclude("")
+	assert.NoError(t, err)
+	assert.Equal(t, toolNames(base), toolNames(res))
+}
+
+func TestExclude_SingleTool(t *testing.T) {
+	base := ToolList{testTool{"phpstan"}, testTool{"eslint"}, testTool{"sw-cli"}}
+	res, err := base.Exclude("eslint")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"phpstan", "sw-cli"}, toolNames(res))
+}
+
+func TestExclude_MultipleTools(t *testing.T) {
+	base := ToolList{testTool{"phpstan"}, testTool{"eslint"}, testTool{"sw-cli"}, testTool{"stylelint"}}
+	res, err := base.Exclude("eslint, stylelint")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"phpstan", "sw-cli"}, toolNames(res))
+}
+
+func TestExclude_AllTools_ReturnsEmpty(t *testing.T) {
+	base := ToolList{testTool{"phpstan"}, testTool{"eslint"}}
+	res, err := base.Exclude("phpstan,eslint")
+	assert.NoError(t, err)
+	assert.Empty(t, res)
+}
+
+func TestExclude_UnknownTool_Error(t *testing.T) {
+	base := ToolList{testTool{"phpstan"}, testTool{"eslint"}}
+	res, err := base.Exclude("rector")
+	assert.Error(t, err)
+	assert.Nil(t, res)
+}
+
+func TestExclude_TrimsAndIgnoresDuplicates(t *testing.T) {
+	base := ToolList{testTool{"phpstan"}, testTool{"eslint"}, testTool{"sw-cli"}}
+	res, err := base.Exclude(" eslint , eslint ,  \teslint\t ")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"phpstan", "sw-cli"}, toolNames(res))
+}


### PR DESCRIPTION
This PR implements #650 by adding an `--exclude` flag to the validation commands and providing a filtering mechanism in the verifier layer.

Summary of changes:
- extension validate: add `--exclude` flag and filter tools after `--only`
- project validate: add `--exclude` flag and filter tools after `--only`
- verifier: implement `ToolList.Exclude(exclude string)` with validation of tool names
- tests: add `internal/verifier/tool_test.go` to cover Exclude behavior (empty, single, multiple, all, unknown, trimmed/duplicates)

Behavior:
- `--only` is applied first, then `--exclude` removes any specified tools
- Unknown tool names in either `--only` or `--exclude` cause a clear error listing possible tools

Try it:
- `shopware-cli project validate --exclude=phpstan,eslint`
- `shopware-cli extension validate path/to/ext --full --exclude=phpstan`

This enables users to run most validations while skipping specific tools that may not be applicable to their setup.