### PR TITLE
fix: optimize twig linter indentation

### DIFF
--- a/internal/html/parser_test.go
+++ b/internal/html/parser_test.go
@@ -63,27 +63,48 @@ func TestFormatting(t *testing.T) {
 			}
 
 			stringData := string(data)
-			stringParts := strings.SplitN(stringData, "-----", 2)
-			stringParts[0] = strings.TrimRight(stringParts[0], "\n")
-			stringParts[1] = strings.TrimLeft(stringParts[1], "\n")
+			stringParts := strings.SplitN(stringData, "-----", 3)
 
-			if len(stringParts) != 2 {
+			if len(stringParts) < 2 {
 				t.Fatalf("file %s does not contain expected delimiter", name)
 			}
 
-			parsed, err := NewParser(stringParts[0])
+			stringParts[0] = strings.Trim(stringParts[0], "\n")
+			stringParts[1] = strings.Trim(stringParts[1], "\n")
+
+			parsed, err := NewAdminParser(stringParts[0])
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			assert.Equal(t, stringParts[1], parsed.Dump(0))
 
-			parsed, err = NewParser(parsed.Dump(0))
+			parsed, err = NewAdminParser(parsed.Dump(0))
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			assert.Equal(t, stringParts[1], parsed.Dump(0))
+
+			if len(stringParts) < 3 {
+				return
+			}
+
+			stringParts[2] = strings.Trim(stringParts[2], "\n")
+
+			parsed, err = NewStorefrontParser(stringParts[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, stringParts[2], parsed.Dump(0))
+
+			parsed, err = NewStorefrontParser(parsed.Dump(0))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, stringParts[2], parsed.Dump(0))
 		})
 	}
 }

--- a/internal/html/testdata/09-elements-with-block.txt
+++ b/internal/html/testdata/09-elements-with-block.txt
@@ -1,5 +1,9 @@
 {% block foo %}<sw-button>Click me</sw-button>{% endblock %}
 -----
 {% block foo %}
+<sw-button>Click me</sw-button>
+{% endblock %}
+-----
+{% block foo %}
     <sw-button>Click me</sw-button>
 {% endblock %}

--- a/internal/html/testdata/10-multi-line-breaks-get-removed.txt
+++ b/internal/html/testdata/10-multi-line-breaks-get-removed.txt
@@ -4,6 +4,12 @@
 <sw-button>Click me</sw-button>{% endblock %}
 -----
 {% block test %}
+<sw-button>Click me</sw-button>
+
+<sw-button>Click me</sw-button>
+{% endblock %}
+-----
+{% block test %}
     <sw-button>Click me</sw-button>
 
     <sw-button>Click me</sw-button>

--- a/internal/html/testdata/29-block-nesting.txt
+++ b/internal/html/testdata/29-block-nesting.txt
@@ -8,6 +8,14 @@
 {% endblock %}
 -----
 {% block a %}
+{% block b %}
+{% block c %}
+{% block d %}{% endblock %}
+{% endblock %}
+{% endblock %}
+{% endblock %}
+-----
+{% block a %}
     {% block b %}
         {% block c %}
             {% block d %}{% endblock %}

--- a/internal/html/testdata/31-block-parent.txt
+++ b/internal/html/testdata/31-block-parent.txt
@@ -5,6 +5,12 @@
 {% endblock %}
 -----
 {% block a %}
+{% block b %}
+{% parent() %}
+{% endblock %}
+{% endblock %}
+-----
+{% block a %}
     {% block b %}
         {% parent() %}
     {% endblock %}

--- a/internal/html/testdata/33-comment-over-block.txt
+++ b/internal/html/testdata/33-comment-over-block.txt
@@ -6,3 +6,6 @@
 -----
 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
 {% block sw_import_export_tabs_profiles %}{% endblock %}
+-----
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+{% block sw_import_export_tabs_profiles %}{% endblock %}

--- a/internal/html/testdata/34-comment-over-block-nested.txt
+++ b/internal/html/testdata/34-comment-over-block-nested.txt
@@ -12,6 +12,12 @@
 -----
 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
 {% block sw_import_export_tabs_profiles %}
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+{% block foo %}{% endblock %}
+{% endblock %}
+-----
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+{% block sw_import_export_tabs_profiles %}
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block foo %}{% endblock %}
 {% endblock %}

--- a/internal/html/testdata/36-block-around-if.txt
+++ b/internal/html/testdata/36-block-around-if.txt
@@ -21,6 +21,27 @@
 -----
 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
 {% block sw_cms_element_product_slider_config_settings_min_width %}
+{% parent() %}
+
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+{% block sw_cms_element_product_slider_config_settings_slides_mobile %}
+<sw-number-field
+    {% if VUE3 %}
+        v-model:value="element.config.slidesMobile.value"
+    {% else %}
+        v-model="element.config.slidesMobile.value"
+    {% endif %}
+    :label="$tc('sw-cms.elements.productSlider.config.label.slidesMobile')"
+    :placeholder="$tc('sw-cms.elements.productSlider.config.placeholder.slidesMobile')"
+    number-type="int"
+    :step="1"
+    :min="1"
+/>
+{% endblock %}
+{% endblock %}
+-----
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+{% block sw_cms_element_product_slider_config_settings_min_width %}
     {% parent() %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/internal/html/testdata/37-formatting-element.txt
+++ b/internal/html/testdata/37-formatting-element.txt
@@ -12,6 +12,19 @@
 {% endblock %}
 -----
 {% block sw_cms_block_product_listing_preview %}
+<div class="sw-cms-preview-product-listing">
+    <div class="sw-cms-preview-product-listing__filter-panel">
+        <div class="sw-cms-preview-product-listing__filter"></div>
+        <div class="sw-cms-preview-product-listing__filter"></div>
+        <div class="sw-cms-preview-product-listing__filter"></div>
+        <div class="sw-cms-preview-product-listing__filter"></div>
+    </div>
+    <sw-cms-product-box-preview has-text/>
+    <sw-cms-product-box-preview has-text/>
+</div>
+{% endblock %}
+-----
+{% block sw_cms_block_product_listing_preview %}
     <div class="sw-cms-preview-product-listing">
         <div class="sw-cms-preview-product-listing__filter-panel">
             <div class="sw-cms-preview-product-listing__filter"></div>

--- a/internal/html/testdata/42-block-nesting-with-elements.txt
+++ b/internal/html/testdata/42-block-nesting-with-elements.txt
@@ -1,0 +1,41 @@
+{% block container %}
+    <sw-container>
+        {% block button %}
+        <sw-button>Click me</sw-button>
+        {% endblock %}
+
+        {% block text %}
+        <span>
+            Lorem ipsum
+        </span>
+        {% endblock %}
+    </sw-container>
+{% endblock %}
+-----
+{% block container %}
+<sw-container>
+    {% block button %}
+    <sw-button>Click me</sw-button>
+    {% endblock %}
+
+    {% block text %}
+    <span>
+        Lorem ipsum
+    </span>
+    {% endblock %}
+</sw-container>
+{% endblock %}
+-----
+{% block container %}
+    <sw-container>
+        {% block button %}
+            <sw-button>Click me</sw-button>
+        {% endblock %}
+
+        {% block text %}
+            <span>
+                Lorem ipsum
+            </span>
+        {% endblock %}
+    </sw-container>
+{% endblock %}

--- a/internal/verifier/admin_twig.go
+++ b/internal/verifier/admin_twig.go
@@ -44,13 +44,13 @@ func (a AdminTwigLinter) Check(ctx context.Context, check *Check, config ToolCon
 				return err
 			}
 
-			parsed, err := html.NewParser(string(file))
+			parsed, err := html.NewAdminParser(string(file))
 			if err != nil {
 				return fmt.Errorf("failed to parse %s: %w", path, err)
 			}
 
 			for _, fixer := range fixers {
-				for _, message := range fixer.Check(parsed) {
+				for _, message := range fixer.Check(parsed.Nodes) {
 					check.AddResult(validation.CheckResult{
 						Message:    message.Message,
 						Path:       strings.TrimPrefix(strings.TrimPrefix(path, "/private"), config.RootDir+"/"),
@@ -93,13 +93,13 @@ func (a AdminTwigLinter) Fix(ctx context.Context, config ToolConfig) error {
 				return err
 			}
 
-			parsed, err := html.NewParser(string(file))
+			parsed, err := html.NewAdminParser(string(file))
 			if err != nil {
 				return err
 			}
 
 			for _, fixer := range fixers {
-				if err := fixer.Fix(parsed); err != nil {
+				if err := fixer.Fix(parsed.Nodes); err != nil {
 					return err
 				}
 			}
@@ -134,7 +134,7 @@ func (a AdminTwigLinter) Format(ctx context.Context, config ToolConfig, dryRun b
 				return err
 			}
 
-			parsed, err := html.NewParser(string(file))
+			parsed, err := html.NewAdminParser(string(file))
 			if err != nil {
 				return fmt.Errorf("failed to parse %s: %w", path, err)
 			}

--- a/internal/verifier/storefront_twig.go
+++ b/internal/verifier/storefront_twig.go
@@ -52,7 +52,7 @@ func (s StorefrontTwigLinter) Check(ctx context.Context, check *Check, config To
 
 			relPath := strings.TrimPrefix(strings.TrimPrefix(path, "/private"), config.RootDir+"/")
 
-			parsed, err := html.NewParser(string(file))
+			parsed, err := html.NewStorefrontParser(string(file))
 			if err != nil {
 				check.AddResult(validation.CheckResult{
 					Path:       relPath,
@@ -66,7 +66,7 @@ func (s StorefrontTwigLinter) Check(ctx context.Context, check *Check, config To
 			}
 
 			for _, fixer := range fixers {
-				for _, message := range fixer.Check(parsed) {
+				for _, message := range fixer.Check(parsed.Nodes) {
 					check.AddResult(validation.CheckResult{
 						Path:       relPath,
 						Message:    message.Message,


### PR DESCRIPTION
Trying to optimize twig template indentation on `block`s to be more like original Administration and Storefront templates.