### PR TITLE
Feature/use git tag as version

### DIFF
--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 
 	cp "github.com/otiai10/copy"
 	"github.com/spf13/cobra"
@@ -177,7 +178,7 @@ var extensionZipCmd = &cobra.Command{
 
 		version := getStringOnStringError(cmd.Flags().GetString("overwrite-version"))
 		if version == "" && cmd.Flags().Changed("use-git-tag-as-version") {
-			version = tag
+			version = strings.TrimPrefix(tag, "v")
 		}
 
 		if err := extension.BuildModifier(ext, extDir, extension.BuildModifierConfig{


### PR DESCRIPTION
  ### Problem                                                                                                                           
                                                            
  Many Shopware plugins are developed without a `version` field in `composer.json` — the version is managed exclusively through git tags. When running `extension zip`, the detected git tag is already used to name the resulting zip file (e.g. `MyPlugin-1.1.0.zip`),  but it is never written into `composer.json` or `manifest.xml`. This means the packaged extension carries no version metadata internally, which can cause issues with version validation and upload workflows.

  ### Solution

  A new flag `--use-git-tag-as-version` is introduced for the `extension zip` command. When set, the git tag detected during packaging is automatically written as the version into:
  - `composer.json` for Platform Plugins and Shopware Bundles
  - `manifest.xml` for Shopware Apps
  The existing `BuildModifier` infrastructure already handles this write — the flag simply wires the detected `tag` into it.
  Git tags using the common `v`-prefix convention (e.g. `v1.1.0`) are handled correctly: the prefix is stripped before writing,
  resulting in a plain semver string (`1.1.0`) in the metadata file.

  ### Constraints
  The flag is mutually exclusive with:
  - **`--disable-git`** — without git, no tag can be detected, so the flag has no meaningful value
  - **`--overwrite-version`** — both flags set the version; combining them would be ambiguous

  ### Unchanged behavior
  The existing `--overwrite-version` flag continues to work as before and takes precedence if used directly.