### PR TITLE
fix: infinite loop on shutdown when running shopware workers

### DIFF
--- a/cmd/project/project_worker.go
+++ b/cmd/project/project_worker.go
@@ -91,7 +91,7 @@ var projectWorkerCmd = &cobra.Command{
 			go func(ctx context.Context, index int) {
 				defer wg.Done()
 
-				for {
+				for ctx.Err() == nil {
 					if err = workerRatelimit.Wait(ctx); err != nil {
 						logging.FromContext(ctx).Error(err)
 						continue


### PR DESCRIPTION
This fixes an infinite loop when shopware-cli project worker is killed with a SIGTERM that got introduced with 649053c.

Previously
```
<send SIGTERM>
ESC[31mERRORESC[0m      context canceled
ESC[31mERRORESC[0m      context canceled
ESC[31mERRORESC[0m      context canceled
ESC[31mERRORESC[0m      context canceled
...
```
Now (again)
```
<send SIGTERM>
ESC[34mINFOESC[0m       received signal terminated

<app quits>
```

Thanks!