### PR TITLE
feat: Support inline faker expressions in dump rewrites

### DIFF
--- a/internal/mysqldump/faker.go
+++ b/internal/mysqldump/faker.go
@@ -18,16 +18,33 @@ const (
 	contactInfo   = "ContactInfo"
 )
 
+// replaceStringWithFakerWhenRequested replaces inline faker expressions in the input string with their evaluated values.
+//
+// The function scans the input string for expressions of the form `{{- faker.Method(args) -}}`
+// (e.g., `{{- faker.Name() -}}`), and replaces each such expression with the result of calling
+// the corresponding faker method. Multiple expressions in the input string are all replaced.
+//
+// If an expression cannot be evaluated (e.g., due to an error in the method name or arguments),
+// the original expression is left unchanged in the output.
+//
+// Parameters:
+//   - request: the input string potentially containing one or more inline faker expressions.
+//
+// Returns:
+//   - The input string with all valid faker expressions replaced by their evaluated values.
+//     Expressions that fail to evaluate are left unchanged.
 func replaceStringWithFakerWhenRequested(request string) string {
 	if !strings.Contains(request, "faker.") {
 		return request
 	}
 
-	r := regexp.MustCompile(`\{\{\-\s*faker(\.[a-zA-Z0-9]+)+\(.*?\)+\s*\-\}\}`)
+	// This regex matches {{- faker.Method("arg1").ChainedMethod() -}}
+	// It handles quoted strings within arguments and chained calls both with and without parens.
+	r := regexp.MustCompile(`\{\{\-\s*faker(?:\.[a-zA-Z0-9]+(?:\((?:(?:"(?:[^"\\]|\\.)*"|[^"()])*)\))?)+\s*\-\}\}`)
 
 	return r.ReplaceAllStringFunc(request, func(match string) string {
-		// Remove {{- -}} and whitespace
-		trimmed := strings.TrimSpace(match[3 : len(match)-3])
+		// Remove {{- -}} and whitespace safely
+		trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(match, "{{-"), "-}}"))
 		val, err := evaluateFakerExpression(trimmed)
 		if err != nil {
 			return match
@@ -37,6 +54,10 @@ func replaceStringWithFakerWhenRequested(request string) string {
 	})
 }
 
+// evaluateFakerExpression evaluates a single faker expression (without the {{- -}} delimiters).
+// It returns the result of the faker function or an error if evaluation fails.
+// This function is intended to be called by replaceStringWithFakerWhenRequested,
+// which handles the full inline syntax (including delimiters) and error recovery.
 func evaluateFakerExpression(request string) (string, error) {
 	if len(request) < 5 || request[0:5] != "faker" {
 		return request, nil

--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -599,7 +599,7 @@ func (d *Dumper) getColumnsForSelect(ctx context.Context, table string, consider
 
 		replacement, ok := d.SelectMap[strings.ToLower(table)][strings.ToLower(column)]
 		if ok && considerRewriteMap {
-			if strings.HasPrefix(replacement, "faker") || strings.HasPrefix(replacement, "{{- faker") {
+			if strings.Contains(replacement, "faker.") {
 				replacement = fmt.Sprintf("'%s'", replacement)
 			}
 


### PR DESCRIPTION
This PR introduces support for inline faker expressions within SQL dump rewrites. This allows users to combine SQL functions with faker data, such as injecting fake data into JSON columns.

**Key Changes:**
-   **New Syntax**: Use `{{- faker.Method() -}}` to embed faker calls within strings.
    -   Example: `JSON_REPLACE(custom_fields, '$.street', '{{- faker.Address.StreetName() -}}')`
-   **Regex Parsing**: Implemented regex-based replacement to handle multiple or embedded faker calls robustly.
-   **Dumper Integration**: Updated the dumper to recognize the new syntax and correctly format the generated SQL.
-   **Cleanup**: Refactored `replaceStringWithFakerWhenRequested` to improve code quality.

Fixes: #737
