### PR TITLE
feat: Enable gitlab reporter for extension validate

### DIFF
--- a/cmd/extension/extension_validate.go
+++ b/cmd/extension/extension_validate.go
@@ -142,15 +142,15 @@ func init() {
 	extensionRootCmd.AddCommand(extensionValidateCmd)
 	extensionValidateCmd.PersistentFlags().Bool("full", false, "Run full validation including PHPStan, ESLint and Stylelint")
 	extensionValidateCmd.PersistentFlags().Bool("store-compliance", false, "Runs specific store compliance checks")
-	extensionValidateCmd.PersistentFlags().String("reporter", "", "Reporting format (summary, json, github, junit, markdown)")
+	extensionValidateCmd.PersistentFlags().String("reporter", "", "Reporting format (summary, json, github, gitlab, junit, markdown)")
 	extensionValidateCmd.PersistentFlags().String("check-against", "highest", "Check against Shopware Version (highest, lowest)")
 	extensionValidateCmd.PersistentFlags().String("only", "", "Run only specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	extensionValidateCmd.PersistentFlags().String("exclude", "", "Exclude specific tools by name (comma-separated, e.g. phpstan,eslint)")
 	extensionValidateCmd.PersistentFlags().Bool("no-copy", false, "Do not copy extension files to temporary directory")
 	extensionValidateCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		reporter, _ := cmd.Flags().GetString("reporter")
-		if reporter != "summary" && reporter != "json" && reporter != "github" && reporter != "junit" && reporter != "markdown" && reporter != "" {
-			return fmt.Errorf("invalid reporter format: %s. Must be either 'summary', 'json', 'github', 'junit' or 'markdown'", reporter)
+		if reporter != "summary" && reporter != "json" && reporter != "github" && reporter != "gitlab" && reporter != "junit" && reporter != "markdown" && reporter != "" {
+			return fmt.Errorf("invalid reporter format: %s. Must be either 'summary', 'json', 'github', 'gitlab', 'junit' or 'markdown'", reporter)
 		}
 
 		mode, _ := cmd.Flags().GetString("check-against")


### PR DESCRIPTION
Seems like I just overlooked this for the extension validate command when I originally build gitlab output. 