### PR TITLE
Add insert-into-limit flag allowing configure insert batch size

### DIFF
--- a/cmd/project/project_dump.go
+++ b/cmd/project/project_dump.go
@@ -241,5 +241,5 @@ func init() {
 	projectDatabaseDumpCmd.Flags().Bool("zstd", false, "Zstd the whole dump")
 	projectDatabaseDumpCmd.Flags().Bool("quick", false, "Use quick option for mysqldump")
 	projectDatabaseDumpCmd.Flags().Int("parallel", 0, "Number of tables to dump concurrently (0 = disabled)")
-	projectDatabaseDumpCmd.Flags().Int("insert-into-limit", 100, "Limit the number of rows per INSERT statement (ignored when --quick is set; quick forces one row per INSERT)")
+	projectDatabaseDumpCmd.Flags().Int("insert-into-limit", 0, "Limit the number of rows per INSERT statement (0 = auto, takes priority over --quick when set)")
 }


### PR DESCRIPTION
This option is crucial for allowing large dumps to be restored efficiently as small batch size slows
import process dramatically.