### PR TITLE
test: isolate php-wasm cache and stub linter in extension tests

### DIFF
--- a/internal/extension/platform.go
+++ b/internal/extension/platform.go
@@ -396,8 +396,12 @@ func (p PlatformPlugin) Validate(c context.Context, check validation.Check) {
 	validateExtensionIcon(p, check)
 
 	validateTheme(p, check)
-	validatePHPFiles(c, p, check)
+	validatePHPFilesFn(c, p, check)
 }
+
+// validatePHPFilesFn can be overridden in tests to skip PHP file validation,
+// which would otherwise require network access to download the PHP wasm binary.
+var validatePHPFilesFn = validatePHPFiles
 
 func validatePHPFiles(c context.Context, ext Extension, check validation.Check) {
 	constraint, err := ext.GetShopwareVersionConstraint()

--- a/internal/extension/platform_test.go
+++ b/internal/extension/platform_test.go
@@ -1,17 +1,21 @@
 package extension
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/shopware/shopware-cli/internal/validation"
 	"github.com/stretchr/testify/assert"
 )
 
 func setupMockPHPVersionServer(t *testing.T) {
 	t.Helper()
+	t.Setenv("SHOPWARE_CLI_CACHE_DIR", t.TempDir())
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"6.4.0.0": "7.4", "6.5.0.0": "8.1", "6.6.0.0": "8.2"}`))
@@ -22,6 +26,12 @@ func setupMockPHPVersionServer(t *testing.T) {
 	phpVersionURL = server.URL
 	t.Cleanup(func() {
 		phpVersionURL = original
+	})
+
+	originalValidate := validatePHPFilesFn
+	validatePHPFilesFn = func(_ context.Context, _ Extension, _ validation.Check) {}
+	t.Cleanup(func() {
+		validatePHPFilesFn = originalValidate
 	})
 }
 

--- a/internal/extension/platform_test.go
+++ b/internal/extension/platform_test.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/shopware/shopware-cli/internal/validation"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/validation"
 )
 
 func setupMockPHPVersionServer(t *testing.T) {

--- a/internal/phplint/download_test.go
+++ b/internal/phplint/download_test.go
@@ -12,6 +12,8 @@ func TestDownloadPHPFile(t *testing.T) {
 		t.Skip("Downloading does not work in Nix build")
 	}
 
+	t.Setenv("SHOPWARE_CLI_CACHE_DIR", t.TempDir())
+
 	_, err := findPHPWasmFile(t.Context(), "7.4")
 	assert.NoError(t, err)
 }

--- a/internal/phplint/lint_test.go
+++ b/internal/phplint/lint_test.go
@@ -12,6 +12,8 @@ func TestLintTestData(t *testing.T) {
 		t.Skip("Downloading does not work in Nix build")
 	}
 
+	t.Setenv("SHOPWARE_CLI_CACHE_DIR", t.TempDir())
+
 	supportedPHPVersions := []string{"7.3", "7.4", "8.1", "8.2", "8.3"}
 
 	for _, version := range supportedPHPVersions {


### PR DESCRIPTION
## Summary
- Tests that exercise the PHP linter silently passed under `sandbox-no-network.sb` because the wasm binary was already cached in `~/Library/Caches/shopware-cli`. Override `SHOPWARE_CLI_CACHE_DIR` to `t.TempDir()` in each affected test so the download path is actually exercised.
- Extract a `validatePHPFilesFn` hook in `internal/extension/platform.go` so `setupMockPHPVersionServer` can stub PHP file validation entirely — `Validate` tests no longer get an extra network-error result polluting their assertions.

## Test plan
- [x] `go test ./internal/extension/` passes.
- [x] `go test ./internal/phplint/` passes (downloads wasm fresh, ~15s).
- [x] `sandbox-exec -f sandbox-no-network.sb go test ./internal/phplint/` now fails as expected, proving the sandbox catches network regressions.