### PR TITLE
feat: compile html.mjml email templates during build (project ci)

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/shopware/shopware-cli/extension"
 	"github.com/shopware/shopware-cli/internal/ci"
+	"github.com/shopware/shopware-cli/internal/mjml"
 	"github.com/shopware/shopware-cli/internal/packagist"
 	"github.com/shopware/shopware-cli/internal/phpexec"
 	"github.com/shopware/shopware-cli/logging"
@@ -190,6 +191,43 @@ var projectCI = &cobra.Command{
 
 		warumupSection.End(cmd.Context())
 
+		// Compile MJML templates based on configuration
+		if shouldCompileMJML(shopCfg) {
+			mjmlSection := ci.Default.Section(cmd.Context(), "Compiling MJML templates")
+
+			// Create compiler with appropriate configuration
+			var mjmlCompiler mjml.Compiler
+			if shopCfg.Build.MJML != nil && shopCfg.Build.MJML.UseWebService {
+				mjmlConfig := mjml.Config{
+					Mode:             mjml.CompilerModeWebService,
+					WebServiceURL:    shopCfg.Build.MJML.WebServiceURL,
+					WebServiceAPIKey: shopCfg.Build.MJML.WebServiceAPIKey,
+				}
+				mjmlCompiler = mjml.NewCompilerWithConfig(mjmlConfig)
+			} else {
+				mjmlCompiler = mjml.NewCompiler()
+			}
+
+			// Get search paths from configuration or use defaults
+			searchPaths := getMJMLSearchPaths(shopCfg, args[0])
+
+			// Process each search path
+			for _, searchPath := range searchPaths {
+				// Check if the directory exists
+				if _, err := os.Stat(searchPath); !os.IsNotExist(err) {
+					logging.FromContext(cmd.Context()).Infof("Processing MJML files in: %s", searchPath)
+					if err := mjmlCompiler.ProcessDirectory(cmd.Context(), searchPath, false); err != nil {
+						logging.FromContext(cmd.Context()).Warnf("MJML compilation had issues in %s: %v", searchPath, err)
+						// Don't fail the build on MJML compilation errors
+					}
+				} else {
+					logging.FromContext(cmd.Context()).Debugf("MJML search path does not exist: %s", searchPath)
+				}
+			}
+
+			mjmlSection.End(cmd.Context())
+		}
+
 		if shopCfg.Build.RemoveExtensionAssets {
 			deleteAssetsSection := ci.Default.Section(cmd.Context(), "Deleting assets of extensions")
 
@@ -271,6 +309,34 @@ func prepareComposerAuth(ctx context.Context, root string) (string, error) {
 func init() {
 	projectRootCmd.AddCommand(projectCI)
 	projectCI.PersistentFlags().Bool("with-dev-dependencies", false, "Install dev dependencies")
+}
+
+// shouldCompileMJML determines if MJML compilation should run
+func shouldCompileMJML(shopCfg *shop.Config) bool {
+	return shopCfg.Build.MJML != nil && shopCfg.Build.MJML.Enabled
+}
+
+// getMJMLSearchPaths returns the paths to search for MJML files
+func getMJMLSearchPaths(shopCfg *shop.Config, projectRoot string) []string {
+	// Use configured paths if available
+	if shopCfg.Build.MJML != nil && len(shopCfg.Build.MJML.SearchPaths) > 0 {
+		// Convert relative paths to absolute paths
+		absolutePaths := make([]string, len(shopCfg.Build.MJML.SearchPaths))
+		for i, path := range shopCfg.Build.MJML.SearchPaths {
+			if filepath.IsAbs(path) {
+				absolutePaths[i] = path
+			} else {
+				absolutePaths[i] = filepath.Join(projectRoot, path)
+			}
+		}
+		return absolutePaths
+	}
+
+	// Default search paths
+	return []string{
+		filepath.Join(projectRoot, "custom", "plugins"),
+		filepath.Join(projectRoot, "custom", "static-plugins"),
+	}
 }
 
 func commandWithRoot(cmd *exec.Cmd, root string) *exec.Cmd {

--- a/internal/mjml/compiler.go
+++ b/internal/mjml/compiler.go
@@ -1,0 +1,306 @@
+package mjml
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/shopware/shopware-cli/logging"
+)
+
+// CompilerMode defines the compilation method
+type CompilerMode string
+
+const (
+	// CompilerModeLocal uses local npm mjml package
+	CompilerModeLocal CompilerMode = "local"
+	// CompilerModeWebService uses remote MJML API service
+	CompilerModeWebService CompilerMode = "webservice"
+)
+
+// Config defines the compiler configuration
+type Config struct {
+	Mode             CompilerMode
+	WebServiceURL    string
+	WebServiceAPIKey string
+}
+
+// Compiler provides MJML to HTML compilation functionality
+type Compiler interface {
+	CompileFile(ctx context.Context, mjmlPath string) (string, error)
+	ProcessDirectory(ctx context.Context, rootDir string, dryRun bool) error
+}
+
+type compiler struct {
+	config Config
+}
+
+// NewCompiler creates a new MJML compiler instance
+func NewCompiler() Compiler {
+	return &compiler{
+		config: Config{
+			Mode: CompilerModeLocal,
+		},
+	}
+}
+
+// NewCompilerWithConfig creates a new MJML compiler instance with configuration
+func NewCompilerWithConfig(config Config) Compiler {
+	return &compiler{
+		config: config,
+	}
+}
+
+// CompileFile compiles an MJML file to HTML using configured method
+func (c *compiler) CompileFile(ctx context.Context, mjmlPath string) (string, error) {
+	if c.config.Mode == CompilerModeWebService {
+		return c.compileWithWebService(ctx, mjmlPath)
+	}
+	return c.compileWithLocal(ctx, mjmlPath)
+}
+
+// compileWithLocal compiles using local npm mjml package
+func (c *compiler) compileWithLocal(ctx context.Context, mjmlPath string) (string, error) {
+	// Check if mjml command is available
+	if err := c.checkMJMLAvailable(ctx); err != nil {
+		return "", err
+	}
+
+	// Run mjml command with the file
+	cmd := exec.CommandContext(ctx, "npx", "mjml", mjmlPath, "--stdout")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("mjml compilation failed for %s: %w (stderr: %s)", mjmlPath, err, stderr.String())
+	}
+
+	if stderr.Len() > 0 {
+		logging.FromContext(ctx).Warnf("MJML compilation warnings for %s: %s", mjmlPath, stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+// compileWithWebService compiles using remote MJML API service
+func (c *compiler) compileWithWebService(ctx context.Context, mjmlPath string) (string, error) {
+	// Read MJML file content
+	mjmlContent, err := os.ReadFile(mjmlPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read MJML file %s: %w", mjmlPath, err)
+	}
+
+	// Prepare request payload
+	payload := map[string]interface{}{
+		"mjml": string(mjmlContent),
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request payload: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, "POST", c.config.WebServiceURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Support different authentication methods:
+	// 1. API key as Bearer token (for some custom services)
+	// 2. No authentication (for public endpoints like mjml.shyim.de)
+	// 3. Basic auth embedded in URL (for official MJML API: https://user:key@api.mjml.io/v1/render)
+	if c.config.WebServiceAPIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.config.WebServiceAPIKey)
+	}
+
+	// Send request
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request to MJML webservice: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logging.FromContext(ctx).Warnf("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	// Read response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("MJML webservice returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response
+	var response map[string]interface{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	html, ok := response["html"].(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected response format from MJML webservice")
+	}
+
+	if errors, ok := response["errors"].([]interface{}); ok && len(errors) > 0 {
+		logging.FromContext(ctx).Warnf("MJML compilation warnings for %s: %v", mjmlPath, errors)
+	}
+
+	return html, nil
+}
+
+// checkMJMLAvailable verifies that the mjml npm package is available
+func (c *compiler) checkMJMLAvailable(ctx context.Context) error {
+	// Skip check if using webservice
+	if c.config.Mode == CompilerModeWebService {
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, "npx", "mjml", "--version")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("mjml is not available. Please install it with: npm install -g mjml")
+	}
+
+	logging.FromContext(ctx).Debugf("MJML version: %s", strings.TrimSpace(stdout.String()))
+	return nil
+}
+
+// ProcessDirectory walks through a directory and compiles all MJML files
+func (c *compiler) ProcessDirectory(ctx context.Context, rootDir string, dryRun bool) error {
+	var processedCount int
+	var errorCount int
+	var skippedCount int
+
+	// First check if mjml is available
+	if err := c.checkMJMLAvailable(ctx); err != nil {
+		return err
+	}
+
+	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		// Check for context cancellation
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Only process .mjml files
+		if !strings.HasSuffix(path, ".mjml") {
+			return nil
+		}
+
+		// Only process html.mjml files
+		baseName := filepath.Base(path)
+		if baseName != "html.mjml" {
+			logging.FromContext(ctx).Debugf("Skipping non-HTML MJML file: %s", path)
+			skippedCount++
+			return nil
+		}
+
+		relPath, _ := filepath.Rel(rootDir, path)
+		logging.FromContext(ctx).Infof("Processing MJML file: %s", relPath)
+
+		// Always compile to check for errors
+		compiled, err := c.CompileFile(ctx, path)
+		if err != nil {
+			errorCount++
+			logging.FromContext(ctx).Errorf("Failed to compile MJML %s: %v", relPath, err)
+			return nil // Continue with other files
+		}
+
+		// Determine output path
+		outputPath := c.getOutputPath(path)
+
+		if dryRun {
+			// In dry-run mode, check if output would be different
+			existingContent, err := os.ReadFile(outputPath)
+			switch {
+			case err != nil && os.IsNotExist(err):
+				logging.FromContext(ctx).Infof("Would create new file: %s", outputPath)
+			case err != nil:
+				logging.FromContext(ctx).Warnf("Cannot read existing file %s: %v", outputPath, err)
+			case string(existingContent) != compiled:
+				logging.FromContext(ctx).Infof("Would update file: %s", outputPath)
+			default:
+				logging.FromContext(ctx).Debugf("File %s is already up to date", outputPath)
+			}
+
+			// Check if MJML file would be removed
+			if _, err := os.Stat(path); err == nil {
+				logging.FromContext(ctx).Infof("Would remove MJML file: %s", path)
+			}
+		} else {
+			// Write compiled HTML to twig file
+			if err := os.WriteFile(outputPath, []byte(compiled), 0644); err != nil {
+				errorCount++
+				logging.FromContext(ctx).Errorf("Failed to write compiled template to %s: %v", outputPath, err)
+				return nil
+			}
+
+			// Remove the original MJML file
+			if err := os.Remove(path); err != nil {
+				errorCount++
+				logging.FromContext(ctx).Errorf("Failed to remove MJML file %s: %v", path, err)
+				return nil // Continue with other files
+			}
+			logging.FromContext(ctx).Debugf("Removed original MJML file: %s", path)
+
+			logging.FromContext(ctx).Infof("Successfully compiled MJML to Twig: %s -> %s", relPath, outputPath)
+		}
+
+		processedCount++
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	logging.FromContext(ctx).Infof("MJML compilation complete - processed: %d, skipped: %d, errors: %d (dry_run: %v)",
+		processedCount, skippedCount, errorCount, dryRun)
+
+	if errorCount > 0 {
+		return fmt.Errorf("compilation completed with %d errors", errorCount)
+	}
+
+	return nil
+}
+
+// getOutputPath determines the output path for a compiled MJML file
+func (c *compiler) getOutputPath(mjmlPath string) string {
+	dir := filepath.Dir(mjmlPath)
+	// html.mjml -> html.twig
+	return filepath.Join(dir, "html.twig")
+}

--- a/internal/mjml/compiler_test.go
+++ b/internal/mjml/compiler_test.go
@@ -1,0 +1,124 @@
+package mjml
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/logging"
+)
+
+func TestGetOutputPath(t *testing.T) {
+	compiler := &compiler{
+		config: Config{Mode: CompilerModeLocal},
+	}
+
+	tests := []struct {
+		name     string
+		mjmlPath string
+		expected string
+	}{
+		{
+			name:     "Simple html.mjml",
+			mjmlPath: "/path/to/template/html.mjml",
+			expected: "/path/to/template/html.twig",
+		},
+		{
+			name:     "Nested path",
+			mjmlPath: "/path/to/nested/template/html.mjml",
+			expected: "/path/to/nested/template/html.twig",
+		},
+		{
+			name:     "Complex path",
+			mjmlPath: "/vendor/frosh/mail/Resources/views/email/order/html.mjml",
+			expected: "/vendor/frosh/mail/Resources/views/email/order/html.twig",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := compiler.getOutputPath(tt.mjmlPath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProcessDirectory_SkipsNonHTMLFiles(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create test files
+	testFiles := []string{
+		"subject.mjml",    // Should be skipped
+		"plain.mjml",      // Should be skipped
+		"html.mjml",       // Should be processed
+		"html.en.mjml",    // Should be skipped (not exactly html.mjml)
+		"custom.mjml",     // Should be skipped
+		"html.de_DE.mjml", // Should be skipped (not exactly html.mjml)
+	}
+
+	for _, file := range testFiles {
+		path := filepath.Join(tempDir, file)
+		err := os.WriteFile(path, []byte("<mjml><mj-body><mj-text>Test</mj-text></mj-body></mjml>"), 0644)
+		assert.NoError(t, err)
+	}
+
+	compiler := NewCompiler()
+
+	// Run in dry-run mode to test file detection logic
+	ctx := logging.WithLogger(context.Background(), logging.NewLogger(true))
+	err := compiler.ProcessDirectory(ctx, tempDir, true)
+
+	// The test should not fail even if mjml is not installed (dry-run mode)
+	if err != nil {
+		t.Logf("Skipping test as mjml is not available: %v", err)
+		t.Skip("mjml not available")
+	}
+
+	// Verify that non-HTML files still exist (weren't processed)
+	assert.FileExists(t, filepath.Join(tempDir, "subject.mjml"))
+	assert.FileExists(t, filepath.Join(tempDir, "plain.mjml"))
+	assert.FileExists(t, filepath.Join(tempDir, "custom.mjml"))
+}
+
+func TestCheckMJMLAvailable(t *testing.T) {
+	c := &compiler{
+		config: Config{Mode: CompilerModeLocal},
+	}
+	ctx := logging.WithLogger(context.Background(), logging.NewLogger(true))
+
+	err := c.checkMJMLAvailable(ctx)
+	if err != nil {
+		t.Logf("MJML is not installed: %v", err)
+		// This is not a failure, just means mjml is not available in test environment
+	}
+}
+
+func TestCheckMJMLAvailable_SkipsForWebService(t *testing.T) {
+	c := &compiler{
+		config: Config{Mode: CompilerModeWebService},
+	}
+	ctx := logging.WithLogger(context.Background(), logging.NewLogger(true))
+
+	// Should not fail even if mjml is not installed when using webservice
+	err := c.checkMJMLAvailable(ctx)
+	assert.NoError(t, err)
+}
+
+func TestNewCompilerWithConfig(t *testing.T) {
+	config := Config{
+		Mode:             CompilerModeWebService,
+		WebServiceURL:    "https://api.mjml.io/v1/render",
+		WebServiceAPIKey: "test-api-key",
+	}
+
+	compiler := NewCompilerWithConfig(config)
+	assert.NotNil(t, compiler)
+
+	// Verify it's configured correctly (type assertion would require exporting the compiler type)
+	// Just ensure it doesn't panic and returns a non-nil compiler
+	assert.NotNil(t, compiler)
+}

--- a/shop/config.go
+++ b/shop/config.go
@@ -62,12 +62,28 @@ type ConfigBuild struct {
 	ForceAdminBuild bool `yaml:"force_admin_build,omitempty"`
 	// Keep following node_modules in the final build
 	KeepNodeModules []string `yaml:"keep_node_modules,omitempty"`
+	// MJML email template compilation configuration
+	MJML *ConfigBuildMJML `yaml:"mjml,omitempty"`
 }
 
 // ConfigBuildExtension defines the configuration for forcing extension builds.
 type ConfigBuildExtension struct {
 	// Name of the extension
 	Name string `yaml:"name" jsonschema:"required"`
+}
+
+// ConfigBuildMJML defines the configuration for MJML email template compilation.
+type ConfigBuildMJML struct {
+	// Whether to enable MJML compilation
+	Enabled bool `yaml:"enabled,omitempty"`
+	// Directories to search for MJML files
+	SearchPaths []string `yaml:"search_paths,omitempty"`
+	// Use webservice for compilation instead of local npm mjml
+	UseWebService bool `yaml:"use_webservice,omitempty"`
+	// Webservice URL for MJML compilation (e.g., https://mjml.shyim.de or https://user:key@api.mjml.io/v1/render)
+	WebServiceURL string `yaml:"webservice_url,omitempty"`
+	// Webservice API key for authentication (optional, for services that require Bearer token auth)
+	WebServiceAPIKey string `yaml:"webservice_api_key,omitempty"`
 }
 
 type ConfigAdminApi struct {

--- a/shop/shopware-project-schema.json
+++ b/shop/shopware-project-schema.json
@@ -123,6 +123,9 @@
           },
           "type": "array",
           "description": "Keep following node_modules in the final build"
+        },
+        "mjml": {
+          "$ref": "#/$defs/ConfigBuildMJML"
         }
       },
       "additionalProperties": false,
@@ -141,6 +144,36 @@
         "name"
       ],
       "description": "ConfigBuildExtension defines the configuration for forcing extension builds."
+    },
+    "ConfigBuildMJML": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable MJML compilation"
+        },
+        "search_paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Directories to search for MJML files"
+        },
+        "use_webservice": {
+          "type": "boolean",
+          "description": "Use webservice for compilation instead of local npm mjml"
+        },
+        "webservice_url": {
+          "type": "string",
+          "description": "Webservice URL for MJML compilation (e.g., https://mjml.shyim.de or https://user:key@api.mjml.io/v1/render)"
+        },
+        "webservice_api_key": {
+          "type": "string",
+          "description": "Webservice API key for authentication (optional, for services that require Bearer token auth)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ConfigBuildMJML defines the configuration for MJML email template compilation."
     },
     "ConfigDeployment": {
       "properties": {


### PR DESCRIPTION
Add a parameter '--mjml-compile' to the project ci command. If set, all html.mjml files within custom/static-plugins will be compiled using 'npx mjml'.

Why? Currently, when using FroshPlatformTemplateMail with mjml, the templates will be compiled at runtime using a web server. This adds a point of failure to the mail sending process at runtime. With these changes, all mjml.html templates will be compiled and the result is stored as a twig file, the original mjml file is removed. FroshPlatformTemplateMail will then pick up and render the html.twig file. MJML compile errors will be detected during build.