### PR TITLE
feat(project): add --no-audit flag to create command

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -43,7 +43,7 @@ jobs:
           path: 'plugin'
 
       - name: Create Shopware
-        run: shopware-cli project create shopware 6.5.7.3
+        run: shopware-cli project create shopware 6.5.7.3 --no-audit
 
       - name: Build asset of Plugin
         run: shopware-cli extension zip plugin


### PR DESCRIPTION
## Summary
- Add `--no-audit` flag to `project create` command to disable composer audit blocking insecure packages
- Updates composer.json template to include audit config when flag is used
- Updates smoke test to use the new flag

## Changes
- Added `--no-audit` boolean flag to project create command
- Modified `generateComposerJson` function to accept and use the noAudit parameter
- Updated composer.json template to include audit config section when flag is enabled
- Updated smoke test workflow to use the new flag

## Motivation
This allows users to create Shopware projects without composer audit blocking insecure packages, which can be useful in development environments or when working with dependencies that have known security issues but are still required.