### PR TITLE
[codex] fix go build ordered map dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/tonistiigi/go-actions-cache v0.0.0-20260120203934-54bc28c26fd2
 	github.com/vulcand/oxy/v2 v2.1.0
 	github.com/wI2L/jsondiff v0.7.1
-	github.com/wk8/go-ordered-map/v2 v2.1.8
+	github.com/pb33f/ordered-map/v2 v2.3.1
 	github.com/yuin/goldmark v1.8.2
 	github.com/zeebo/xxh3 v1.1.0
 	go.uber.org/zap v1.27.1
@@ -61,7 +61,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -10,7 +10,7 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/invopop/jsonschema"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
+	orderedmap "github.com/pb33f/ordered-map/v2"
 	"gopkg.in/yaml.v3"
 
 	"github.com/shopware/shopware-cli/internal/compatibility"

--- a/internal/validation/types.go
+++ b/internal/validation/types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/invopop/jsonschema"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
+	orderedmap "github.com/pb33f/ordered-map/v2"
 	"gopkg.in/yaml.v3"
 )
 


### PR DESCRIPTION
## What changed

Switched the JSON schema ordered-map imports from `github.com/wk8/go-ordered-map/v2` to `github.com/pb33f/ordered-map/v2` in the schema builders that populate `jsonschema.Schema.Properties`.

## Why

`github.com/invopop/jsonschema` now expects `*github.com/pb33f/ordered-map/v2.OrderedMap[string, *jsonschema.Schema]` for `Schema.Properties`. The previous `wk8` ordered-map type is not assignable, which caused `go build ./...` to fail in `internal/validation` and `internal/shop`.

## Impact

Restores `go build ./...` while keeping the generated schema property ordering behavior.

## Validation

- `go build ./...`
- `go test ./...`