### PR TITLE
fix: template formatting for nested template expressions

### DIFF
--- a/internal/html/parser.go
+++ b/internal/html/parser.go
@@ -510,6 +510,12 @@ func (t *TwigBlockNode) Dump(indent int) string {
 		for i, child := range nonEmptyChildren {
 			if elementChild, ok := child.(*ElementNode); ok {
 				builder.WriteString(elementChild.Dump(childIndent))
+			} else if tplChild, ok := child.(*TemplateExpressionNode); ok {
+				// Template expressions need proper indentation when they're direct children of twig blocks
+				for j := 0; j < childIndent; j++ {
+					builder.WriteString(indentStr)
+				}
+				builder.WriteString(tplChild.Dump(childIndent))
 			} else {
 				builder.WriteString(child.Dump(childIndent))
 			}

--- a/internal/html/testdata/43-template-expression-in-nested-block.txt
+++ b/internal/html/testdata/43-template-expression-in-nested-block.txt
@@ -1,0 +1,23 @@
+{% block container %}
+    <sw-container>
+        {% block text %}
+        {{ nestedExpression }}
+        {% endblock %}
+    </sw-container>
+{% endblock %}
+-----
+{% block container %}
+<sw-container>
+    {% block text %}
+    {{ nestedExpression }}
+    {% endblock %}
+</sw-container>
+{% endblock %}
+-----
+{% block container %}
+    <sw-container>
+        {% block text %}
+            {{ nestedExpression }}
+        {% endblock %}
+    </sw-container>
+{% endblock %}


### PR DESCRIPTION
Admin parser currently converts
```
{% block container %}
    <sw-container>
        {% block text %}
        {{ nestedExpression }}
        {% endblock %}
    </sw-container>
{% endblock %}
```
to
```
{% block container %}
<sw-container>
    {% block text %}
{{ nestedExpression }}
    {% endblock %}
</sw-container>
{% endblock %}
```
instead of
```
{% block container %}
<sw-container>
    {% block text %}
    {{ nestedExpression }}
    {% endblock %}
</sw-container>
{% endblock %}
```