### PR TITLE
feat: support country-agnostic language files

### DIFF
--- a/extension/snippet_validator.go
+++ b/extension/snippet_validator.go
@@ -80,19 +80,13 @@ func validateStorefrontSnippetsByPath(snippetFolder, rootDir string, check valid
 			continue
 		}
 
-		var mainFile string
-
-		for _, file := range files {
-			if strings.HasSuffix(filepath.Base(file), "en-GB.json") {
-				mainFile = file
-			}
-		}
+		mainFile := findMainSnippetFile(files)
 
 		if len(mainFile) == 0 {
 			check.AddResult(validation.CheckResult{
 				Path:       snippetFolder,
 				Identifier: "snippet.validator",
-				Message:    fmt.Sprintf("No en-GB.json file found in %s, using %s", snippetFolder, files[0]),
+				Message:    fmt.Sprintf("No en.json or en-GB.json file found in %s, using %s", snippetFolder, files[0]),
 				Severity:   validation.SeverityWarning,
 			})
 			mainFile = files[0]
@@ -195,18 +189,12 @@ func validateAdministrationByPath(adminFolder, rootDir string, check validation.
 			continue
 		}
 
-		var mainFile string
-
-		for _, file := range files {
-			if strings.HasSuffix(filepath.Base(file), "en-GB.json") {
-				mainFile = file
-			}
-		}
+		mainFile := findMainSnippetFile(files)
 
 		if len(mainFile) == 0 {
 			check.AddResult(validation.CheckResult{
 				Identifier: "snippet.validator",
-				Message:    fmt.Sprintf("No en-GB.json file found in %s, using %s", strings.ReplaceAll(folder, rootDir+"/", ""), strings.ReplaceAll(files[0], rootDir+"/", "")),
+				Message:    fmt.Sprintf("No en.json or en-GB.json file found in %s, using %s", strings.ReplaceAll(folder, rootDir+"/", ""), strings.ReplaceAll(files[0], rootDir+"/", "")),
 				Severity:   validation.SeverityWarning,
 			})
 			mainFile = files[0]
@@ -311,4 +299,20 @@ func compareSnippets(mainFile []byte, mainFilePath, file string, check validatio
 			continue
 		}
 	}
+}
+
+// Search for the country-agnostic language file en.json
+// If it isn't found search for the en-GB.json
+func findMainSnippetFile(files []string) string {
+	for _, file := range files {
+		if strings.HasSuffix(filepath.Base(file), "en.json") {
+			return file
+		}
+	}
+	for _, file := range files {
+		if strings.HasSuffix(filepath.Base(file), "en-GB.json") {
+			return file
+		}
+	}
+	return ""
 }

--- a/extension/snippet_validator_test.go
+++ b/extension/snippet_validator_test.go
@@ -96,3 +96,21 @@ func TestSnippetValidateFindsInvalidJsonInGermanFile(t *testing.T) {
 	assert.Len(t, check.Results, 1)
 	assert.Contains(t, check.Results[0].Message, "contains invalid JSON")
 }
+
+func TestSnippetValidatePrioritizesCountryAgnosticEnglish(t *testing.T) {
+	tmpDir := t.TempDir()
+	check := &testCheck{}
+
+	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en.json"), []byte(`{"a": "1"}`), os.ModePerm)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1", "b": "2"}`), os.ModePerm)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "3"}`), os.ModePerm)
+
+	assert.NoError(t, validateStorefrontSnippetsByPath(tmpDir, tmpDir, check))
+	assert.Len(t, check.Results, 1)
+	assert.Contains(
+		t,
+		check.Results[0].Message,
+		"en-GB.json, missing key \"/b\" in this snippet file, but defined in the main language",
+	)
+}


### PR DESCRIPTION
As we now add country-agnostic language files, we should first check them.
Without this change the snippet validation will fail in plugins that only use the country-agnostic language files.