### PR TITLE
fix: unescape defaults, fixes #876

### DIFF
--- a/internal/mysqldump/schema.go
+++ b/internal/mysqldump/schema.go
@@ -425,6 +425,15 @@ func formatDefault(value string, colType string) string {
 		return value
 	}
 
+	// MariaDB (and some MySQL versions) return COLUMN_DEFAULT as a SQL expression
+	// with backslash-escaped quotes (e.g. \\'foo\\' for string default 'foo').
+	// After unescaping, if the value is already a single-quoted SQL string literal,
+	// use it directly to avoid double-escaping.
+	unescaped := unescape(value)
+	if len(unescaped) >= 2 && unescaped[0] == '\'' && unescaped[len(unescaped)-1] == '\'' {
+		return unescaped
+	}
+
 	if isExpression(value) {
 		if isSpecialDefault(value) {
 			return value

--- a/internal/mysqldump/schema_test.go
+++ b/internal/mysqldump/schema_test.go
@@ -514,6 +514,10 @@ func TestFormatDefault(t *testing.T) {
 		{"hex literal lowercase", "x'0fa91ce3e96a4bc2be4bd9ce752c3425'", "binary(16)", "x'0fa91ce3e96a4bc2be4bd9ce752c3425'"},
 		{"hex literal uppercase", "X'0FA91CE3'", "binary(16)", "X'0FA91CE3'"},
 		{"hex literal 0x format", "0x0fa91ce3e96a4bc2be4bd9ce752c3425", "binary(16)", "0x0fa91ce3e96a4bc2be4bd9ce752c3425"},
+		// MariaDB returns COLUMN_DEFAULT as a backslash-escaped SQL string literal.
+		// These must not be double-quoted/escaped.
+		{"mariadb escaped string default", "\\'product\\'", "varchar(255)", "'product'"},
+		{"mariadb escaped binary string default", "\\'somevalue\\'", "binary(16)", "'somevalue'"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```diff
 CREATE TABLE `property_group` (
   `id` binary(16) NOT NULL,
-  `sorting_type` varchar(50) NOT NULL DEFAULT '\'alphanumeric\'',
-  `display_type` varchar(50) NOT NULL DEFAULT '\'text\'',
+  `sorting_type` varchar(50) NOT NULL DEFAULT 'alphanumeric',
+  `display_type` varchar(50) NOT NULL DEFAULT 'text',
```