### PR TITLE
feat: add incompatibility check for Docker without libkrun on macOS

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -437,25 +437,25 @@ var projectCreateCmd = &cobra.Command{
 			}
 		}
 
-		if system.IsWSLWindowsMount(projectFolder) {
-			wslMsg := "Creating a project in a Windows-mounted directory (/mnt/c, etc.) under WSL is known to cause severe performance issues. Consider creating the project in the native Linux filesystem instead (e.g., ~/projects/)."
+		incompatibilities := system.CheckIncompatibilities(useDocker, projectFolder)
 
+		for _, incompatibility := range incompatibilities {
 			if interactive {
-				var wslContinue string
+				var continueAnyway string
 				if err := huh.NewForm(huh.NewGroup(
 					tui.NewYesNo().
-						Title(wslMsg).
-						Description("Do you want to continue anyway?").
-						Value(&wslContinue),
+						Title(incompatibility.Title).
+						Description(fmt.Sprintf("%s. Do you want to continue anyway?", incompatibility.Description)).
+						Value(&continueAnyway),
 				)).Run(); err != nil {
 					return err
 				}
 
-				if wslContinue == tui.No {
+				if continueAnyway == tui.No {
 					return fmt.Errorf("project creation cancelled")
 				}
 			} else {
-				logging.FromContext(cmd.Context()).Warnf(wslMsg)
+				logging.FromContext(cmd.Context()).Warnf("%s. %s", incompatibility.Title, incompatibility.Description)
 			}
 		}
 

--- a/internal/system/docker_unix.go
+++ b/internal/system/docker_unix.go
@@ -3,7 +3,9 @@
 package system
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"runtime"
 )
 
@@ -17,4 +19,58 @@ func IsDockerMountable() bool {
 	}
 
 	return false
+}
+
+type dockerSettings struct {
+	UseLibkrun bool `json:"UseLibkrun"`
+}
+
+// IsDockerUsingLibkrun checks if Docker is using libkrun (Docker VMM) for improved host mount performance on macOS.
+func IsDockerUsingLibkrun() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false
+	}
+
+	path := filepath.Join(home, "Library/Group Containers/group.com.docker/settings-store.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return true
+	}
+
+	var settings dockerSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return true
+	}
+
+	return settings.UseLibkrun
+}
+
+type Incompatibility struct {
+	Title       string
+	Description string
+}
+
+func CheckIncompatibilities(useDocker bool, projectFolder string) []Incompatibility {
+	var incompatibilities []Incompatibility
+
+	if useDocker && runtime.GOOS == "darwin" && !IsDockerUsingLibkrun() {
+		incompatibilities = append(incompatibilities, Incompatibility{
+			Title:       "Using Docker on macOS without libkrun (Docker VMM) may cause severe performance issues with file watching",
+			Description: "Consider enabling libkrun in Docker Desktop settings for improved host mount performance",
+		})
+	}
+
+	if IsWSL() && IsWSLWindowsMount(projectFolder) {
+		incompatibilities = append(incompatibilities, Incompatibility{
+			Title:       "Creating a project in a Windows-mounted directory (/mnt/c, etc.) under WSL is known to cause severe performance issues",
+			Description: "Consider creating the project in the native Linux filesystem instead (e.g., ~/projects/)",
+		})
+	}
+
+	return incompatibilities
 }

--- a/internal/system/docker_unix_test.go
+++ b/internal/system/docker_unix_test.go
@@ -1,0 +1,66 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsDockerUsingLibkrun(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Run("file not found returns true", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+			assert.True(t, IsDockerUsingLibkrun())
+		})
+
+		t.Run("UseLibkrun true returns true", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+
+			settingsFile := filepath.Join(tmpDir, "Library/Group Containers/group.com.docker/settings-store.json")
+			assert.NoError(t, os.MkdirAll(filepath.Dir(settingsFile), 0755))
+			assert.NoError(t, os.WriteFile(settingsFile, []byte(`{"UseLibkrun":true}`), 0644))
+
+			assert.True(t, IsDockerUsingLibkrun())
+		})
+
+		t.Run("UseLibkrun false returns false", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+
+			settingsFile := filepath.Join(tmpDir, "Library/Group Containers/group.com.docker/settings-store.json")
+			assert.NoError(t, os.MkdirAll(filepath.Dir(settingsFile), 0755))
+			assert.NoError(t, os.WriteFile(settingsFile, []byte(`{"UseLibkrun":false}`), 0644))
+
+			assert.False(t, IsDockerUsingLibkrun())
+		})
+
+		t.Run("invalid json returns true", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+
+			settingsFile := filepath.Join(tmpDir, "Library/Group Containers/group.com.docker/settings-store.json")
+			assert.NoError(t, os.MkdirAll(filepath.Dir(settingsFile), 0755))
+			assert.NoError(t, os.WriteFile(settingsFile, []byte(`invalid json`), 0644))
+
+			assert.True(t, IsDockerUsingLibkrun())
+		})
+	} else {
+		t.Run("non-darwin returns false", func(t *testing.T) {
+			t.Setenv("HOME", "/tmp/test-home")
+			assert.False(t, IsDockerUsingLibkrun())
+		})
+	}
+}
+
+func TestCheckIncompatibilities(t *testing.T) {
+	t.Run("no incompatibilities on non-darwin", func(t *testing.T) {
+		t.Setenv("HOME", "/tmp/test-home")
+		incompatibilities := CheckIncompatibilities(false, "/tmp/project")
+		assert.Empty(t, incompatibilities)
+	})
+}


### PR DESCRIPTION
## Summary

- Added `CheckIncompatibilities()` function in `internal/system/docker_unix.go` to detect environment issues
- Added `IsDockerUsingLibkrun()` to check if Docker is using libkrun (Docker VMM) for improved host mount performance
- Warns users on macOS when using Docker without libkrun enabled, which causes severe performance issues with file watching

## Checklist

- [x] Code follows the project's style guidelines
- [x] Changes are covered by tests
- [x] Documentation has been updated (if applicable)