### PR TITLE
fix: Sub-bundles not handled in project ci

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -132,7 +132,11 @@ var projectCI = &cobra.Command{
 
 		lookingForExtensionsSection := ci.Default.Section(cmd.Context(), "Looking for extensions")
 
-		sources := extension.FindAssetSourcesOfProject(cmd.Context(), args[0], shopCfg)
+		sources, err := extension.DumpAndLoadAssetSourcesOfProject(cmd.Context(), args[0], shopCfg)
+		if err != nil {
+			logging.FromContext(cmd.Context()).Warnf("bundle:dump failed, falling back to static extension discovery (sub-bundles may be missed): %s", err.Error())
+			sources = extension.FindAssetSourcesOfProject(cmd.Context(), args[0], shopCfg)
+		}
 
 		shopwareConstraint, err := extension.GetShopwareProjectConstraint(args[0])
 		if err != nil {

--- a/internal/extension/project.go
+++ b/internal/extension/project.go
@@ -191,12 +191,19 @@ func DumpAndLoadAssetSourcesOfProject(ctx context.Context, project string, shopC
 		return nil, fmt.Errorf("could not bundle features: %w", err)
 	}
 
-	var pluginsJson map[string]ExtensionAssetConfigEntry
+	return loadAssetSourcesFromPluginsJSON(ctx, project)
+}
 
+// loadAssetSourcesFromPluginsJSON reads var/plugins.json (written by bundle:dump) and converts it
+// into asset sources. It is separated from DumpAndLoadAssetSourcesOfProject so it can be tested
+// without a live PHP environment.
+func loadAssetSourcesFromPluginsJSON(ctx context.Context, project string) ([]asset.Source, error) {
 	pluginJsonBytes, err := os.ReadFile(path.Join(project, "var", "plugins.json"))
 	if err != nil {
 		return nil, fmt.Errorf("could not read plugins.json: %w", err)
 	}
+
+	var pluginsJson map[string]ExtensionAssetConfigEntry
 
 	if err := json.Unmarshal(pluginJsonBytes, &pluginsJson); err != nil {
 		return nil, fmt.Errorf("could not parse plugins.json: %w", err)

--- a/internal/extension/project_test.go
+++ b/internal/extension/project_test.go
@@ -1,6 +1,7 @@
 package extension
 
 import (
+	"encoding/json"
 	"os"
 	"path"
 	"path/filepath"
@@ -211,6 +212,81 @@ func TestFindAssetSourcesOfProjectYAMLBundleNameOverride(t *testing.T) {
 
 	assert.Contains(t, names, "CustomBundleName")
 	assert.NotContains(t, names, "MyBundle")
+}
+
+func writePluginsJSON(t *testing.T, dir string, entries map[string]ExtensionAssetConfigEntry) {
+	t.Helper()
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "var"), os.ModePerm))
+	data, err := json.Marshal(entries)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "var", "plugins.json"), data, 0o644))
+}
+
+func entryFilePath(p string) *string { return &p }
+
+/**
+ * TestLoadAssetSourcesFromPluginsJSON_SubBundle verifies that a sub-bundle registered in the
+ * Shopware kernel (and therefore written to var/plugins.json by bundle:dump) is included in the
+ * returned sources.
+ */
+func TestLoadAssetSourcesFromPluginsJSON_SubBundle(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	adminEntry := entryFilePath("src/Resources/app/administration/src/main.js")
+	writePluginsJSON(t, tmpDir, map[string]ExtensionAssetConfigEntry{
+		"MyPlugin": {
+			BasePath: "custom/plugins/MyPlugin/",
+			Administration: ExtensionAssetConfigAdmin{
+				EntryFilePath: adminEntry,
+			},
+		},
+		"MyPluginSubBundle": {
+			BasePath: "custom/plugins/MyPlugin/src/SubBundle/",
+			Administration: ExtensionAssetConfigAdmin{
+				EntryFilePath: adminEntry,
+			},
+		},
+	})
+
+	sources, err := loadAssetSourcesFromPluginsJSON(t.Context(), tmpDir)
+	assert.NoError(t, err)
+
+	names := make([]string, 0, len(sources))
+	for _, s := range sources {
+		names = append(names, s.Name)
+	}
+
+	assert.ElementsMatch(t, []string{"MyPlugin", "MyPluginSubBundle"}, names)
+}
+
+// TestLoadAssetSourcesFromPluginsJSON_SkipsEntriesWithoutEntryFile verifies that bundles that have
+// no admin or storefront entry file are not included (they have no JS to build).
+func TestLoadAssetSourcesFromPluginsJSON_SkipsEntriesWithoutEntryFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	adminEntry := entryFilePath("src/Resources/app/administration/src/main.js")
+	writePluginsJSON(t, tmpDir, map[string]ExtensionAssetConfigEntry{
+		"WithJS": {
+			BasePath: "custom/plugins/WithJS/",
+			Administration: ExtensionAssetConfigAdmin{
+				EntryFilePath: adminEntry,
+			},
+		},
+		"NoJS": {
+			BasePath: "custom/plugins/NoJS/",
+		},
+	})
+
+	sources, err := loadAssetSourcesFromPluginsJSON(t.Context(), tmpDir)
+	assert.NoError(t, err)
+
+	names := make([]string, 0, len(sources))
+	for _, s := range sources {
+		names = append(names, s.Name)
+	}
+
+	assert.Contains(t, names, "WithJS")
+	assert.NotContains(t, names, "NoJS")
 }
 
 func TestFindAssetSourcesOfProjectYAMLBundleDeduplication(t *testing.T) {


### PR DESCRIPTION
## Description

Other than the `project admin-build` command, the `project ci` does not consider the bundle dump, which leads to sub-bundles from plugins not being discovered. Corresponding assets, like JS files, are therefore not compiled.

This PR adds `DumpAndLoadAssetSourcesOfProject` to the `project ci` command to implement the same behavior as the `admin-build` command.