### PR TITLE
Add Environment Config tab to dev TUI

### DIFF
--- a/internal/devtui/command_palette.go
+++ b/internal/devtui/command_palette.go
@@ -27,6 +27,7 @@ var paletteCommands = []paletteCommand{
 	{Label: "Stop Storefront Watcher", ID: "sf-watch-stop"},
 	{Label: "Toggle Logs Tab", Shortcut: "2", ID: "tab-logs"},
 	{Label: "Toggle General Tab", Shortcut: "1", ID: "tab-general"},
+	{Label: "Toggle Config Tab", Shortcut: "3", ID: "tab-config"},
 	{Label: "Quit", Shortcut: "ctrl+c", ID: "quit"},
 }
 

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -37,6 +37,8 @@ const (
 	key1        = "1"
 	key2        = "2"
 	key3        = "3"
+	keyLeft     = "left"
+	keyRight    = "right"
 
 	defaultUsername = "admin"
 

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -18,9 +18,10 @@ type activeTab int
 const (
 	tabGeneral activeTab = iota
 	tabLogs
+	tabConfig
 )
 
-var tabNames = []string{"General", "Logs"}
+var tabNames = []string{"General", "Logs", "Config"}
 
 const (
 	keyCtrlC    = "ctrl+c"
@@ -35,6 +36,7 @@ const (
 	keyK        = "k"
 	key1        = "1"
 	key2        = "2"
+	key3        = "3"
 
 	defaultUsername = "admin"
 
@@ -130,6 +132,7 @@ type Model struct {
 	activeTab      activeTab
 	general        GeneralModel
 	logs           LogsModel
+	configTab      ConfigModel
 	width          int
 	height         int
 	dockerMode     bool
@@ -188,6 +191,7 @@ func New(opts Options) Model {
 		activeTab:   tabGeneral,
 		general:     NewGeneralModel(opts.Executor.Type(), shopURL, username, password, opts.ProjectRoot, opts.Executor),
 		logs:        NewLogsModel(opts.ProjectRoot, isDocker),
+		configTab:   NewConfigModel(opts.Config),
 		dockerMode:  isDocker,
 		projectRoot: opts.ProjectRoot,
 		executor:    opts.Executor,
@@ -230,6 +234,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.general.SetSize(m.width, m.height-4)
 		m.logs.SetSize(m.width, m.height-4)
+		m.configTab.SetSize(m.width, m.height-4)
 		return m, nil
 
 	case dockerAlreadyRunningMsg, dockerNeedStartMsg, dockerOutputLineMsg,
@@ -328,6 +333,12 @@ func (m Model) updateChildren(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	newLogs, cmd := m.logs.Update(msg)
 	m.logs = newLogs
+	if cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+
+	newConfig, cmd := m.configTab.Update(msg)
+	m.configTab = newConfig
 	if cmd != nil {
 		cmds = append(cmds, cmd)
 	}

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -189,6 +189,14 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// When the config tab is actively editing a text input, route all keys
+	// to it so typed characters are not intercepted by global shortcuts.
+	if m.activeTab == tabConfig && m.configTab.editing {
+		newConfig, cmd := m.configTab.HandleKey(msg)
+		m.configTab = newConfig
+		return m, cmd
+	}
+
 	switch msg.String() {
 	case "ctrl+p":
 		m.overlay = overlayCommandPalette
@@ -209,9 +217,27 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key2:
 		m.activeTab = tabLogs
 		return m, nil
-	case keyTab, keyShiftTab:
-		m.activeTab = (m.activeTab + 1) % 2
+	case key3:
+		m.activeTab = tabConfig
 		return m, nil
+	case keyTab:
+		m.activeTab = (m.activeTab + 1) % activeTab(len(tabNames))
+		return m, nil
+	case keyShiftTab:
+		m.activeTab = (m.activeTab - 1 + activeTab(len(tabNames))) % activeTab(len(tabNames))
+		return m, nil
+	}
+
+	if m.activeTab == tabConfig {
+		newConfig, cmd := m.configTab.HandleKey(msg)
+		m.configTab = newConfig
+		// Handle save action.
+		if m.configTab.cursor == fieldSave && msg.String() == keyEnter && m.configTab.modified {
+			m.configTab.ApplyToConfig(m.config)
+			_ = shop.WriteConfig(m.config, m.projectRoot)
+			return m, func() tea.Msg { return configSavedMsg{} }
+		}
+		return m, cmd
 	}
 
 	return m.updateChildren(msg)
@@ -276,6 +302,8 @@ func (m Model) executeCommand(id string) (tea.Model, tea.Cmd) {
 		m.activeTab = tabLogs
 	case "tab-general":
 		m.activeTab = tabGeneral
+	case "tab-config":
+		m.activeTab = tabConfig
 	case "quit":
 		if m.dockerMode {
 			m.overlay = overlayStopConfirm

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -128,9 +128,9 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	if m.overlay == overlayStopConfirm {
 		switch msg.String() {
-		case "left", "h":
+		case keyLeft, "h":
 			m.stopConfirmYes = true
-		case "right", "l":
+		case keyRight, "l":
 			m.stopConfirmYes = false
 		case keyTab:
 			m.stopConfirmYes = !m.stopConfirmYes
@@ -409,9 +409,9 @@ func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch m.install.step {
 	case installStepAsk:
 		switch msg.String() {
-		case "left", "h":
+		case keyLeft, "h":
 			m.install.confirmYes = true
-		case "right", "l":
+		case keyRight, "l":
 			m.install.confirmYes = false
 		case keyTab:
 			m.install.confirmYes = !m.install.confirmYes

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -235,6 +235,11 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.configTab.cursor == fieldSave && msg.String() == keyEnter && m.configTab.modified {
 			m.configTab.ApplyToConfig(m.config)
 			_ = shop.WriteConfig(m.config, m.projectRoot)
+			// Write credentials to .shopware-project.local.yml so they stay
+			// out of version control.
+			if localCfg := m.configTab.LocalConfig(); localCfg != nil {
+				_ = shop.WriteLocalConfig(localCfg, m.projectRoot)
+			}
 			return m, func() tea.Msg { return configSavedMsg{} }
 		}
 		return m, cmd

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -192,11 +192,13 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// When the config tab is actively editing a text input, route all keys
 	// to it so typed characters are not intercepted by global shortcuts.
 	if m.activeTab == tabConfig && m.configTab.editing {
-		newConfig, cmd := m.configTab.HandleKey(msg)
-		m.configTab = newConfig
-		return m, cmd
+		return m.updateConfigTab(msg)
 	}
 
+	return m.updateDashboardKeys(msg)
+}
+
+func (m Model) updateDashboardKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+p":
 		m.overlay = overlayCommandPalette
@@ -229,23 +231,28 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.activeTab == tabConfig {
-		newConfig, cmd := m.configTab.HandleKey(msg)
-		m.configTab = newConfig
-		// Handle save action.
-		if m.configTab.cursor == fieldSave && msg.String() == keyEnter && m.configTab.modified {
-			m.configTab.ApplyToConfig(m.config)
-			_ = shop.WriteConfig(m.config, m.projectRoot)
-			// Write credentials to .shopware-project.local.yml so they stay
-			// out of version control.
-			if localCfg := m.configTab.LocalConfig(); localCfg != nil {
-				_ = shop.WriteLocalConfig(localCfg, m.projectRoot)
-			}
-			return m, func() tea.Msg { return configSavedMsg{} }
-		}
-		return m, cmd
+		return m.updateConfigTab(msg)
 	}
 
 	return m.updateChildren(msg)
+}
+
+func (m Model) updateConfigTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	newConfig, cmd := m.configTab.HandleKey(msg)
+	m.configTab = newConfig
+
+	if m.configTab.cursor == fieldSave && msg.String() == keyEnter && m.configTab.modified {
+		m.configTab.ApplyToConfig(m.config)
+		_ = shop.WriteConfig(m.config, m.projectRoot)
+		// Write credentials to .shopware-project.local.yml so they stay
+		// out of version control.
+		if localCfg := m.configTab.LocalConfig(); localCfg != nil {
+			_ = shop.WriteLocalConfig(localCfg, m.projectRoot)
+		}
+		return m, func() tea.Msg { return configSavedMsg{} }
+	}
+
+	return m, cmd
 }
 
 func (m Model) updateCommandPalette(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {

--- a/internal/devtui/model_view.go
+++ b/internal/devtui/model_view.go
@@ -56,6 +56,8 @@ func (m Model) renderDashboard() string {
 	case tabLogs:
 		m.logs.SetSize(contentW, contentH)
 		content = m.logs.View()
+	case tabConfig:
+		content = m.configTab.View(m.width, boxHeight)
 	}
 
 	contentBox := lipgloss.NewStyle().
@@ -76,6 +78,17 @@ func (m Model) renderDashboardFooter() string {
 			{Key: "↑/↓", Label: "Move cursor"},
 			{Key: "enter", Label: "Open source"},
 			{Key: "f", Label: followState},
+			{Key: "tab", Label: "Next tab"},
+			{Key: "ctrl+c", Label: "Exit"},
+		}
+		return tui.ShortcutBar(shortcuts...)
+	}
+
+	if m.activeTab == tabConfig {
+		shortcuts := []tui.Shortcut{
+			{Key: "↑/↓", Label: "Navigate"},
+			{Key: "←/→", Label: "Change value"},
+			{Key: "enter", Label: "Edit/Save"},
 			{Key: "tab", Label: "Next tab"},
 			{Key: "ctrl+c", Label: "Exit"},
 		}

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -1,0 +1,407 @@
+package devtui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+// configField identifies an editable field in the config tab.
+type configField int
+
+const (
+	fieldPHPVersion configField = iota
+	fieldProfiler
+	fieldBlackfireServerID
+	fieldBlackfireServerToken
+	fieldTidewaysAPIKey
+	fieldNodeVersion
+	fieldSave
+	fieldCount // sentinel – number of fields
+)
+
+var (
+	phpVersions  = []string{"8.2", "8.3", "8.4"}
+	nodeVersions = []string{"22", "24"}
+	profilers    = []string{"", "xdebug", "blackfire", "tideways", "pcov", "spx"}
+)
+
+// ConfigModel holds the state for the Environment Config tab.
+type ConfigModel struct {
+	cursor configField
+
+	phpVersion  int // index into phpVersions
+	nodeVersion int // index into nodeVersions
+	profiler    int // index into profilers
+
+	blackfireServerID    textinput.Model
+	blackfireServerToken textinput.Model
+	tidewaysAPIKey       textinput.Model
+
+	editing  bool // true when a text input is focused
+	saved    bool // flash a "saved" indicator
+	modified bool // config has unsaved changes
+
+	width  int
+	height int
+}
+
+type configSavedMsg struct{}
+
+func NewConfigModel(cfg *shop.Config) ConfigModel {
+	m := ConfigModel{}
+
+	if cfg != nil && cfg.Docker != nil {
+		if cfg.Docker.PHP != nil {
+			m.phpVersion = indexOf(phpVersions, cfg.Docker.PHP.Version, 1) // default 8.3
+			m.profiler = indexOf(profilers, cfg.Docker.PHP.Profiler, 0)
+			m.blackfireServerID = newConfigInput("Server ID", cfg.Docker.PHP.BlackfireServerID)
+			m.blackfireServerToken = newConfigInput("Server Token", cfg.Docker.PHP.BlackfireServerToken)
+			m.tidewaysAPIKey = newConfigInput("API Key", cfg.Docker.PHP.TidewaysAPIKey)
+		}
+		if cfg.Docker.Node != nil {
+			m.nodeVersion = indexOf(nodeVersions, cfg.Docker.Node.Version, 0)
+		}
+	}
+
+	// Ensure text inputs are initialized even if config was nil.
+	if m.blackfireServerID.Placeholder == "" {
+		m.blackfireServerID = newConfigInput("Server ID", "")
+	}
+	if m.blackfireServerToken.Placeholder == "" {
+		m.blackfireServerToken = newConfigInput("Server Token", "")
+	}
+	if m.tidewaysAPIKey.Placeholder == "" {
+		m.tidewaysAPIKey = newConfigInput("API Key", "")
+	}
+
+	return m
+}
+
+func newConfigInput(placeholder, value string) textinput.Model {
+	ti := textinput.New()
+	ti.Placeholder = placeholder
+	ti.CharLimit = 128
+	ti.Prompt = ""
+	if value != "" {
+		ti.SetValue(value)
+	}
+	return ti
+}
+
+func indexOf(slice []string, value string, defaultIdx int) int {
+	for i, v := range slice {
+		if v == value {
+			return i
+		}
+	}
+	return defaultIdx
+}
+
+func (m *ConfigModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+func (m ConfigModel) Update(msg tea.Msg) (ConfigModel, tea.Cmd) {
+	if _, ok := msg.(configSavedMsg); ok {
+		m.saved = true
+		m.modified = false
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m ConfigModel) HandleKey(msg tea.KeyPressMsg) (ConfigModel, tea.Cmd) {
+	key := msg.String()
+
+	// When editing a text field, route keys to the active input.
+	if m.editing {
+		switch key {
+		case keyEnter, "esc":
+			m.blurAll()
+			m.editing = false
+			return m, nil
+		default:
+			var cmd tea.Cmd
+			switch m.cursor {
+			case fieldBlackfireServerID:
+				m.blackfireServerID, cmd = m.blackfireServerID.Update(msg)
+			case fieldBlackfireServerToken:
+				m.blackfireServerToken, cmd = m.blackfireServerToken.Update(msg)
+			case fieldTidewaysAPIKey:
+				m.tidewaysAPIKey, cmd = m.tidewaysAPIKey.Update(msg)
+			}
+			m.modified = true
+			return m, cmd
+		}
+	}
+
+	switch key {
+	case keyUp, keyK:
+		m.moveCursorUp()
+	case keyDown, keyJ:
+		m.moveCursorDown()
+	case keyEnter, " ":
+		return m.activateField()
+	case "left", "h":
+		m.cyclePrev()
+	case "right", "l":
+		m.cycleNext()
+	}
+
+	return m, nil
+}
+
+func (m *ConfigModel) moveCursorUp() {
+	for {
+		if m.cursor <= 0 {
+			return
+		}
+		m.cursor--
+		if m.isFieldVisible(m.cursor) {
+			return
+		}
+	}
+}
+
+func (m *ConfigModel) moveCursorDown() {
+	for {
+		if m.cursor >= fieldCount-1 {
+			return
+		}
+		m.cursor++
+		if m.isFieldVisible(m.cursor) {
+			return
+		}
+	}
+}
+
+func (m ConfigModel) isFieldVisible(f configField) bool {
+	profilerName := profilers[m.profiler]
+	switch f {
+	case fieldBlackfireServerID, fieldBlackfireServerToken:
+		return profilerName == "blackfire"
+	case fieldTidewaysAPIKey:
+		return profilerName == "tideways"
+	default:
+		return true
+	}
+}
+
+func (m *ConfigModel) activateField() (ConfigModel, tea.Cmd) {
+	switch m.cursor {
+	case fieldPHPVersion:
+		m.phpVersion = (m.phpVersion + 1) % len(phpVersions)
+		m.modified = true
+	case fieldNodeVersion:
+		m.nodeVersion = (m.nodeVersion + 1) % len(nodeVersions)
+		m.modified = true
+	case fieldProfiler:
+		m.profiler = (m.profiler + 1) % len(profilers)
+		m.modified = true
+		// Re-validate cursor position after profiler change.
+		if !m.isFieldVisible(m.cursor) {
+			m.moveCursorDown()
+		}
+	case fieldBlackfireServerID:
+		m.editing = true
+		m.blackfireServerID.Focus()
+		return *m, textinput.Blink
+	case fieldBlackfireServerToken:
+		m.editing = true
+		m.blackfireServerToken.Focus()
+		return *m, textinput.Blink
+	case fieldTidewaysAPIKey:
+		m.editing = true
+		m.tidewaysAPIKey.Focus()
+		return *m, textinput.Blink
+	case fieldSave:
+		// Save is handled by the parent model.
+		return *m, nil
+	}
+	return *m, nil
+}
+
+func (m *ConfigModel) cyclePrev() {
+	m.saved = false
+	switch m.cursor {
+	case fieldPHPVersion:
+		m.phpVersion = (m.phpVersion - 1 + len(phpVersions)) % len(phpVersions)
+		m.modified = true
+	case fieldNodeVersion:
+		m.nodeVersion = (m.nodeVersion - 1 + len(nodeVersions)) % len(nodeVersions)
+		m.modified = true
+	case fieldProfiler:
+		m.profiler = (m.profiler - 1 + len(profilers)) % len(profilers)
+		m.modified = true
+	}
+}
+
+func (m *ConfigModel) cycleNext() {
+	m.saved = false
+	switch m.cursor {
+	case fieldPHPVersion:
+		m.phpVersion = (m.phpVersion + 1) % len(phpVersions)
+		m.modified = true
+	case fieldNodeVersion:
+		m.nodeVersion = (m.nodeVersion + 1) % len(nodeVersions)
+		m.modified = true
+	case fieldProfiler:
+		m.profiler = (m.profiler + 1) % len(profilers)
+		m.modified = true
+	}
+}
+
+func (m *ConfigModel) blurAll() {
+	m.blackfireServerID.Blur()
+	m.blackfireServerToken.Blur()
+	m.tidewaysAPIKey.Blur()
+}
+
+// ApplyToConfig writes the current form values into the given Config.
+func (m ConfigModel) ApplyToConfig(cfg *shop.Config) {
+	if cfg.Docker == nil {
+		cfg.Docker = &shop.ConfigDocker{}
+	}
+	if cfg.Docker.PHP == nil {
+		cfg.Docker.PHP = &shop.ConfigDockerPHP{}
+	}
+	if cfg.Docker.Node == nil {
+		cfg.Docker.Node = &shop.ConfigDockerNode{}
+	}
+
+	cfg.Docker.PHP.Version = phpVersions[m.phpVersion]
+	cfg.Docker.Node.Version = nodeVersions[m.nodeVersion]
+	cfg.Docker.PHP.Profiler = profilers[m.profiler]
+
+	// Only persist credentials for the active profiler.
+	cfg.Docker.PHP.BlackfireServerID = ""
+	cfg.Docker.PHP.BlackfireServerToken = ""
+	cfg.Docker.PHP.TidewaysAPIKey = ""
+
+	switch profilers[m.profiler] {
+	case "blackfire":
+		cfg.Docker.PHP.BlackfireServerID = m.blackfireServerID.Value()
+		cfg.Docker.PHP.BlackfireServerToken = m.blackfireServerToken.Value()
+	case "tideways":
+		cfg.Docker.PHP.TidewaysAPIKey = m.tidewaysAPIKey.Value()
+	}
+}
+
+func (m ConfigModel) View(width, height int) string {
+	var s strings.Builder
+
+	selectedArrow := lipgloss.NewStyle().Foreground(tui.BrandColor).Render("▸ ")
+	normalIndent := "  "
+
+	divider := tui.SectionDivider(width - 8)
+
+	// --- PHP Settings ---
+	s.WriteString(tui.TitleStyle.Render("PHP"))
+	s.WriteString("\n")
+	s.WriteString(m.renderSelect(fieldPHPVersion, "Version", phpVersions[m.phpVersion], selectedArrow, normalIndent))
+	s.WriteString(m.renderSelect(fieldProfiler, "Profiler", m.profilerLabel(), selectedArrow, normalIndent))
+
+	// Profiler-specific credential fields.
+	profilerName := profilers[m.profiler]
+	if profilerName == "blackfire" {
+		s.WriteString(m.renderInput(fieldBlackfireServerID, "Server ID", m.blackfireServerID, selectedArrow, normalIndent))
+		s.WriteString(m.renderInput(fieldBlackfireServerToken, "Server Token", m.blackfireServerToken, selectedArrow, normalIndent))
+	}
+	if profilerName == "tideways" {
+		s.WriteString(m.renderInput(fieldTidewaysAPIKey, "API Key", m.tidewaysAPIKey, selectedArrow, normalIndent))
+	}
+
+	s.WriteString(divider)
+
+	// --- Node Settings ---
+	s.WriteString(tui.TitleStyle.Render("Node.js"))
+	s.WriteString("\n")
+	s.WriteString(m.renderSelect(fieldNodeVersion, "Version", nodeVersions[m.nodeVersion], selectedArrow, normalIndent))
+
+	s.WriteString(divider)
+
+	// --- Save Button ---
+	if m.cursor == fieldSave {
+		s.WriteString(selectedArrow)
+	} else {
+		s.WriteString(normalIndent)
+	}
+	if m.saved {
+		s.WriteString(activeBadgeStyle.Render("Saved"))
+		s.WriteString("  ")
+		s.WriteString(helpStyle.Render("Restart Docker to apply changes."))
+	} else if m.modified {
+		if m.cursor == fieldSave {
+			s.WriteString(activeBtnStyle.Render("Save & Regenerate"))
+		} else {
+			s.WriteString(warningBadgeStyle.Render("unsaved changes"))
+			s.WriteString("  ")
+			s.WriteString(helpStyle.Render("Navigate to Save & Regenerate"))
+		}
+	} else {
+		s.WriteString(helpStyle.Render("No changes"))
+	}
+	s.WriteString("\n")
+
+	return s.String()
+}
+
+func (m ConfigModel) profilerLabel() string {
+	p := profilers[m.profiler]
+	if p == "" {
+		return "none"
+	}
+	return p
+}
+
+func (m ConfigModel) renderSelect(field configField, label, value, selectedArrow, normalIndent string) string {
+	prefix := normalIndent
+	if m.cursor == field {
+		prefix = selectedArrow
+	}
+
+	valStyle := valueStyle
+	if m.cursor == field {
+		valStyle = lipgloss.NewStyle().Foreground(tui.BrandColor).Bold(true)
+	}
+
+	arrows := ""
+	if m.cursor == field {
+		arrows = helpStyle.Render(" ◂ ▸")
+	}
+
+	return fmt.Sprintf("%s%-20s%s%s\n", prefix, tui.LabelStyle.Render(label), valStyle.Render(value), arrows)
+}
+
+func (m ConfigModel) renderInput(field configField, label string, input textinput.Model, selectedArrow, normalIndent string) string {
+	prefix := normalIndent
+	if m.cursor == field {
+		prefix = selectedArrow
+	}
+
+	if m.cursor == field && m.editing {
+		return fmt.Sprintf("%s%-20s%s\n", prefix, tui.LabelStyle.Render(label), input.View())
+	}
+
+	val := input.Value()
+	if val == "" {
+		val = helpStyle.Render("(not set)")
+	} else {
+		val = secretStyle.Render(val)
+	}
+
+	hint := ""
+	if m.cursor == field {
+		hint = helpStyle.Render(" enter to edit")
+	}
+
+	return fmt.Sprintf("%s%-20s%s%s\n", prefix, tui.LabelStyle.Render(label), val, hint)
+}

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -265,7 +265,8 @@ func (m *ConfigModel) blurAll() {
 	m.tidewaysAPIKey.Blur()
 }
 
-// ApplyToConfig writes the current form values into the given Config.
+// ApplyToConfig writes the non-sensitive form values into the given Config.
+// Credentials are excluded — use LocalConfig to obtain them separately.
 func (m ConfigModel) ApplyToConfig(cfg *shop.Config) {
 	if cfg.Docker == nil {
 		cfg.Docker = &shop.ConfigDocker{}
@@ -281,17 +282,32 @@ func (m ConfigModel) ApplyToConfig(cfg *shop.Config) {
 	cfg.Docker.Node.Version = nodeVersions[m.nodeVersion]
 	cfg.Docker.PHP.Profiler = profilers[m.profiler]
 
-	// Only persist credentials for the active profiler.
+	// Credentials are stored in the local config file, not here.
 	cfg.Docker.PHP.BlackfireServerID = ""
 	cfg.Docker.PHP.BlackfireServerToken = ""
 	cfg.Docker.PHP.TidewaysAPIKey = ""
+}
+
+// LocalConfig returns a partial Config containing only the sensitive
+// credential fields for the active profiler. This is written to
+// .shopware-project.local.yml so secrets stay out of version control.
+func (m ConfigModel) LocalConfig() *shop.Config {
+	php := &shop.ConfigDockerPHP{}
 
 	switch profilers[m.profiler] {
 	case "blackfire":
-		cfg.Docker.PHP.BlackfireServerID = m.blackfireServerID.Value()
-		cfg.Docker.PHP.BlackfireServerToken = m.blackfireServerToken.Value()
+		php.BlackfireServerID = m.blackfireServerID.Value()
+		php.BlackfireServerToken = m.blackfireServerToken.Value()
 	case "tideways":
-		cfg.Docker.PHP.TidewaysAPIKey = m.tidewaysAPIKey.Value()
+		php.TidewaysAPIKey = m.tidewaysAPIKey.Value()
+	default:
+		return nil // no credentials to persist
+	}
+
+	return &shop.Config{
+		Docker: &shop.ConfigDocker{
+			PHP: php,
+		},
 	}
 }
 

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -25,10 +25,15 @@ const (
 	fieldCount // sentinel – number of fields
 )
 
+const (
+	profilerBlackfire = "blackfire"
+	profilerTideways  = "tideways"
+)
+
 var (
 	phpVersions  = []string{"8.2", "8.3", "8.4"}
 	nodeVersions = []string{"22", "24"}
-	profilers    = []string{"", "xdebug", "blackfire", "tideways", "pcov", "spx"}
+	profilers    = []string{"", "xdebug", profilerBlackfire, profilerTideways, "pcov", "spx"}
 )
 
 // ConfigModel holds the state for the Environment Config tab.
@@ -129,7 +134,7 @@ func (m ConfigModel) HandleKey(msg tea.KeyPressMsg) (ConfigModel, tea.Cmd) {
 			return m, nil
 		default:
 			var cmd tea.Cmd
-			switch m.cursor {
+			switch m.cursor { //nolint:exhaustive
 			case fieldBlackfireServerID:
 				m.blackfireServerID, cmd = m.blackfireServerID.Update(msg)
 			case fieldBlackfireServerToken:
@@ -149,9 +154,9 @@ func (m ConfigModel) HandleKey(msg tea.KeyPressMsg) (ConfigModel, tea.Cmd) {
 		m.moveCursorDown()
 	case keyEnter, " ":
 		return m.activateField()
-	case "left", "h":
+	case keyLeft, "h":
 		m.cyclePrev()
-	case "right", "l":
+	case keyRight, "l":
 		m.cycleNext()
 	}
 
@@ -186,12 +191,13 @@ func (m ConfigModel) isFieldVisible(f configField) bool {
 	profilerName := profilers[m.profiler]
 	switch f {
 	case fieldBlackfireServerID, fieldBlackfireServerToken:
-		return profilerName == "blackfire"
+		return profilerName == profilerBlackfire
 	case fieldTidewaysAPIKey:
-		return profilerName == "tideways"
-	default:
+		return profilerName == profilerTideways
+	case fieldPHPVersion, fieldProfiler, fieldNodeVersion, fieldSave, fieldCount:
 		return true
 	}
+	return true
 }
 
 func (m *ConfigModel) activateField() (ConfigModel, tea.Cmd) {
@@ -221,8 +227,8 @@ func (m *ConfigModel) activateField() (ConfigModel, tea.Cmd) {
 		m.editing = true
 		m.tidewaysAPIKey.Focus()
 		return *m, textinput.Blink
-	case fieldSave:
-		// Save is handled by the parent model.
+	case fieldSave, fieldCount:
+		// Save is handled by the parent model; fieldCount is a sentinel.
 		return *m, nil
 	}
 	return *m, nil
@@ -230,7 +236,7 @@ func (m *ConfigModel) activateField() (ConfigModel, tea.Cmd) {
 
 func (m *ConfigModel) cyclePrev() {
 	m.saved = false
-	switch m.cursor {
+	switch m.cursor { //nolint:exhaustive
 	case fieldPHPVersion:
 		m.phpVersion = (m.phpVersion - 1 + len(phpVersions)) % len(phpVersions)
 		m.modified = true
@@ -245,7 +251,7 @@ func (m *ConfigModel) cyclePrev() {
 
 func (m *ConfigModel) cycleNext() {
 	m.saved = false
-	switch m.cursor {
+	switch m.cursor { //nolint:exhaustive
 	case fieldPHPVersion:
 		m.phpVersion = (m.phpVersion + 1) % len(phpVersions)
 		m.modified = true
@@ -294,10 +300,10 @@ func (m ConfigModel) LocalConfig() *shop.Config {
 	php := &shop.ConfigDockerPHP{}
 
 	switch profilers[m.profiler] {
-	case "blackfire":
+	case profilerBlackfire:
 		php.BlackfireServerID = m.blackfireServerID.Value()
 		php.BlackfireServerToken = m.blackfireServerToken.Value()
-	case "tideways":
+	case profilerTideways:
 		php.TidewaysAPIKey = m.tidewaysAPIKey.Value()
 	default:
 		return nil // no credentials to persist
@@ -326,11 +332,11 @@ func (m ConfigModel) View(width, height int) string {
 
 	// Profiler-specific credential fields.
 	profilerName := profilers[m.profiler]
-	if profilerName == "blackfire" {
+	if profilerName == profilerBlackfire {
 		s.WriteString(m.renderInput(fieldBlackfireServerID, "Server ID", m.blackfireServerID, selectedArrow, normalIndent))
 		s.WriteString(m.renderInput(fieldBlackfireServerToken, "Server Token", m.blackfireServerToken, selectedArrow, normalIndent))
 	}
-	if profilerName == "tideways" {
+	if profilerName == profilerTideways {
 		s.WriteString(m.renderInput(fieldTidewaysAPIKey, "API Key", m.tidewaysAPIKey, selectedArrow, normalIndent))
 	}
 

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -355,19 +355,18 @@ func (m ConfigModel) View(width, height int) string {
 	} else {
 		s.WriteString(normalIndent)
 	}
-	if m.saved {
+	switch {
+	case m.saved:
 		s.WriteString(activeBadgeStyle.Render("Saved"))
 		s.WriteString("  ")
 		s.WriteString(helpStyle.Render("Restart Docker to apply changes."))
-	} else if m.modified {
-		if m.cursor == fieldSave {
-			s.WriteString(activeBtnStyle.Render("Save & Regenerate"))
-		} else {
-			s.WriteString(warningBadgeStyle.Render("unsaved changes"))
-			s.WriteString("  ")
-			s.WriteString(helpStyle.Render("Navigate to Save & Regenerate"))
-		}
-	} else {
+	case m.modified && m.cursor == fieldSave:
+		s.WriteString(activeBtnStyle.Render("Save & Regenerate"))
+	case m.modified:
+		s.WriteString(warningBadgeStyle.Render("unsaved changes"))
+		s.WriteString("  ")
+		s.WriteString(helpStyle.Render("Navigate to Save & Regenerate"))
+	default:
 		s.WriteString(helpStyle.Render("No changes"))
 	}
 	s.WriteString("\n")

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -1,7 +1,6 @@
 package devtui
 
 import (
-	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
@@ -378,6 +377,8 @@ func (m ConfigModel) profilerLabel() string {
 	return p
 }
 
+var configKeyStyle = lipgloss.NewStyle().Width(22).Foreground(tui.TextColor)
+
 func (m ConfigModel) renderSelect(field configField, label, value, selectedArrow, normalIndent string) string {
 	prefix := normalIndent
 	if m.cursor == field {
@@ -394,7 +395,7 @@ func (m ConfigModel) renderSelect(field configField, label, value, selectedArrow
 		arrows = helpStyle.Render(" ◂ ▸")
 	}
 
-	return fmt.Sprintf("%s%-20s%s%s\n", prefix, tui.LabelStyle.Render(label), valStyle.Render(value), arrows)
+	return prefix + configKeyStyle.Render(label) + valStyle.Render(value) + arrows + "\n"
 }
 
 func (m ConfigModel) renderInput(field configField, label string, input textinput.Model, selectedArrow, normalIndent string) string {
@@ -404,7 +405,7 @@ func (m ConfigModel) renderInput(field configField, label string, input textinpu
 	}
 
 	if m.cursor == field && m.editing {
-		return fmt.Sprintf("%s%-20s%s\n", prefix, tui.LabelStyle.Render(label), input.View())
+		return prefix + configKeyStyle.Render(label) + input.View() + "\n"
 	}
 
 	val := input.Value()
@@ -419,5 +420,5 @@ func (m ConfigModel) renderInput(field configField, label string, input textinpu
 		hint = helpStyle.Render(" enter to edit")
 	}
 
-	return fmt.Sprintf("%s%-20s%s%s\n", prefix, tui.LabelStyle.Render(label), val, hint)
+	return prefix + configKeyStyle.Render(label) + val + hint + "\n"
 }

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -56,7 +56,7 @@ func TestConfigModel_ApplyToConfig(t *testing.T) {
 	assert.Empty(t, cfg.Docker.PHP.BlackfireServerID)
 }
 
-func TestConfigModel_ApplyToConfig_Blackfire(t *testing.T) {
+func TestConfigModel_ApplyToConfig_BlackfireCredentialsExcluded(t *testing.T) {
 	cfg := &shop.Config{}
 	m := NewConfigModel(nil)
 	m.profiler = 2 // blackfire
@@ -66,22 +66,42 @@ func TestConfigModel_ApplyToConfig_Blackfire(t *testing.T) {
 	m.ApplyToConfig(cfg)
 
 	assert.Equal(t, "blackfire", cfg.Docker.PHP.Profiler)
-	assert.Equal(t, "srv-id", cfg.Docker.PHP.BlackfireServerID)
-	assert.Equal(t, "srv-token", cfg.Docker.PHP.BlackfireServerToken)
-	assert.Empty(t, cfg.Docker.PHP.TidewaysAPIKey)
+	// Credentials should NOT be in the main config.
+	assert.Empty(t, cfg.Docker.PHP.BlackfireServerID)
+	assert.Empty(t, cfg.Docker.PHP.BlackfireServerToken)
 }
 
-func TestConfigModel_ApplyToConfig_Tideways(t *testing.T) {
-	cfg := &shop.Config{}
+func TestConfigModel_LocalConfig_Blackfire(t *testing.T) {
+	m := NewConfigModel(nil)
+	m.profiler = 2 // blackfire
+	m.blackfireServerID.SetValue("srv-id")
+	m.blackfireServerToken.SetValue("srv-token")
+
+	localCfg := m.LocalConfig()
+	assert.NotNil(t, localCfg)
+	assert.Equal(t, "srv-id", localCfg.Docker.PHP.BlackfireServerID)
+	assert.Equal(t, "srv-token", localCfg.Docker.PHP.BlackfireServerToken)
+}
+
+func TestConfigModel_LocalConfig_Tideways(t *testing.T) {
 	m := NewConfigModel(nil)
 	m.profiler = 3 // tideways
 	m.tidewaysAPIKey.SetValue("tw-key")
 
-	m.ApplyToConfig(cfg)
+	localCfg := m.LocalConfig()
+	assert.NotNil(t, localCfg)
+	assert.Equal(t, "tw-key", localCfg.Docker.PHP.TidewaysAPIKey)
+	assert.Empty(t, localCfg.Docker.PHP.BlackfireServerID)
+}
 
-	assert.Equal(t, "tideways", cfg.Docker.PHP.Profiler)
-	assert.Equal(t, "tw-key", cfg.Docker.PHP.TidewaysAPIKey)
-	assert.Empty(t, cfg.Docker.PHP.BlackfireServerID)
+func TestConfigModel_LocalConfig_NoCredentials(t *testing.T) {
+	m := NewConfigModel(nil)
+	m.profiler = 0 // none
+
+	assert.Nil(t, m.LocalConfig())
+
+	m.profiler = 1 // xdebug
+	assert.Nil(t, m.LocalConfig())
 }
 
 func TestConfigModel_FieldVisibility(t *testing.T) {

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -1,0 +1,150 @@
+package devtui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+func TestNewConfigModel_NilConfig(t *testing.T) {
+	m := NewConfigModel(nil)
+
+	assert.Equal(t, 1, m.phpVersion)   // default 8.3 (index 1)
+	assert.Equal(t, 0, m.nodeVersion)  // default 22 (index 0)
+	assert.Equal(t, 0, m.profiler)     // default none (index 0)
+	assert.False(t, m.editing)
+	assert.False(t, m.saved)
+	assert.False(t, m.modified)
+}
+
+func TestNewConfigModel_WithConfig(t *testing.T) {
+	cfg := &shop.Config{
+		Docker: &shop.ConfigDocker{
+			PHP: &shop.ConfigDockerPHP{
+				Version:           "8.2",
+				Profiler:          "blackfire",
+				BlackfireServerID: "my-server-id",
+			},
+			Node: &shop.ConfigDockerNode{
+				Version: "24",
+			},
+		},
+	}
+
+	m := NewConfigModel(cfg)
+
+	assert.Equal(t, 0, m.phpVersion) // 8.2 is index 0
+	assert.Equal(t, 1, m.nodeVersion) // 24 is index 1
+	assert.Equal(t, 2, m.profiler) // blackfire is index 2
+	assert.Equal(t, "my-server-id", m.blackfireServerID.Value())
+}
+
+func TestConfigModel_ApplyToConfig(t *testing.T) {
+	cfg := &shop.Config{}
+	m := NewConfigModel(nil)
+	m.phpVersion = 2  // 8.4
+	m.nodeVersion = 1 // 24
+	m.profiler = 1    // xdebug
+
+	m.ApplyToConfig(cfg)
+
+	assert.Equal(t, "8.4", cfg.Docker.PHP.Version)
+	assert.Equal(t, "24", cfg.Docker.Node.Version)
+	assert.Equal(t, "xdebug", cfg.Docker.PHP.Profiler)
+	assert.Empty(t, cfg.Docker.PHP.BlackfireServerID)
+}
+
+func TestConfigModel_ApplyToConfig_Blackfire(t *testing.T) {
+	cfg := &shop.Config{}
+	m := NewConfigModel(nil)
+	m.profiler = 2 // blackfire
+	m.blackfireServerID.SetValue("srv-id")
+	m.blackfireServerToken.SetValue("srv-token")
+
+	m.ApplyToConfig(cfg)
+
+	assert.Equal(t, "blackfire", cfg.Docker.PHP.Profiler)
+	assert.Equal(t, "srv-id", cfg.Docker.PHP.BlackfireServerID)
+	assert.Equal(t, "srv-token", cfg.Docker.PHP.BlackfireServerToken)
+	assert.Empty(t, cfg.Docker.PHP.TidewaysAPIKey)
+}
+
+func TestConfigModel_ApplyToConfig_Tideways(t *testing.T) {
+	cfg := &shop.Config{}
+	m := NewConfigModel(nil)
+	m.profiler = 3 // tideways
+	m.tidewaysAPIKey.SetValue("tw-key")
+
+	m.ApplyToConfig(cfg)
+
+	assert.Equal(t, "tideways", cfg.Docker.PHP.Profiler)
+	assert.Equal(t, "tw-key", cfg.Docker.PHP.TidewaysAPIKey)
+	assert.Empty(t, cfg.Docker.PHP.BlackfireServerID)
+}
+
+func TestConfigModel_FieldVisibility(t *testing.T) {
+	m := NewConfigModel(nil)
+
+	// No profiler - credential fields should be hidden.
+	m.profiler = 0
+	assert.False(t, m.isFieldVisible(fieldBlackfireServerID))
+	assert.False(t, m.isFieldVisible(fieldBlackfireServerToken))
+	assert.False(t, m.isFieldVisible(fieldTidewaysAPIKey))
+
+	// Blackfire - only blackfire fields visible.
+	m.profiler = indexOf(profilers, "blackfire", 0)
+	assert.True(t, m.isFieldVisible(fieldBlackfireServerID))
+	assert.True(t, m.isFieldVisible(fieldBlackfireServerToken))
+	assert.False(t, m.isFieldVisible(fieldTidewaysAPIKey))
+
+	// Tideways - only tideways field visible.
+	m.profiler = indexOf(profilers, "tideways", 0)
+	assert.False(t, m.isFieldVisible(fieldBlackfireServerID))
+	assert.True(t, m.isFieldVisible(fieldTidewaysAPIKey))
+}
+
+func TestConfigModel_CursorNavigation(t *testing.T) {
+	m := NewConfigModel(nil)
+	m.profiler = 0 // no profiler, so credential fields are hidden.
+
+	assert.Equal(t, fieldPHPVersion, m.cursor)
+
+	m.moveCursorDown()
+	assert.Equal(t, fieldProfiler, m.cursor)
+
+	// Should skip hidden credential fields to Node Version.
+	m.moveCursorDown()
+	assert.Equal(t, fieldNodeVersion, m.cursor, "should skip hidden fields to Node Version")
+
+	m.moveCursorDown()
+	assert.Equal(t, fieldSave, m.cursor)
+
+	m.moveCursorUp()
+	assert.Equal(t, fieldNodeVersion, m.cursor, "should go back to Node Version")
+
+	m.moveCursorUp()
+	assert.Equal(t, fieldProfiler, m.cursor, "should skip hidden fields going up")
+}
+
+func TestConfigModel_CycleValues(t *testing.T) {
+	m := NewConfigModel(nil)
+
+	initial := m.phpVersion
+	m.cycleNext()
+	assert.NotEqual(t, initial, m.phpVersion)
+	assert.True(t, m.modified)
+
+	m.modified = false
+	m.cursor = fieldNodeVersion
+	m.cycleNext()
+	assert.True(t, m.modified)
+}
+
+func TestIndexOf(t *testing.T) {
+	assert.Equal(t, 0, indexOf(phpVersions, "8.2", 1))
+	assert.Equal(t, 1, indexOf(phpVersions, "8.3", 0))
+	assert.Equal(t, 2, indexOf(phpVersions, "8.4", 0))
+	assert.Equal(t, 1, indexOf(phpVersions, "unknown", 1)) // default
+}

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -11,9 +11,9 @@ import (
 func TestNewConfigModel_NilConfig(t *testing.T) {
 	m := NewConfigModel(nil)
 
-	assert.Equal(t, 1, m.phpVersion)   // default 8.3 (index 1)
-	assert.Equal(t, 0, m.nodeVersion)  // default 22 (index 0)
-	assert.Equal(t, 0, m.profiler)     // default none (index 0)
+	assert.Equal(t, 1, m.phpVersion)  // default 8.3 (index 1)
+	assert.Equal(t, 0, m.nodeVersion) // default 22 (index 0)
+	assert.Equal(t, 0, m.profiler)    // default none (index 0)
 	assert.False(t, m.editing)
 	assert.False(t, m.saved)
 	assert.False(t, m.modified)
@@ -35,9 +35,9 @@ func TestNewConfigModel_WithConfig(t *testing.T) {
 
 	m := NewConfigModel(cfg)
 
-	assert.Equal(t, 0, m.phpVersion) // 8.2 is index 0
+	assert.Equal(t, 0, m.phpVersion)  // 8.2 is index 0
 	assert.Equal(t, 1, m.nodeVersion) // 24 is index 1
-	assert.Equal(t, 2, m.profiler) // blackfire is index 2
+	assert.Equal(t, 2, m.profiler)    // blackfire is index 2
 	assert.Equal(t, "my-server-id", m.blackfireServerID.Value())
 }
 

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -539,6 +539,24 @@ func WriteConfig(cfg *Config, dir string) error {
 	return nil
 }
 
+// WriteLocalConfig writes a partial configuration to .shopware-project.local.yml.
+// This file is deep-merged on top of the main config at read time and is intended
+// for credentials and other values that should not be committed to version control.
+func WriteLocalConfig(cfg *Config, dir string) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal local shop configuration: %w", err)
+	}
+
+	filePath := filepath.Join(dir, ".shopware-project.local.yml")
+
+	if err := os.WriteFile(filePath, data, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to write local shop configuration to %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
 func ReadConfig(ctx context.Context, fileName string, allowFallback bool) (*Config, error) {
 	config := &Config{foundConfig: false}
 


### PR DESCRIPTION
## Summary
This PR adds a new "Config" tab to the development TUI that allows users to configure Docker environment settings (PHP version, Node.js version, and profiler selection) with support for profiler-specific credentials.

## Key Changes

- **New Config Tab UI** (`internal/devtui/tab_config.go`):
  - Created `ConfigModel` to manage environment configuration state
  - Supports selecting PHP versions (8.2, 8.3, 8.4), Node.js versions (22, 24), and profilers (none, xdebug, blackfire, tideways, pcov, spx)
  - Implements conditional field visibility based on selected profiler (e.g., Blackfire Server ID/Token only shown when Blackfire is selected)
  - Handles text input for sensitive credentials (Blackfire Server ID/Token, Tideways API Key)
  - Tracks modified state and provides visual feedback for unsaved changes and successful saves

- **Configuration Persistence**:
  - Added `WriteLocalConfig()` in `internal/shop/config.go` to write credentials to `.shopware-project.local.yml` (excluded from version control)
  - Main config values (versions, profiler choice) written to standard config file
  - Credentials separated from main config to keep secrets out of version control

- **Tab Navigation**:
  - Added Config tab as third tab (accessible via `3` key or Tab navigation)
  - Updated tab cycling logic to support three tabs
  - Added keyboard shortcuts for tab switching (1=General, 2=Logs, 3=Config)

- **User Interaction**:
  - Arrow keys (↑/↓) and vim keys (j/k) for navigation
  - Left/Right arrows (h/l) to cycle through select field values
  - Enter to activate/edit fields, Esc to exit editing mode
  - Visual indicators for selected fields, unsaved changes, and saved state
  - Cursor automatically skips hidden credential fields based on profiler selection

- **Comprehensive Tests** (`internal/devtui/tab_config_test.go`):
  - Tests for config initialization with and without existing configuration
  - Tests for applying config changes and credential separation
  - Tests for field visibility based on profiler selection
  - Tests for cursor navigation with hidden fields
  - Tests for value cycling and helper functions

## Notable Implementation Details

- Credentials are stored separately in a local config file to prevent accidental commits of secrets
- Field visibility is dynamically managed—credential input fields only appear when their corresponding profiler is selected
- Cursor navigation intelligently skips hidden fields when moving up/down
- The model maintains both a "modified" flag (for unsaved changes) and a "saved" flag (for visual feedback)
- Text inputs are properly focused/blurred to enable editing mode without interfering with global keyboard shortcuts

https://claude.ai/code/session_01U7yvsUhc6vAv349PveRYxx