### PR TITLE
feat: add environment variable for overriding the cache directory

### DIFF
--- a/internal/system/cache.go
+++ b/internal/system/cache.go
@@ -7,6 +7,10 @@ import (
 
 // GetShopwareCliCacheDir returns the base cache directory for shopware-c
 func GetShopwareCliCacheDir() string {
+	if dir := os.Getenv("SHOPWARE_CLI_CACHE_DIR"); dir != "" {
+		return dir
+	}
+
 	cacheDir, _ := os.UserCacheDir()
 
 	return path.Join(cacheDir, "shopware-cli")


### PR DESCRIPTION
Some CI systems have limitations on what paths they can cache. This makes handling those cases easier by allowing us to override the cache directory.