### PR TITLE
feat: toggle password visibility in devtui install wizard

### DIFF
--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -94,13 +94,14 @@ var (
 )
 
 type installWizard struct {
-	step       installStep
-	cursor     int
-	confirmYes bool
-	language   string
-	currency   string
-	username   textinput.Model
-	password   textinput.Model
+	step            installStep
+	cursor          int
+	confirmYes      bool
+	language        string
+	currency        string
+	username        textinput.Model
+	password        textinput.Model
+	checkboxFocused bool
 }
 
 type Options struct {

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -78,6 +78,7 @@ func (m Model) updateLifecycle(msg tea.Msg) (tea.Model, tea.Cmd) {
 		passwordInput.Placeholder = "shopware"
 		passwordInput.Prompt = "Password: "
 		passwordInput.CharLimit = 50
+		passwordInput.EchoMode = textinput.EchoPassword
 
 		m.install = installWizard{step: installStepAsk, confirmYes: true, username: usernameInput, password: passwordInput}
 		return m, nil
@@ -415,88 +416,133 @@ func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	switch m.install.step {
 	case installStepAsk:
-		switch msg.String() {
-		case keyLeft, "h":
-			m.install.confirmYes = true
-		case keyRight, "l":
-			m.install.confirmYes = false
-		case keyTab:
-			m.install.confirmYes = !m.install.confirmYes
-		case keyEnter:
-			if m.install.confirmYes {
-				m.install.step = installStepLanguage
-				m.install.cursor = 0
-			} else {
-				m.overlay = overlayNone
-				return m, m.startDashboard()
-			}
-		}
-
+		return m.updateInstallStepAsk(msg)
 	case installStepLanguage:
-		switch msg.String() {
-		case keyUp, keyK:
-			if m.install.cursor > 0 {
-				m.install.cursor--
-			}
-		case keyDown, keyJ:
-			if m.install.cursor < len(installLanguages)-1 {
-				m.install.cursor++
-			}
-		case keyEnter:
-			m.install.language = installLanguages[m.install.cursor].id
-			m.install.step = installStepCurrency
-			m.install.cursor = 0
-		}
-
+		return m.updateInstallStepLanguage(msg)
 	case installStepCurrency:
-		switch msg.String() {
-		case keyUp, keyK:
-			if m.install.cursor > 0 {
-				m.install.cursor--
-			}
-		case keyDown, keyJ:
-			if m.install.cursor < len(installCurrencies)-1 {
-				m.install.cursor++
-			}
-		case keyEnter:
-			m.install.currency = installCurrencies[m.install.cursor]
-			m.install.step = installStepUsername
-			m.install.username.SetValue(defaultUsername)
-			m.install.username.Focus()
-			return m, textinput.Blink
-		}
-
+		return m.updateInstallStepCurrency(msg)
 	case installStepUsername:
-		switch msg.String() {
-		case keyEnter:
-			m.install.step = installStepPassword
-			m.install.username.Blur()
-			m.install.password.SetValue("shopware")
-			m.install.password.Focus()
-			return m, textinput.Blink
-		default:
-			var cmd tea.Cmd
-			m.install.username, cmd = m.install.username.Update(msg)
-			return m, cmd
-		}
-
+		return m.updateInstallStepUsername(msg)
 	case installStepPassword:
-		switch msg.String() {
-		case keyEnter:
-			m.install.password.Blur()
-			m.overlay = overlayInstalling
-			m.overlayLines = nil
-			m.installProg = installProgress{
-				spinner:  newBrandSpinner(),
-				progress: newInstallProgress(),
-			}
-			return m, tea.Batch(m.installProg.spinner.Tick, m.runShopwareInstall())
-		default:
-			var cmd tea.Cmd
-			m.install.password, cmd = m.install.password.Update(msg)
-			return m, cmd
-		}
+		return m.updateInstallStepPassword(msg)
 	}
 
 	return m, nil
+}
+
+func (m Model) updateInstallStepAsk(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyLeft, "h":
+		m.install.confirmYes = true
+	case keyRight, "l":
+		m.install.confirmYes = false
+	case keyTab:
+		m.install.confirmYes = !m.install.confirmYes
+	case keyEnter:
+		if m.install.confirmYes {
+			m.install.step = installStepLanguage
+			m.install.cursor = 0
+			return m, nil
+		}
+		m.overlay = overlayNone
+		return m, m.startDashboard()
+	}
+	return m, nil
+}
+
+func (m Model) updateInstallStepLanguage(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyUp, keyK:
+		if m.install.cursor > 0 {
+			m.install.cursor--
+		}
+	case keyDown, keyJ:
+		if m.install.cursor < len(installLanguages)-1 {
+			m.install.cursor++
+		}
+	case keyEnter:
+		m.install.language = installLanguages[m.install.cursor].id
+		m.install.step = installStepCurrency
+		m.install.cursor = 0
+	}
+	return m, nil
+}
+
+func (m Model) updateInstallStepCurrency(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyUp, keyK:
+		if m.install.cursor > 0 {
+			m.install.cursor--
+		}
+	case keyDown, keyJ:
+		if m.install.cursor < len(installCurrencies)-1 {
+			m.install.cursor++
+		}
+	case keyEnter:
+		m.install.currency = installCurrencies[m.install.cursor]
+		m.install.step = installStepUsername
+		m.install.username.SetValue(defaultUsername)
+		m.install.username.Focus()
+		return m, textinput.Blink
+	}
+	return m, nil
+}
+
+func (m Model) updateInstallStepUsername(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == keyEnter {
+		m.install.step = installStepPassword
+		m.install.username.Blur()
+		m.install.password.SetValue("shopware")
+		m.install.password.Focus()
+		m.install.checkboxFocused = false
+		return m, textinput.Blink
+	}
+	var cmd tea.Cmd
+	m.install.username, cmd = m.install.username.Update(msg)
+	return m, cmd
+}
+
+func (m Model) updateInstallStepPassword(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyEnter:
+		return m.handleInstallPasswordEnter()
+	case keyTab, keyDown:
+		if !m.install.checkboxFocused {
+			m.install.checkboxFocused = true
+			m.install.password.Blur()
+		}
+		return m, nil
+	case keyShiftTab, keyUp:
+		if m.install.checkboxFocused {
+			m.install.checkboxFocused = false
+			m.install.password.Focus()
+			return m, textinput.Blink
+		}
+		return m, nil
+	}
+	if m.install.checkboxFocused {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.install.password, cmd = m.install.password.Update(msg)
+	return m, cmd
+}
+
+func (m Model) handleInstallPasswordEnter() (tea.Model, tea.Cmd) {
+	if m.install.checkboxFocused {
+		if m.install.password.EchoMode == textinput.EchoPassword {
+			m.install.password.EchoMode = textinput.EchoNormal
+		} else {
+			m.install.password.EchoMode = textinput.EchoPassword
+		}
+		return m, nil
+	}
+	m.install.password.Blur()
+	m.overlay = overlayInstalling
+	m.overlayLines = nil
+	m.installProg = installProgress{
+		spinner:  newBrandSpinner(),
+		progress: newInstallProgress(),
+	}
+	return m, tea.Batch(m.installProg.spinner.Tick, m.runShopwareInstall())
 }

--- a/internal/devtui/model_view.go
+++ b/internal/devtui/model_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -296,9 +297,11 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 		b.WriteString("\n\n")
 		b.WriteString(tui.TitleStyle.Render("Admin Password"))
 		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter the password for the admin account"))
+		b.WriteString(tui.DimStyle.Render("Enter the password for the admin account (default: shopware)"))
 		b.WriteString("\n\n")
 		b.WriteString(m.install.password.View())
+		b.WriteString("\n\n")
+		b.WriteString(renderShowPasswordCheckbox(m.install.password.EchoMode == textinput.EchoNormal, m.install.checkboxFocused))
 	}
 }
 
@@ -319,7 +322,14 @@ func (m Model) installFooterHint() string {
 			tui.Shortcut{Key: "enter", Label: "Continue"},
 		)
 	case installStepPassword:
+		if m.install.checkboxFocused {
+			return tui.ShortcutBar(
+				tui.Shortcut{Key: "↑", Label: "Back"},
+				tui.Shortcut{Key: "enter", Label: "Toggle"},
+			)
+		}
 		return tui.ShortcutBar(
+			tui.Shortcut{Key: "↓/tab", Label: "Show password"},
 			tui.Shortcut{Key: "enter", Label: "Install"},
 		)
 	}

--- a/internal/devtui/styles.go
+++ b/internal/devtui/styles.go
@@ -81,6 +81,18 @@ var (
 				Padding(0, 2)
 )
 
+func renderShowPasswordCheckbox(checked, focused bool) string {
+	box := "[ ]"
+	if checked {
+		box = "[x]"
+	}
+	style := lipgloss.NewStyle().Foreground(tui.MutedColor)
+	if focused {
+		style = lipgloss.NewStyle().Foreground(tui.BrandColor).Bold(true)
+	}
+	return style.Render(box + " Show password")
+}
+
 func renderConfirmButtons(yesLabel, noLabel string, yesActive bool) string {
 	var yes, no string
 	if yesActive {


### PR DESCRIPTION
## Summary
- Mask the admin password field by default on the final step of the devtui installation wizard.
- Add a `Show password` checkbox below the input; arrow down / tab focuses it, enter toggles visibility, arrow up / shift+tab returns focus to the input.
- Footer shortcut bar adapts to whichever element is focused.

## Test plan
- [ ] Run the devtui against a fresh project and step through the install wizard until the password screen.
- [ ] Confirm the password input renders masked by default.
- [ ] Press ↓ / Tab to focus the checkbox, press Enter, verify the password becomes visible and the box renders as `[x]`.
- [ ] Press Enter again to re-mask, then ↑ / Shift+Tab to return to the input and confirm typing still works.
- [ ] With the input focused, press Enter and verify the install starts as before.