### PR TITLE
fix: Update Composer to 2.9.x to address security vulnerabilities

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,7 +2,8 @@ FROM ghcr.io/shyim/wolfi-php/base:latest
 ARG PHP_VERSION=8.3
 
 LABEL org.opencontainers.image.source=https://github.com/shopware/shopware-cli
-COPY --from=composer/composer:2-bin /composer /usr/bin/composer
+# Updated to include Composer 2.9.6+ with fixes for CVE-2026-40261 and CVE-2026-40176
+COPY --from=composer/composer:2.9-bin /composer /usr/bin/composer
 
 RUN <<EOF
     set -euxo pipefail


### PR DESCRIPTION
This update ensures the Docker base image includes Composer 2.9.6 or later, which contains fixes for two critical command injection vulnerabilities:

- CVE-2026-40261: Command injection in Perforce::syncCodeBase()
- CVE-2026-40176: Command injection in Perforce::generateP4Command()

Both vulnerabilities affect all users, even those not using Perforce.

References:
- https://blog.packagist.com/composer-2-9-6-fixes-perforce-driver-command-injection-vulnerabilities/