### PR TITLE
feat(devtui): modal value picker and overlay restructure

### DIFF
--- a/internal/devtui/install_wizard.go
+++ b/internal/devtui/install_wizard.go
@@ -1,0 +1,297 @@
+package devtui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/progress"
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+type installStep int
+
+const (
+	installStepAsk installStep = iota
+	installStepLanguage
+	installStepCurrency
+	installStepUsername
+	installStepPassword
+)
+
+type installLanguage struct {
+	id    string
+	label string
+}
+
+var (
+	installLanguages = []installLanguage{
+		{"en-GB", "English (UK)"},
+		{"en-US", "English (US)"},
+		{"de-DE", "Deutsch"},
+		{"cs-CZ", "Čeština"},
+		{"da-DK", "Dansk"},
+		{"es-ES", "Español"},
+		{"fr-FR", "Français"},
+		{"it-IT", "Italiano"},
+		{"nl-NL", "Nederlands"},
+		{"nn-NO", "Norsk"},
+		{"pl-PL", "Język polski"},
+		{"pt-PT", "Português"},
+		{"sv-SE", "Svenska"},
+	}
+	installCurrencies = []string{"EUR", "USD", "GBP", "PLN", "CHF", "SEK", "DKK", "NOK", "CZK"}
+)
+
+type installWizard struct {
+	step            installStep
+	cursor          int
+	confirmYes      bool
+	language        string
+	currency        string
+	username        textinput.Model
+	password        textinput.Model
+	checkboxFocused bool
+}
+
+type installProgress struct {
+	currentStep int
+	done        bool
+	showLogs    bool
+	spinner     spinner.Model
+	progress    progress.Model
+}
+
+var installStepPatterns = []struct {
+	pattern string
+	label   string
+}{
+	{"system:install", "Installing Shopware"},
+	{"user:create", "Creating admin account"},
+	{"messenger:setup-transports", "Setting up message transports"},
+	{"sales-channel:create:storefront", "Creating storefront"},
+	{"theme:change", "Compiling theme"},
+	{"plugin:refresh", "Refreshing plugins"},
+}
+
+func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if k := msg.String(); k == keyQ || k == keyCtrlC {
+		return m, tea.Quit
+	}
+
+	switch m.install.step {
+	case installStepAsk:
+		return m.updateInstallStepAsk(msg)
+	case installStepLanguage:
+		return m.updateInstallStepLanguage(msg)
+	case installStepCurrency:
+		return m.updateInstallStepCurrency(msg)
+	case installStepUsername:
+		return m.updateInstallStepUsername(msg)
+	case installStepPassword:
+		return m.updateInstallStepPassword(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) updateInstallStepAsk(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyLeft, "h":
+		m.install.confirmYes = true
+	case keyRight, "l":
+		m.install.confirmYes = false
+	case keyTab:
+		m.install.confirmYes = !m.install.confirmYes
+	case keyEnter:
+		if m.install.confirmYes {
+			m.install.step = installStepLanguage
+			m.install.cursor = 0
+			return m, nil
+		}
+		m.phase = phaseDashboard
+		return m, m.startDashboard()
+	}
+	return m, nil
+}
+
+func (m Model) updateInstallStepLanguage(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyUp, keyK:
+		if m.install.cursor > 0 {
+			m.install.cursor--
+		}
+	case keyDown, keyJ:
+		if m.install.cursor < len(installLanguages)-1 {
+			m.install.cursor++
+		}
+	case keyEnter:
+		m.install.language = installLanguages[m.install.cursor].id
+		m.install.step = installStepCurrency
+		m.install.cursor = 0
+	}
+	return m, nil
+}
+
+func (m Model) updateInstallStepCurrency(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyUp, keyK:
+		if m.install.cursor > 0 {
+			m.install.cursor--
+		}
+	case keyDown, keyJ:
+		if m.install.cursor < len(installCurrencies)-1 {
+			m.install.cursor++
+		}
+	case keyEnter:
+		m.install.currency = installCurrencies[m.install.cursor]
+		m.install.step = installStepUsername
+		m.install.username.SetValue(defaultUsername)
+		m.install.username.Focus()
+		return m, textinput.Blink
+	}
+	return m, nil
+}
+
+func (m Model) updateInstallStepUsername(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == keyEnter {
+		m.install.step = installStepPassword
+		m.install.username.Blur()
+		m.install.password.SetValue("shopware")
+		m.install.password.Focus()
+		m.install.checkboxFocused = false
+		return m, textinput.Blink
+	}
+	var cmd tea.Cmd
+	m.install.username, cmd = m.install.username.Update(msg)
+	return m, cmd
+}
+
+func (m Model) updateInstallStepPassword(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case keyEnter:
+		return m.handleInstallPasswordEnter()
+	case keyTab, keyDown:
+		if !m.install.checkboxFocused {
+			m.install.checkboxFocused = true
+			m.install.password.Blur()
+		}
+		return m, nil
+	case keyShiftTab, keyUp:
+		if m.install.checkboxFocused {
+			m.install.checkboxFocused = false
+			m.install.password.Focus()
+			return m, textinput.Blink
+		}
+		return m, nil
+	}
+	if m.install.checkboxFocused {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.install.password, cmd = m.install.password.Update(msg)
+	return m, cmd
+}
+
+func (m Model) handleInstallPasswordEnter() (tea.Model, tea.Cmd) {
+	if m.install.checkboxFocused {
+		if m.install.password.EchoMode == textinput.EchoPassword {
+			m.install.password.EchoMode = textinput.EchoNormal
+		} else {
+			m.install.password.EchoMode = textinput.EchoPassword
+		}
+		return m, nil
+	}
+	m.install.password.Blur()
+	m.phase = phaseInstalling
+	m.overlayLines = nil
+	m.installProg = installProgress{
+		spinner:  newBrandSpinner(),
+		progress: newInstallProgress(),
+	}
+	return m, tea.Batch(m.installProg.spinner.Tick, m.runShopwareInstall())
+}
+
+func (m Model) renderInstallPrompt(b *strings.Builder) {
+	switch m.install.step {
+	case installStepAsk:
+		warnStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ErrorColor)
+		b.WriteString(warnStyle.Render("Shopware is not installed"))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("This project has not been set up yet. The installation\nwill create the database, run migrations and configure\nyour local development environment."))
+		b.WriteString("\n\n")
+		b.WriteString(renderConfirmButtons("Yes, install now", "No, skip", m.install.confirmYes))
+
+	case installStepLanguage:
+		b.WriteString(tui.TextBadge("Step 1/4"))
+		b.WriteString("\n\n")
+		opts := make([]tui.SelectOption, len(installLanguages))
+		for i, lang := range installLanguages {
+			opts[i] = tui.SelectOption{Label: lang.label, Detail: lang.id}
+		}
+		b.WriteString(tui.RenderSelectList("Default Language", "Select the primary language for your storefront", opts, m.install.cursor))
+
+	case installStepCurrency:
+		b.WriteString(tui.TextBadge("Step 2/4"))
+		b.WriteString("\n\n")
+		opts := make([]tui.SelectOption, len(installCurrencies))
+		for i, curr := range installCurrencies {
+			opts[i] = tui.SelectOption{Label: curr}
+		}
+		b.WriteString(tui.RenderSelectList("Default Currency", "Select the default currency for pricing", opts, m.install.cursor))
+
+	case installStepUsername:
+		b.WriteString(tui.TextBadge("Step 3/4"))
+		b.WriteString("\n\n")
+		b.WriteString(tui.TitleStyle.Render("Admin Username"))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("Enter the username for the admin account"))
+		b.WriteString("\n\n")
+		b.WriteString(m.install.username.View())
+
+	case installStepPassword:
+		b.WriteString(tui.TextBadge("Step 4/4"))
+		b.WriteString("\n\n")
+		b.WriteString(tui.TitleStyle.Render("Admin Password"))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("Enter the password for the admin account (default: shopware)"))
+		b.WriteString("\n\n")
+		b.WriteString(m.install.password.View())
+		b.WriteString("\n\n")
+		b.WriteString(renderShowPasswordCheckbox(m.install.password.EchoMode == textinput.EchoNormal, m.install.checkboxFocused))
+	}
+}
+
+func (m Model) installFooterHint() string {
+	switch m.install.step {
+	case installStepAsk:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "←/→", Label: "Select"},
+			tui.Shortcut{Key: "enter", Label: "Confirm"},
+		)
+	case installStepLanguage, installStepCurrency:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "↑/↓", Label: "Select"},
+			tui.Shortcut{Key: "enter", Label: "Confirm"},
+		)
+	case installStepUsername:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "enter", Label: "Continue"},
+		)
+	case installStepPassword:
+		if m.install.checkboxFocused {
+			return tui.ShortcutBar(
+				tui.Shortcut{Key: "↑", Label: "Back"},
+				tui.Shortcut{Key: "enter", Label: "Toggle"},
+			)
+		}
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "↓/tab", Label: "Show password"},
+			tui.Shortcut{Key: "enter", Label: "Install"},
+		)
+	}
+	return ""
+}

--- a/internal/devtui/keys.go
+++ b/internal/devtui/keys.go
@@ -1,0 +1,19 @@
+package devtui
+
+const (
+	keyCtrlC    = "ctrl+c"
+	keyDown     = "down"
+	keyEnter    = "enter"
+	keyUp       = "up"
+	keyTab      = "tab"
+	keyShiftTab = "shift+tab"
+	keyQ        = "q"
+	keyF        = "f"
+	keyJ        = "j"
+	keyK        = "k"
+	key1        = "1"
+	key2        = "2"
+	key3        = "3"
+	keyLeft     = "left"
+	keyRight    = "right"
+)

--- a/internal/devtui/lifecycle.go
+++ b/internal/devtui/lifecycle.go
@@ -1,0 +1,119 @@
+package devtui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+// updateLifecycle handles async messages from the boot state machine: Docker
+// container start/stop, Shopware install detection, install completion. The
+// state machine drives m.phase forward; user input during a phase is handled
+// by phase-specific key handlers in updateKeyPress.
+func (m Model) updateLifecycle(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case dockerAlreadyRunningMsg:
+		m.phase = phaseDashboard
+		return m, m.checkShopwareInstalled()
+
+	case dockerNeedStartMsg:
+		m.phase = phaseStarting
+		m.overlayLines = nil
+		m.dockerShowLogs = false
+		m.dockerSpinner = newBrandSpinner()
+		return m, tea.Batch(m.dockerSpinner.Tick, m.startContainers())
+
+	case dockerOutputLineMsg:
+		m.overlayLines = append(m.overlayLines, string(msg))
+		maxLines := m.overlayMaxLines()
+		if len(m.overlayLines) > maxLines {
+			m.overlayLines = m.overlayLines[len(m.overlayLines)-maxLines:]
+		}
+		if m.phase == phaseInstalling {
+			line := string(msg)
+			if strings.HasPrefix(line, "Start: ") {
+				for i, sp := range installStepPatterns {
+					if strings.Contains(line, sp.pattern) && i >= m.installProg.currentStep {
+						m.installProg.currentStep = i
+						pct := float64(i) / float64(len(installStepPatterns))
+						cmd := m.installProg.progress.SetPercent(pct)
+						return m, tea.Batch(cmd, m.readNextDockerOutput())
+					}
+				}
+			}
+		}
+		return m, m.readNextDockerOutput()
+
+	case dockerOutputDoneMsg:
+		return m, nil
+
+	case dockerStartedMsg:
+		if msg.err != nil {
+			m.overlayLines = append(m.overlayLines, errorStyle.Render("Failed: "+msg.err.Error()))
+			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Press q to exit"))
+			return m, nil
+		}
+		m.phase = phaseDashboard
+		m.overlayLines = nil
+		m.dockerOutChan = nil
+		return m, m.checkShopwareInstalled()
+
+	case shopwareInstalledMsg:
+		m.phase = phaseDashboard
+		return m, m.startDashboard()
+
+	case shopwareNotInstalledMsg:
+		m.phase = phaseInstallPrompt
+		m.overlayLines = nil
+
+		usernameInput := textinput.New()
+		usernameInput.Placeholder = defaultUsername
+		usernameInput.Prompt = "Username: "
+		usernameInput.CharLimit = 50
+
+		passwordInput := textinput.New()
+		passwordInput.Placeholder = "shopware"
+		passwordInput.Prompt = "Password: "
+		passwordInput.CharLimit = 50
+		passwordInput.EchoMode = textinput.EchoPassword
+
+		m.install = installWizard{step: installStepAsk, confirmYes: true, username: usernameInput, password: passwordInput}
+		return m, nil
+
+	case shopwareInstallDoneMsg:
+		if msg.err != nil {
+			m.installProg.showLogs = true
+			m.overlayLines = append(m.overlayLines, "", errorStyle.Render("Installation failed: "+msg.err.Error()))
+			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Press q to exit"))
+			return m, nil
+		}
+		m.installProg.done = true
+		m.installProg.currentStep = len(installStepPatterns)
+
+		username := m.install.username.Value()
+		password := m.install.password.Value()
+
+		adminApi := &shop.ConfigAdminApi{
+			Username: username,
+			Password: password,
+		}
+		m.envConfig.AdminApi = adminApi
+		_ = shop.WriteConfig(m.config, m.projectRoot)
+
+		m.general.username = username
+		m.general.password = password
+
+		m.phase = phaseDashboard
+		m.overlayLines = nil
+		m.dockerOutChan = nil
+		return m, m.startDashboard()
+
+	case dockerStoppedMsg:
+		return m, tea.Quit
+	}
+
+	return m, nil
+}

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -6,7 +6,6 @@ import (
 
 	"charm.land/bubbles/v2/progress"
 	"charm.land/bubbles/v2/spinner"
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/shopware/shopware-cli/internal/executor"
@@ -24,111 +23,32 @@ const (
 var tabNames = []string{"General", "Logs", "Config"}
 
 const (
-	keyCtrlC    = "ctrl+c"
-	keyDown     = "down"
-	keyEnter    = "enter"
-	keyUp       = "up"
-	keyTab      = "tab"
-	keyShiftTab = "shift+tab"
-	keyQ        = "q"
-	keyF        = "f"
-	keyJ        = "j"
-	keyK        = "k"
-	key1        = "1"
-	key2        = "2"
-	key3        = "3"
-	keyLeft     = "left"
-	keyRight    = "right"
-
 	defaultUsername = "admin"
 
 	watcherAdmin      = "Admin Watcher"
 	watcherStorefront = "Storefront Watcher"
 )
 
-type overlay int
+// phase identifies the lifecycle phase of the dashboard. A phase fills the
+// whole screen and transitions via async messages (Docker start/stop,
+// install). Modals (commandPalette, valuePicker, stopConfirm) float above
+// phaseDashboard and are tracked separately on Model.modal.
+type phase int
 
 const (
-	overlayNone overlay = iota
-	overlayStarting
-	overlayStopConfirm
-	overlayStopping
-	overlayInstallPrompt
-	overlayInstalling
-	overlayCommandPalette
-	overlayTask
+	phaseDashboard phase = iota
+	phaseStarting
+	phaseStopping
+	phaseInstallPrompt
+	phaseInstalling
+	phaseTask
 )
-
-type installStep int
-
-const (
-	installStepAsk installStep = iota
-	installStepLanguage
-	installStepCurrency
-	installStepUsername
-	installStepPassword
-)
-
-type installLanguage struct {
-	id    string
-	label string
-}
-
-var (
-	installLanguages = []installLanguage{
-		{"en-GB", "English (UK)"},
-		{"en-US", "English (US)"},
-		{"de-DE", "Deutsch"},
-		{"cs-CZ", "Čeština"},
-		{"da-DK", "Dansk"},
-		{"es-ES", "Español"},
-		{"fr-FR", "Français"},
-		{"it-IT", "Italiano"},
-		{"nl-NL", "Nederlands"},
-		{"nn-NO", "Norsk"},
-		{"pl-PL", "Język polski"},
-		{"pt-PT", "Português"},
-		{"sv-SE", "Svenska"},
-	}
-	installCurrencies = []string{"EUR", "USD", "GBP", "PLN", "CHF", "SEK", "DKK", "NOK", "CZK"}
-)
-
-type installWizard struct {
-	step            installStep
-	cursor          int
-	confirmYes      bool
-	language        string
-	currency        string
-	username        textinput.Model
-	password        textinput.Model
-	checkboxFocused bool
-}
 
 type Options struct {
 	ProjectRoot string
 	Config      *shop.Config
 	EnvConfig   *shop.EnvironmentConfig
 	Executor    executor.Executor
-}
-
-type installProgress struct {
-	currentStep int
-	done        bool
-	showLogs    bool
-	spinner     spinner.Model
-	progress    progress.Model
-}
-
-var installStepPatterns = []struct {
-	pattern string
-	label   string
-}{
-	{"system:install", "Installing Shopware"},
-	{"user:create", "Creating admin account"},
-	{"messenger:setup-transports", "Setting up message transports"},
-	{"sales-channel:create:storefront", "Creating storefront"},
-	{"theme:change", "Compiling theme"},
-	{"plugin:refresh", "Refreshing plugins"},
 }
 
 type Model struct {
@@ -139,23 +59,22 @@ type Model struct {
 	width          int
 	height         int
 	dockerMode     bool
-	overlay        overlay
+	phase          phase
+	modal          Modal // floating overlay above the dashboard; nil when none
 	overlayLines   []string
 	projectRoot    string
 	executor       executor.Executor
 	dockerOutChan  <-chan string
 	install        installWizard
 	installProg    installProgress
-	stopConfirmYes bool
 	dockerSpinner  spinner.Model
 	dockerShowLogs bool
-	palette        commandPalette
 	config         *shop.Config
 	envConfig      *shop.EnvironmentConfig
 	taskTitle      string
 	taskDone       bool
 	taskErr        error
-	watchers       map[string]*executor.Process // running watcher processes keyed by name
+	watchers       map[string]*executor.Process
 }
 
 type dockerAlreadyRunningMsg struct{}
@@ -291,11 +210,38 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		delete(m.watchers, name)
 		return m.updateChildren(msg)
 
+	case paletteResultMsg:
+		m.modal = nil
+		if msg.ID == "" {
+			return m, nil
+		}
+		return m.executeCommand(msg.ID)
+
+	case valuePickerResultMsg:
+		m.modal = nil
+		if msg.Cancelled {
+			return m, nil
+		}
+		m.configTab.ApplyPickerValue(msg.Field, msg.Value)
+		return m, nil
+
+	case stopConfirmResultMsg:
+		m.modal = nil
+		m.shutdown()
+		if msg.Stop {
+			m.phase = phaseStopping
+			m.overlayLines = nil
+			m.dockerShowLogs = false
+			m.dockerSpinner = newBrandSpinner()
+			return m, tea.Batch(m.dockerSpinner.Tick, m.stopContainers())
+		}
+		return m, tea.Quit
+
 	case tea.KeyPressMsg:
 		return m.updateKeyPress(msg)
 	}
 
-	if m.overlay == overlayInstalling {
+	if m.phase == phaseInstalling {
 		switch msg := msg.(type) {
 		case spinner.TickMsg:
 			var cmd tea.Cmd
@@ -309,7 +255,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.overlay == overlayStarting || m.overlay == overlayStopping {
+	if m.phase == phaseStarting || m.phase == phaseStopping {
 		if msg, ok := msg.(spinner.TickMsg); ok {
 			var cmd tea.Cmd
 			m.dockerSpinner, cmd = m.dockerSpinner.Update(msg)
@@ -318,7 +264,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.overlay != overlayNone {
+	if m.phase != phaseDashboard {
 		return m, nil
 	}
 

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -2,9 +2,6 @@ package devtui
 
 import (
 	"context"
-	"os"
-	"os/exec"
-	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/textinput"
@@ -13,143 +10,18 @@ import (
 	"github.com/shopware/shopware-cli/internal/shop"
 )
 
-func (m Model) updateLifecycle(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case dockerAlreadyRunningMsg:
-		m.overlay = overlayNone
-		return m, m.checkShopwareInstalled()
-
-	case dockerNeedStartMsg:
-		m.overlay = overlayStarting
-		m.overlayLines = nil
-		m.dockerShowLogs = false
-		m.dockerSpinner = newBrandSpinner()
-		return m, tea.Batch(m.dockerSpinner.Tick, m.startContainers())
-
-	case dockerOutputLineMsg:
-		m.overlayLines = append(m.overlayLines, string(msg))
-		maxLines := m.overlayMaxLines()
-		if len(m.overlayLines) > maxLines {
-			m.overlayLines = m.overlayLines[len(m.overlayLines)-maxLines:]
-		}
-		if m.overlay == overlayInstalling {
-			line := string(msg)
-			if strings.HasPrefix(line, "Start: ") {
-				for i, sp := range installStepPatterns {
-					if strings.Contains(line, sp.pattern) && i >= m.installProg.currentStep {
-						m.installProg.currentStep = i
-						pct := float64(i) / float64(len(installStepPatterns))
-						cmd := m.installProg.progress.SetPercent(pct)
-						return m, tea.Batch(cmd, m.readNextDockerOutput())
-					}
-				}
-			}
-		}
-		return m, m.readNextDockerOutput()
-
-	case dockerOutputDoneMsg:
-		return m, nil
-
-	case dockerStartedMsg:
-		if msg.err != nil {
-			m.overlayLines = append(m.overlayLines, errorStyle.Render("Failed: "+msg.err.Error()))
-			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Press q to exit"))
-			return m, nil
-		}
-		m.overlay = overlayNone
-		m.overlayLines = nil
-		m.dockerOutChan = nil
-		return m, m.checkShopwareInstalled()
-
-	case shopwareInstalledMsg:
-		m.overlay = overlayNone
-		return m, m.startDashboard()
-
-	case shopwareNotInstalledMsg:
-		m.overlay = overlayInstallPrompt
-		m.overlayLines = nil
-
-		usernameInput := textinput.New()
-		usernameInput.Placeholder = defaultUsername
-		usernameInput.Prompt = "Username: "
-		usernameInput.CharLimit = 50
-
-		passwordInput := textinput.New()
-		passwordInput.Placeholder = "shopware"
-		passwordInput.Prompt = "Password: "
-		passwordInput.CharLimit = 50
-		passwordInput.EchoMode = textinput.EchoPassword
-
-		m.install = installWizard{step: installStepAsk, confirmYes: true, username: usernameInput, password: passwordInput}
-		return m, nil
-
-	case shopwareInstallDoneMsg:
-		if msg.err != nil {
-			m.installProg.showLogs = true
-			m.overlayLines = append(m.overlayLines, "", errorStyle.Render("Installation failed: "+msg.err.Error()))
-			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Press q to exit"))
-			return m, nil
-		}
-		m.installProg.done = true
-		m.installProg.currentStep = len(installStepPatterns)
-
-		username := m.install.username.Value()
-		password := m.install.password.Value()
-
-		adminApi := &shop.ConfigAdminApi{
-			Username: username,
-			Password: password,
-		}
-		m.envConfig.AdminApi = adminApi
-		_ = shop.WriteConfig(m.config, m.projectRoot)
-
-		m.general.username = username
-		m.general.password = password
-
-		m.overlay = overlayNone
-		m.overlayLines = nil
-		m.dockerOutChan = nil
-		return m, m.startDashboard()
-
-	case dockerStoppedMsg:
-		return m, tea.Quit
-	}
-
-	return m, nil
-}
-
 func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if m.overlay == overlayCommandPalette {
-		return m.updateCommandPalette(msg)
+	if m.modal != nil {
+		next, cmd := m.modal.Update(msg)
+		m.modal = next
+		return m, cmd
 	}
 
-	if m.overlay == overlayInstallPrompt {
+	if m.phase == phaseInstallPrompt {
 		return m.updateInstallPrompt(msg)
 	}
 
-	if m.overlay == overlayStopConfirm {
-		switch msg.String() {
-		case keyLeft, "h":
-			m.stopConfirmYes = true
-		case keyRight, "l":
-			m.stopConfirmYes = false
-		case keyTab:
-			m.stopConfirmYes = !m.stopConfirmYes
-		case keyEnter:
-			m.shutdown()
-			if m.stopConfirmYes {
-				m.overlay = overlayStopping
-				m.overlayLines = nil
-				m.dockerShowLogs = false
-				m.dockerSpinner = newBrandSpinner()
-				return m, tea.Batch(m.dockerSpinner.Tick, m.stopContainers())
-			}
-			return m, tea.Quit
-		}
-		return m, nil
-	}
-
-	if m.overlay == overlayStarting || m.overlay == overlayStopping {
+	if m.phase == phaseStarting || m.phase == phaseStopping {
 		switch msg.String() {
 		case "l":
 			m.dockerShowLogs = !m.dockerShowLogs
@@ -159,7 +31,7 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.overlay == overlayInstalling {
+	if m.phase == phaseInstalling {
 		switch msg.String() {
 		case "l":
 			m.installProg.showLogs = !m.installProg.showLogs
@@ -169,9 +41,9 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.overlay == overlayTask {
+	if m.phase == phaseTask {
 		if m.taskDone {
-			m.overlay = overlayNone
+			m.phase = phaseDashboard
 			m.overlayLines = nil
 			m.taskDone = false
 			m.taskErr = nil
@@ -183,33 +55,17 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.overlay != overlayNone {
-		if msg.String() == keyQ || msg.String() == keyCtrlC {
-			return m, tea.Quit
-		}
-		return m, nil
-	}
-
-	// When the config tab is actively editing a text input, route all keys
-	// to it so typed characters are not intercepted by global shortcuts.
-	if m.activeTab == tabConfig && m.configTab.editing {
-		return m.updateConfigTab(msg)
-	}
-
 	return m.updateDashboardKeys(msg)
 }
 
 func (m Model) updateDashboardKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+p":
-		m.overlay = overlayCommandPalette
-		m.palette = newCommandPalette()
+		m.modal = newCommandPalette()
 		return m, textinput.Blink
 	case keyCtrlC, keyQ:
 		if m.dockerMode {
-			m.overlay = overlayStopConfirm
-			m.overlayLines = nil
-			m.stopConfirmYes = true
+			m.modal = newStopConfirm()
 			return m, nil
 		}
 		m.shutdown()
@@ -239,43 +95,24 @@ func (m Model) updateDashboardKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateConfigTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == keyEnter {
+		if m.configTab.cursor == fieldSave && m.configTab.modified {
+			m.configTab.ApplyToConfig(m.config)
+			_ = shop.WriteConfig(m.config, m.projectRoot)
+			if localCfg := m.configTab.LocalConfig(); localCfg != nil {
+				_ = shop.WriteLocalConfig(localCfg, m.projectRoot)
+			}
+			return m, func() tea.Msg { return configSavedMsg{} }
+		}
+		if picker := m.configTab.PickerForCursor(); picker != nil {
+			m.modal = picker
+			return m, textinput.Blink
+		}
+		return m, nil
+	}
+
 	newConfig, cmd := m.configTab.HandleKey(msg)
 	m.configTab = newConfig
-
-	if m.configTab.cursor == fieldSave && msg.String() == keyEnter && m.configTab.modified {
-		m.configTab.ApplyToConfig(m.config)
-		_ = shop.WriteConfig(m.config, m.projectRoot)
-		// Write credentials to .shopware-project.local.yml so they stay
-		// out of version control.
-		if localCfg := m.configTab.LocalConfig(); localCfg != nil {
-			_ = shop.WriteLocalConfig(localCfg, m.projectRoot)
-		}
-		return m, func() tea.Msg { return configSavedMsg{} }
-	}
-
-	return m, cmd
-}
-
-func (m Model) updateCommandPalette(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc", "ctrl+p":
-		m.overlay = overlayNone
-		return m, nil
-	case keyUp, keyK:
-		m.palette.moveUp()
-		return m, nil
-	case keyDown, keyJ:
-		m.palette.moveDown()
-		return m, nil
-	case keyEnter:
-		id := m.palette.selectedID()
-		m.overlay = overlayNone
-		return m.executeCommand(id)
-	}
-
-	var cmd tea.Cmd
-	m.palette.filter, cmd = m.palette.filter.Update(msg)
-	m.palette.applyFilter()
 	return m, cmd
 }
 
@@ -319,8 +156,7 @@ func (m Model) executeCommand(id string) (tea.Model, tea.Cmd) {
 		m.activeTab = tabConfig
 	case "quit":
 		if m.dockerMode {
-			m.overlay = overlayStopConfirm
-			m.stopConfirmYes = true
+			m.modal = newStopConfirm()
 			return m, nil
 		}
 		m.shutdown()
@@ -346,203 +182,4 @@ func (m *Model) stopWatcher(name string) tea.Cmd {
 
 		return watcherStoppedMsg{name: name}
 	}
-}
-
-func (m *Model) runTask(title string, taskFn func() (*exec.Cmd, error)) tea.Cmd {
-	m.overlay = overlayTask
-	m.taskTitle = title
-	m.taskDone = false
-	m.taskErr = nil
-	m.overlayLines = nil
-
-	ch := make(chan string, streamBufferSize)
-	m.dockerOutChan = ch
-
-	doneCmd := func() tea.Msg {
-		cmd, err := taskFn()
-		if err != nil {
-			close(ch)
-			return taskDoneMsg{err: err}
-		}
-
-		err = streamCmdOutput(cmd, ch, true)
-		return taskDoneMsg{err: err}
-	}
-
-	return tea.Batch(readFromChan(ch), doneCmd)
-}
-
-func (m *Model) runAdminBuild() tea.Cmd {
-	return m.runSelfCommand("Building Administration...", "project", "admin-build")
-}
-
-func (m *Model) runStorefrontBuild() tea.Cmd {
-	return m.runSelfCommand("Building Storefront...", "project", "storefront-build")
-}
-
-func (m *Model) runSelfCommand(title string, args ...string) tea.Cmd {
-	projectRoot := m.projectRoot
-	dockerMode := m.dockerMode
-
-	return m.runTask(title, func() (*exec.Cmd, error) {
-		selfBin, err := os.Executable()
-		if err != nil {
-			return nil, err
-		}
-
-		cmd := exec.CommandContext(context.Background(), selfBin, append(args, projectRoot)...)
-		if dockerMode {
-			cmd.Dir = projectRoot
-		}
-
-		return cmd, nil
-	})
-}
-
-func (m *Model) runCacheClear() tea.Cmd {
-	e := m.executor
-	return func() tea.Msg {
-		cmd := e.ConsoleCommand(context.Background(), "cache:clear")
-		_ = cmd.Run()
-		return nil
-	}
-}
-
-func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case keyQ, keyCtrlC:
-		return m, tea.Quit
-	}
-
-	switch m.install.step {
-	case installStepAsk:
-		return m.updateInstallStepAsk(msg)
-	case installStepLanguage:
-		return m.updateInstallStepLanguage(msg)
-	case installStepCurrency:
-		return m.updateInstallStepCurrency(msg)
-	case installStepUsername:
-		return m.updateInstallStepUsername(msg)
-	case installStepPassword:
-		return m.updateInstallStepPassword(msg)
-	}
-
-	return m, nil
-}
-
-func (m Model) updateInstallStepAsk(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case keyLeft, "h":
-		m.install.confirmYes = true
-	case keyRight, "l":
-		m.install.confirmYes = false
-	case keyTab:
-		m.install.confirmYes = !m.install.confirmYes
-	case keyEnter:
-		if m.install.confirmYes {
-			m.install.step = installStepLanguage
-			m.install.cursor = 0
-			return m, nil
-		}
-		m.overlay = overlayNone
-		return m, m.startDashboard()
-	}
-	return m, nil
-}
-
-func (m Model) updateInstallStepLanguage(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case keyUp, keyK:
-		if m.install.cursor > 0 {
-			m.install.cursor--
-		}
-	case keyDown, keyJ:
-		if m.install.cursor < len(installLanguages)-1 {
-			m.install.cursor++
-		}
-	case keyEnter:
-		m.install.language = installLanguages[m.install.cursor].id
-		m.install.step = installStepCurrency
-		m.install.cursor = 0
-	}
-	return m, nil
-}
-
-func (m Model) updateInstallStepCurrency(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case keyUp, keyK:
-		if m.install.cursor > 0 {
-			m.install.cursor--
-		}
-	case keyDown, keyJ:
-		if m.install.cursor < len(installCurrencies)-1 {
-			m.install.cursor++
-		}
-	case keyEnter:
-		m.install.currency = installCurrencies[m.install.cursor]
-		m.install.step = installStepUsername
-		m.install.username.SetValue(defaultUsername)
-		m.install.username.Focus()
-		return m, textinput.Blink
-	}
-	return m, nil
-}
-
-func (m Model) updateInstallStepUsername(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == keyEnter {
-		m.install.step = installStepPassword
-		m.install.username.Blur()
-		m.install.password.SetValue("shopware")
-		m.install.password.Focus()
-		m.install.checkboxFocused = false
-		return m, textinput.Blink
-	}
-	var cmd tea.Cmd
-	m.install.username, cmd = m.install.username.Update(msg)
-	return m, cmd
-}
-
-func (m Model) updateInstallStepPassword(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case keyEnter:
-		return m.handleInstallPasswordEnter()
-	case keyTab, keyDown:
-		if !m.install.checkboxFocused {
-			m.install.checkboxFocused = true
-			m.install.password.Blur()
-		}
-		return m, nil
-	case keyShiftTab, keyUp:
-		if m.install.checkboxFocused {
-			m.install.checkboxFocused = false
-			m.install.password.Focus()
-			return m, textinput.Blink
-		}
-		return m, nil
-	}
-	if m.install.checkboxFocused {
-		return m, nil
-	}
-	var cmd tea.Cmd
-	m.install.password, cmd = m.install.password.Update(msg)
-	return m, cmd
-}
-
-func (m Model) handleInstallPasswordEnter() (tea.Model, tea.Cmd) {
-	if m.install.checkboxFocused {
-		if m.install.password.EchoMode == textinput.EchoPassword {
-			m.install.password.EchoMode = textinput.EchoNormal
-		} else {
-			m.install.password.EchoMode = textinput.EchoPassword
-		}
-		return m, nil
-	}
-	m.install.password.Blur()
-	m.overlay = overlayInstalling
-	m.overlayLines = nil
-	m.installProg = installProgress{
-		spinner:  newBrandSpinner(),
-		progress: newInstallProgress(),
-	}
-	return m, tea.Batch(m.installProg.spinner.Tick, m.runShopwareInstall())
 }

--- a/internal/devtui/model_view.go
+++ b/internal/devtui/model_view.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -19,15 +18,17 @@ func (m Model) View() tea.View {
 	v := tea.NewView("")
 	v.AltScreen = true
 
-	switch m.overlay {
-	case overlayNone:
+	switch m.phase {
+	case phaseDashboard:
 		v.Content = m.renderDashboard()
-	case overlayCommandPalette:
-		v.Content = m.palette.view(m.width, m.height)
-	case overlayStarting, overlayStopConfirm, overlayStopping, overlayInstallPrompt, overlayInstalling:
-		v.Content = m.renderOverlay()
-	case overlayTask:
+	case phaseStarting, phaseStopping, phaseInstallPrompt, phaseInstalling:
+		v.Content = m.renderPhase()
+	case phaseTask:
 		v.Content = m.renderDockerLogs(m.taskTitle, "")
+	}
+
+	if m.modal != nil {
+		v.Content = m.modal.View(m.width, m.height)
 	}
 
 	return v
@@ -88,7 +89,6 @@ func (m Model) renderDashboardFooter() string {
 	if m.activeTab == tabConfig {
 		shortcuts := []tui.Shortcut{
 			{Key: "↑/↓", Label: "Navigate"},
-			{Key: "←/→", Label: "Change value"},
 			{Key: "enter", Label: "Edit/Save"},
 			{Key: "tab", Label: "Next tab"},
 			{Key: "ctrl+c", Label: "Exit"},
@@ -103,44 +103,31 @@ func (m Model) renderDashboardFooter() string {
 	)
 }
 
-func (m Model) renderOverlay() string {
+func (m Model) renderPhase() string {
 	var content strings.Builder
 	var footerHint string
 
-	switch m.overlay {
-	case overlayStarting:
+	switch m.phase {
+	case phaseStarting:
 		footerHint = tui.ShortcutBadge("l", "Toggle logs")
 		if m.dockerShowLogs {
 			return m.renderDockerLogs("Starting Docker containers...", footerHint)
 		}
 		cardContent := fmt.Sprintf("%s Starting Docker containers...", m.dockerSpinner.View())
 		content.WriteString(tui.RenderPhaseCard(cardContent))
-	case overlayStopConfirm:
-		var card strings.Builder
-		warnStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ErrorColor)
-		card.WriteString(warnStyle.Render("Stop Docker containers?"))
-		card.WriteString("\n")
-		card.WriteString(tui.DimStyle.Render("Do you want to stop the running Docker containers?\nThey can be restarted with shopware-cli project dev."))
-		card.WriteString("\n\n")
-		card.WriteString(renderConfirmButtons("Yes, stop", "No, quit", m.stopConfirmYes))
-		content.WriteString(tui.RenderPhaseCard(card.String()))
-		footerHint = tui.ShortcutBar(
-			tui.Shortcut{Key: "←/→", Label: "Select"},
-			tui.Shortcut{Key: "enter", Label: "Confirm"},
-		)
-	case overlayStopping:
+	case phaseStopping:
 		footerHint = tui.ShortcutBadge("l", "Toggle logs")
 		if m.dockerShowLogs {
 			return m.renderDockerLogs("Stopping Docker containers...", footerHint)
 		}
 		cardContent := fmt.Sprintf("%s Stopping Docker containers...", m.dockerSpinner.View())
 		content.WriteString(tui.RenderPhaseCard(cardContent))
-	case overlayInstallPrompt:
+	case phaseInstallPrompt:
 		var card strings.Builder
 		m.renderInstallPrompt(&card)
 		content.WriteString(tui.RenderPhaseCard(card.String()))
 		footerHint = m.installFooterHint()
-	case overlayInstalling:
+	case phaseInstalling:
 		if m.installProg.showLogs {
 			footerHint = tui.ShortcutBadge("l", "Toggle logs")
 			return m.renderDockerLogs("Installing Shopware...", footerHint)
@@ -164,7 +151,7 @@ func (m Model) renderOverlay() string {
 		}
 		content.WriteString(tui.RenderPhaseCard(strings.TrimRight(card.String(), "\n")))
 		footerHint = tui.ShortcutBadge("l", "Toggle logs")
-	case overlayNone, overlayCommandPalette, overlayTask:
+	case phaseDashboard, phaseTask:
 	}
 
 	return renderPhaseLayout(content.String(), m.width, m.height, footerHint)
@@ -253,85 +240,4 @@ func (m Model) overlayMaxLines() int {
 		return 10
 	}
 	return maxLines
-}
-
-func (m Model) renderInstallPrompt(b *strings.Builder) {
-	switch m.install.step {
-	case installStepAsk:
-		warnStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ErrorColor)
-		b.WriteString(warnStyle.Render("Shopware is not installed"))
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("This project has not been set up yet. The installation\nwill create the database, run migrations and configure\nyour local development environment."))
-		b.WriteString("\n\n")
-		b.WriteString(renderConfirmButtons("Yes, install now", "No, skip", m.install.confirmYes))
-
-	case installStepLanguage:
-		b.WriteString(tui.TextBadge("Step 1/4"))
-		b.WriteString("\n\n")
-		opts := make([]tui.SelectOption, len(installLanguages))
-		for i, lang := range installLanguages {
-			opts[i] = tui.SelectOption{Label: lang.label, Detail: lang.id}
-		}
-		b.WriteString(tui.RenderSelectList("Default Language", "Select the primary language for your storefront", opts, m.install.cursor))
-
-	case installStepCurrency:
-		b.WriteString(tui.TextBadge("Step 2/4"))
-		b.WriteString("\n\n")
-		opts := make([]tui.SelectOption, len(installCurrencies))
-		for i, curr := range installCurrencies {
-			opts[i] = tui.SelectOption{Label: curr}
-		}
-		b.WriteString(tui.RenderSelectList("Default Currency", "Select the default currency for pricing", opts, m.install.cursor))
-
-	case installStepUsername:
-		b.WriteString(tui.TextBadge("Step 3/4"))
-		b.WriteString("\n\n")
-		b.WriteString(tui.TitleStyle.Render("Admin Username"))
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter the username for the admin account"))
-		b.WriteString("\n\n")
-		b.WriteString(m.install.username.View())
-
-	case installStepPassword:
-		b.WriteString(tui.TextBadge("Step 4/4"))
-		b.WriteString("\n\n")
-		b.WriteString(tui.TitleStyle.Render("Admin Password"))
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter the password for the admin account (default: shopware)"))
-		b.WriteString("\n\n")
-		b.WriteString(m.install.password.View())
-		b.WriteString("\n\n")
-		b.WriteString(renderShowPasswordCheckbox(m.install.password.EchoMode == textinput.EchoNormal, m.install.checkboxFocused))
-	}
-}
-
-func (m Model) installFooterHint() string {
-	switch m.install.step {
-	case installStepAsk:
-		return tui.ShortcutBar(
-			tui.Shortcut{Key: "←/→", Label: "Select"},
-			tui.Shortcut{Key: "enter", Label: "Confirm"},
-		)
-	case installStepLanguage, installStepCurrency:
-		return tui.ShortcutBar(
-			tui.Shortcut{Key: "↑/↓", Label: "Select"},
-			tui.Shortcut{Key: "enter", Label: "Confirm"},
-		)
-	case installStepUsername:
-		return tui.ShortcutBar(
-			tui.Shortcut{Key: "enter", Label: "Continue"},
-		)
-	case installStepPassword:
-		if m.install.checkboxFocused {
-			return tui.ShortcutBar(
-				tui.Shortcut{Key: "↑", Label: "Back"},
-				tui.Shortcut{Key: "enter", Label: "Toggle"},
-			)
-		}
-		return tui.ShortcutBar(
-			tui.Shortcut{Key: "↓/tab", Label: "Show password"},
-			tui.Shortcut{Key: "enter", Label: "Install"},
-		)
-	}
-	return ""
 }

--- a/internal/devtui/overlay.go
+++ b/internal/devtui/overlay.go
@@ -1,0 +1,14 @@
+package devtui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+// Modal is a dismissable overlay floating above the dashboard. It owns its own
+// state, key handling, and rendering. Returning a nil Modal from Update
+// dismisses it. The optional resultCmd is run after dismissal — typically used
+// to apply a confirmation result back to the parent Model.
+type Modal interface {
+	Update(msg tea.Msg) (next Modal, cmd tea.Cmd)
+	View(width, height int) string
+}

--- a/internal/devtui/overlay_palette.go
+++ b/internal/devtui/overlay_palette.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/shopware/shopware-cli/internal/tui"
@@ -31,22 +32,24 @@ var paletteCommands = []paletteCommand{
 	{Label: "Quit", Shortcut: "ctrl+c", ID: "quit"},
 }
 
+// paletteResultMsg is emitted when the user picks a command. ID is empty if
+// the palette was cancelled.
+type paletteResultMsg struct{ ID string }
+
 type commandPalette struct {
 	filter   textinput.Model
 	cursor   int
 	filtered []int // indices into paletteCommands
 }
 
-func newCommandPalette() commandPalette {
+func newCommandPalette() *commandPalette {
 	ti := textinput.New()
 	ti.Prompt = lipgloss.NewStyle().Foreground(tui.BrandColor).Render("> ")
 	ti.Placeholder = "Type to filter"
 	ti.CharLimit = 64
 	ti.Focus()
 
-	cp := commandPalette{
-		filter: ti,
-	}
+	cp := &commandPalette{filter: ti}
 	cp.applyFilter()
 	return cp
 }
@@ -64,35 +67,49 @@ func (cp *commandPalette) applyFilter() {
 	}
 }
 
-func (cp *commandPalette) moveUp() {
-	if cp.cursor > 0 {
-		cp.cursor--
-	}
-}
-
-func (cp *commandPalette) moveDown() {
-	if cp.cursor < len(cp.filtered)-1 {
-		cp.cursor++
-	}
-}
-
-func (cp commandPalette) selectedID() string {
+func (cp *commandPalette) selectedID() string {
 	if len(cp.filtered) == 0 {
 		return ""
 	}
 	return paletteCommands[cp.filtered[cp.cursor]].ID
 }
 
-func (cp commandPalette) view(width, height int) string {
+func (cp *commandPalette) Update(msg tea.Msg) (Modal, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return cp, nil
+	}
+
+	switch key.String() {
+	case "esc", "ctrl+p":
+		return nil, emit(paletteResultMsg{})
+	case keyUp, keyK:
+		if cp.cursor > 0 {
+			cp.cursor--
+		}
+		return cp, nil
+	case keyDown, keyJ:
+		if cp.cursor < len(cp.filtered)-1 {
+			cp.cursor++
+		}
+		return cp, nil
+	case keyEnter:
+		return nil, emit(paletteResultMsg{ID: cp.selectedID()})
+	}
+
+	var cmd tea.Cmd
+	cp.filter, cmd = cp.filter.Update(msg)
+	cp.applyFilter()
+	return cp, cmd
+}
+
+func (cp *commandPalette) View(width, height int) string {
 	paletteWidth := min(width-4, 70)
 	innerWidth := paletteWidth - 6 // border(2) + padding(4)
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(tui.BrandColor)
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.BrandColor)
 
 	var b strings.Builder
-
 	b.WriteString(titleStyle.Render("Commands"))
 	b.WriteString("\n\n")
 	b.WriteString(cp.filter.View())
@@ -103,14 +120,10 @@ func (cp commandPalette) view(width, height int) string {
 		Background(tui.SelectedBgColor).
 		Bold(true).
 		Width(innerWidth)
-
 	normalStyle := lipgloss.NewStyle().
 		Foreground(tui.TextColor).
 		Width(innerWidth)
-
-	shortcutStyle := lipgloss.NewStyle().
-		Foreground(tui.MutedColor)
-
+	shortcutStyle := lipgloss.NewStyle().Foreground(tui.MutedColor)
 	selectedShortcutStyle := lipgloss.NewStyle().
 		Foreground(tui.MutedColor).
 		Background(tui.SelectedBgColor)
@@ -121,7 +134,6 @@ func (cp commandPalette) view(width, height int) string {
 		if i == cp.cursor {
 			rowStyle, scStyle = selectedStyle, selectedShortcutStyle
 		}
-
 		if cmd.Shortcut != "" {
 			sc := scStyle.Render(cmd.Shortcut)
 			gap := max(innerWidth-lipgloss.Width(cmd.Label)-lipgloss.Width(cmd.Shortcut), 1)
@@ -131,7 +143,6 @@ func (cp commandPalette) view(width, height int) string {
 		}
 		b.WriteString("\n")
 	}
-
 	if len(cp.filtered) == 0 {
 		b.WriteString(lipgloss.NewStyle().Foreground(tui.MutedColor).Render("No matching commands"))
 		b.WriteString("\n")
@@ -144,19 +155,21 @@ func (cp commandPalette) view(width, height int) string {
 		tui.Shortcut{Key: "esc", Label: "Cancel"},
 	))
 
+	return centeredModal(b.String(), paletteWidth, width, height)
+}
+
+// emit returns a tea.Cmd that yields msg.
+func emit(msg tea.Msg) tea.Cmd {
+	return func() tea.Msg { return msg }
+}
+
+// centeredModal wraps content in the standard rounded brand-colored box and
+// centers it within (width, height).
+func centeredModal(content string, modalWidth, width, height int) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(tui.BrandColor).
 		Padding(1, 2).
-		Width(paletteWidth)
-
-	modal := box.Render(b.String())
-
-	return lipgloss.Place(
-		width,
-		height,
-		lipgloss.Center,
-		lipgloss.Center,
-		modal,
-	)
+		Width(modalWidth)
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box.Render(content))
 }

--- a/internal/devtui/overlay_picker.go
+++ b/internal/devtui/overlay_picker.go
@@ -1,0 +1,177 @@
+package devtui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+type valuePickerKind int
+
+const (
+	valuePickerList valuePickerKind = iota
+	valuePickerText
+)
+
+// valuePickerResultMsg is emitted when the picker is dismissed. Cancelled is
+// true if Esc was pressed; otherwise Field/Value carry the chosen value.
+type valuePickerResultMsg struct {
+	Cancelled bool
+	Field     configField
+	Value     string
+}
+
+// valuePicker is a modal that edits a single config field. It renders either
+// a selectable list of options or a text input, depending on kind.
+type valuePicker struct {
+	kind   valuePickerKind
+	field  configField
+	title  string
+	help   string
+	secret bool
+
+	options []string // list mode
+	labels  []string // optional pretty labels; falls back to options
+	cursor  int
+
+	input textinput.Model // text mode
+}
+
+func newListPicker(field configField, title string, options []string, labels []string, current int) *valuePicker {
+	return &valuePicker{
+		kind:    valuePickerList,
+		field:   field,
+		title:   title,
+		options: options,
+		labels:  labels,
+		cursor:  current,
+	}
+}
+
+func newTextPicker(field configField, title, help, value string, secret bool) *valuePicker {
+	ti := textinput.New()
+	ti.Placeholder = title
+	ti.CharLimit = 128
+	ti.Prompt = lipgloss.NewStyle().Foreground(tui.BrandColor).Render("> ")
+	if value != "" {
+		ti.SetValue(value)
+	}
+	ti.Focus()
+	return &valuePicker{
+		kind:   valuePickerText,
+		field:  field,
+		title:  title,
+		help:   help,
+		secret: secret,
+		input:  ti,
+	}
+}
+
+func (vp *valuePicker) selectedValue() string {
+	if vp.kind == valuePickerText {
+		return vp.input.Value()
+	}
+	if len(vp.options) == 0 {
+		return ""
+	}
+	return vp.options[vp.cursor]
+}
+
+func (vp *valuePicker) optionLabel(i int) string {
+	if i < len(vp.labels) && vp.labels[i] != "" {
+		return vp.labels[i]
+	}
+	if i < len(vp.options) {
+		return vp.options[i]
+	}
+	return ""
+}
+
+func (vp *valuePicker) Update(msg tea.Msg) (Modal, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return vp, nil
+	}
+
+	switch key.String() {
+	case "esc":
+		return nil, emit(valuePickerResultMsg{Cancelled: true, Field: vp.field})
+	case keyEnter:
+		return nil, emit(valuePickerResultMsg{Field: vp.field, Value: vp.selectedValue()})
+	}
+
+	if vp.kind == valuePickerList {
+		switch key.String() {
+		case keyUp, keyK:
+			if vp.cursor > 0 {
+				vp.cursor--
+			}
+		case keyDown, keyJ:
+			if vp.cursor < len(vp.options)-1 {
+				vp.cursor++
+			}
+		}
+		return vp, nil
+	}
+
+	var cmd tea.Cmd
+	vp.input, cmd = vp.input.Update(msg)
+	return vp, cmd
+}
+
+func (vp *valuePicker) View(width, height int) string {
+	modalWidth := min(width-4, 70)
+	innerWidth := modalWidth - 6
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.BrandColor)
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(vp.title))
+	b.WriteString("\n\n")
+	if vp.help != "" {
+		b.WriteString(helpStyle.Render(vp.help))
+		b.WriteString("\n\n")
+	}
+
+	switch vp.kind {
+	case valuePickerList:
+		selectedStyle := lipgloss.NewStyle().
+			Foreground(tui.BrandColor).
+			Background(tui.SelectedBgColor).
+			Bold(true).
+			Width(innerWidth)
+		normalStyle := lipgloss.NewStyle().
+			Foreground(tui.TextColor).
+			Width(innerWidth)
+
+		for i := range vp.options {
+			label := vp.optionLabel(i)
+			if i == vp.cursor {
+				b.WriteString(selectedStyle.Render(label))
+			} else {
+				b.WriteString(normalStyle.Render(label))
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString(tui.ShortcutBar(
+			tui.Shortcut{Key: "↑/↓", Label: "Choose"},
+			tui.Shortcut{Key: "enter", Label: "Confirm"},
+			tui.Shortcut{Key: "esc", Label: "Cancel"},
+		))
+
+	case valuePickerText:
+		b.WriteString(vp.input.View())
+		b.WriteString("\n\n")
+		b.WriteString(tui.ShortcutBar(
+			tui.Shortcut{Key: "enter", Label: "Confirm"},
+			tui.Shortcut{Key: "esc", Label: "Cancel"},
+		))
+	}
+
+	return centeredModal(b.String(), modalWidth, width, height)
+}

--- a/internal/devtui/overlay_stop_confirm.go
+++ b/internal/devtui/overlay_stop_confirm.go
@@ -1,0 +1,61 @@
+package devtui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+// stopConfirmResultMsg is emitted when the user resolves the stop-confirm
+// dialog. Stop is true if the user chose to stop containers; if Cancelled is
+// true the dialog was dismissed without action (currently unused — Esc is
+// not bound).
+type stopConfirmResultMsg struct {
+	Stop bool
+}
+
+type stopConfirm struct {
+	yes bool
+}
+
+func newStopConfirm() *stopConfirm {
+	return &stopConfirm{yes: true}
+}
+
+func (sc *stopConfirm) Update(msg tea.Msg) (Modal, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return sc, nil
+	}
+
+	switch key.String() {
+	case keyLeft, "h":
+		sc.yes = true
+	case keyRight, "l":
+		sc.yes = false
+	case keyTab:
+		sc.yes = !sc.yes
+	case keyEnter:
+		return nil, emit(stopConfirmResultMsg{Stop: sc.yes})
+	}
+	return sc, nil
+}
+
+func (sc *stopConfirm) View(width, height int) string {
+	var card strings.Builder
+	warnStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ErrorColor)
+	card.WriteString(warnStyle.Render("Stop Docker containers?"))
+	card.WriteString("\n")
+	card.WriteString(tui.DimStyle.Render("Do you want to stop the running Docker containers?\nThey can be restarted with shopware-cli project dev."))
+	card.WriteString("\n\n")
+	card.WriteString(renderConfirmButtons("Yes, stop", "No, quit", sc.yes))
+
+	footerHint := tui.ShortcutBar(
+		tui.Shortcut{Key: "←/→", Label: "Select"},
+		tui.Shortcut{Key: "enter", Label: "Confirm"},
+	)
+	return renderPhaseLayout(tui.RenderPhaseCard(card.String()), width, height, footerHint)
+}

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -50,7 +50,6 @@ type ConfigModel struct {
 	blackfireServerToken textinput.Model
 	tidewaysAPIKey       textinput.Model
 
-	editing  bool // true when a text input is focused
 	saved    bool // flash a "saved" indicator
 	modified bool // config has unsaved changes
 
@@ -127,44 +126,91 @@ func (m ConfigModel) Update(msg tea.Msg) (ConfigModel, tea.Cmd) {
 }
 
 func (m ConfigModel) HandleKey(msg tea.KeyPressMsg) (ConfigModel, tea.Cmd) {
-	key := msg.String()
-
-	// When editing a text field, route keys to the active input.
-	if m.editing {
-		switch key {
-		case keyEnter, "esc":
-			m.blurAll()
-			m.editing = false
-			return m, nil
-		default:
-			var cmd tea.Cmd
-			switch m.cursor { //nolint:exhaustive
-			case fieldBlackfireServerID:
-				m.blackfireServerID, cmd = m.blackfireServerID.Update(msg)
-			case fieldBlackfireServerToken:
-				m.blackfireServerToken, cmd = m.blackfireServerToken.Update(msg)
-			case fieldTidewaysAPIKey:
-				m.tidewaysAPIKey, cmd = m.tidewaysAPIKey.Update(msg)
-			}
-			m.modified = true
-			return m, cmd
-		}
-	}
-
-	switch key {
+	switch msg.String() {
 	case keyUp, keyK:
 		m.moveCursorUp()
 	case keyDown, keyJ:
 		m.moveCursorDown()
-	case keyEnter, " ":
-		return m.activateField()
-	case keyLeft, "h":
-		m.cyclePrev()
-	case keyRight, "l":
-		m.cycleNext()
 	}
 
 	return m, nil
+}
+
+// PickerForCursor returns a Modal that edits the field under the cursor, or
+// nil if the cursor is not on an editable field.
+func (m ConfigModel) PickerForCursor() Modal {
+	switch m.cursor { //nolint:exhaustive
+	case fieldPHPVersion:
+		return newListPicker(fieldPHPVersion, "PHP Version", phpVersions, nil, m.phpVersion)
+	case fieldNodeVersion:
+		return newListPicker(fieldNodeVersion, "Node.js Version", nodeVersions, nil, m.nodeVersion)
+	case fieldProfiler:
+		labels := make([]string, len(profilers))
+		for i, p := range profilers {
+			if p == "" {
+				labels[i] = "none"
+			} else {
+				labels[i] = p
+			}
+		}
+		return newListPicker(fieldProfiler, "PHP Profiler", profilers, labels, m.profiler)
+	case fieldBlackfireServerID:
+		return newTextPicker(fieldBlackfireServerID, "Blackfire Server ID", "Server ID for the Blackfire profiler", m.blackfireServerID.Value(), true)
+	case fieldBlackfireServerToken:
+		return newTextPicker(fieldBlackfireServerToken, "Blackfire Server Token", "Server token for the Blackfire profiler", m.blackfireServerToken.Value(), true)
+	case fieldTidewaysAPIKey:
+		return newTextPicker(fieldTidewaysAPIKey, "Tideways API Key", "API key for Tideways", m.tidewaysAPIKey.Value(), true)
+	}
+	return nil
+}
+
+// ApplyPickerValue stores the chosen value for the field. Returns true if the
+// value changed.
+func (m *ConfigModel) ApplyPickerValue(field configField, value string) bool {
+	changed := false
+	switch field { //nolint:exhaustive
+	case fieldPHPVersion:
+		idx := indexOf(phpVersions, value, m.phpVersion)
+		if idx != m.phpVersion {
+			m.phpVersion = idx
+			changed = true
+		}
+	case fieldNodeVersion:
+		idx := indexOf(nodeVersions, value, m.nodeVersion)
+		if idx != m.nodeVersion {
+			m.nodeVersion = idx
+			changed = true
+		}
+	case fieldProfiler:
+		idx := indexOf(profilers, value, m.profiler)
+		if idx != m.profiler {
+			m.profiler = idx
+			changed = true
+			if !m.isFieldVisible(m.cursor) {
+				m.moveCursorDown()
+			}
+		}
+	case fieldBlackfireServerID:
+		if m.blackfireServerID.Value() != value {
+			m.blackfireServerID.SetValue(value)
+			changed = true
+		}
+	case fieldBlackfireServerToken:
+		if m.blackfireServerToken.Value() != value {
+			m.blackfireServerToken.SetValue(value)
+			changed = true
+		}
+	case fieldTidewaysAPIKey:
+		if m.tidewaysAPIKey.Value() != value {
+			m.tidewaysAPIKey.SetValue(value)
+			changed = true
+		}
+	}
+	if changed {
+		m.modified = true
+		m.saved = false
+	}
+	return changed
 }
 
 func (m *ConfigModel) moveCursorUp() {
@@ -202,76 +248,6 @@ func (m ConfigModel) isFieldVisible(f configField) bool {
 		return true
 	}
 	return true
-}
-
-func (m *ConfigModel) activateField() (ConfigModel, tea.Cmd) {
-	switch m.cursor {
-	case fieldPHPVersion:
-		m.phpVersion = (m.phpVersion + 1) % len(phpVersions)
-		m.modified = true
-	case fieldNodeVersion:
-		m.nodeVersion = (m.nodeVersion + 1) % len(nodeVersions)
-		m.modified = true
-	case fieldProfiler:
-		m.profiler = (m.profiler + 1) % len(profilers)
-		m.modified = true
-		// Re-validate cursor position after profiler change.
-		if !m.isFieldVisible(m.cursor) {
-			m.moveCursorDown()
-		}
-	case fieldBlackfireServerID:
-		m.editing = true
-		m.blackfireServerID.Focus()
-		return *m, textinput.Blink
-	case fieldBlackfireServerToken:
-		m.editing = true
-		m.blackfireServerToken.Focus()
-		return *m, textinput.Blink
-	case fieldTidewaysAPIKey:
-		m.editing = true
-		m.tidewaysAPIKey.Focus()
-		return *m, textinput.Blink
-	case fieldSave, fieldCount:
-		// Save is handled by the parent model; fieldCount is a sentinel.
-		return *m, nil
-	}
-	return *m, nil
-}
-
-func (m *ConfigModel) cyclePrev() {
-	m.saved = false
-	switch m.cursor { //nolint:exhaustive
-	case fieldPHPVersion:
-		m.phpVersion = (m.phpVersion - 1 + len(phpVersions)) % len(phpVersions)
-		m.modified = true
-	case fieldNodeVersion:
-		m.nodeVersion = (m.nodeVersion - 1 + len(nodeVersions)) % len(nodeVersions)
-		m.modified = true
-	case fieldProfiler:
-		m.profiler = (m.profiler - 1 + len(profilers)) % len(profilers)
-		m.modified = true
-	}
-}
-
-func (m *ConfigModel) cycleNext() {
-	m.saved = false
-	switch m.cursor { //nolint:exhaustive
-	case fieldPHPVersion:
-		m.phpVersion = (m.phpVersion + 1) % len(phpVersions)
-		m.modified = true
-	case fieldNodeVersion:
-		m.nodeVersion = (m.nodeVersion + 1) % len(nodeVersions)
-		m.modified = true
-	case fieldProfiler:
-		m.profiler = (m.profiler + 1) % len(profilers)
-		m.modified = true
-	}
-}
-
-func (m *ConfigModel) blurAll() {
-	m.blackfireServerID.Blur()
-	m.blackfireServerToken.Blur()
-	m.tidewaysAPIKey.Blur()
 }
 
 // ApplyToConfig writes the non-sensitive form values into the given Config.
@@ -399,22 +375,13 @@ func (m ConfigModel) renderSelect(field configField, label, value, selectedArrow
 		valStyle = lipgloss.NewStyle().Foreground(tui.BrandColor).Bold(true)
 	}
 
-	arrows := ""
-	if m.cursor == field {
-		arrows = helpStyle.Render(" ◂ ▸")
-	}
-
-	return prefix + configKeyStyle.Render(label) + valStyle.Render(value) + arrows + "\n"
+	return prefix + configKeyStyle.Render(label) + valStyle.Render(value) + "\n"
 }
 
 func (m ConfigModel) renderInput(field configField, label string, input textinput.Model, selectedArrow, normalIndent string) string {
 	prefix := normalIndent
 	if m.cursor == field {
 		prefix = selectedArrow
-	}
-
-	if m.cursor == field && m.editing {
-		return prefix + configKeyStyle.Render(label) + input.View() + "\n"
 	}
 
 	val := input.Value()

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -14,7 +14,6 @@ func TestNewConfigModel_NilConfig(t *testing.T) {
 	assert.Equal(t, 1, m.phpVersion)  // default 8.3 (index 1)
 	assert.Equal(t, 0, m.nodeVersion) // default 22 (index 0)
 	assert.Equal(t, 0, m.profiler)    // default none (index 0)
-	assert.False(t, m.editing)
 	assert.False(t, m.saved)
 	assert.False(t, m.modified)
 }
@@ -148,17 +147,54 @@ func TestConfigModel_CursorNavigation(t *testing.T) {
 	assert.Equal(t, fieldProfiler, m.cursor, "should skip hidden fields going up")
 }
 
-func TestConfigModel_CycleValues(t *testing.T) {
+func TestConfigModel_PickerForCursor_Select(t *testing.T) {
 	m := NewConfigModel(nil)
+	m.cursor = fieldPHPVersion
 
-	initial := m.phpVersion
-	m.cycleNext()
-	assert.NotEqual(t, initial, m.phpVersion)
+	modal := m.PickerForCursor()
+	picker, ok := modal.(*valuePicker)
+	assert.True(t, ok)
+	assert.Equal(t, valuePickerList, picker.kind)
+	assert.Equal(t, fieldPHPVersion, picker.field)
+	assert.ElementsMatch(t, phpVersions, picker.options)
+}
+
+func TestConfigModel_PickerForCursor_Text(t *testing.T) {
+	m := NewConfigModel(nil)
+	m.profiler = indexOf(profilers, "blackfire", 0)
+	m.blackfireServerID.SetValue("existing")
+	m.cursor = fieldBlackfireServerID
+
+	modal := m.PickerForCursor()
+	picker, ok := modal.(*valuePicker)
+	assert.True(t, ok)
+	assert.Equal(t, valuePickerText, picker.kind)
+	assert.Equal(t, "existing", picker.input.Value())
+}
+
+func TestConfigModel_ApplyPickerValue(t *testing.T) {
+	m := NewConfigModel(nil)
+	m.modified = false
+
+	changed := m.ApplyPickerValue(fieldPHPVersion, "8.4")
+	assert.True(t, changed)
+	assert.Equal(t, indexOf(phpVersions, "8.4", -1), m.phpVersion)
 	assert.True(t, m.modified)
 
+	// Same value again — no change.
 	m.modified = false
-	m.cursor = fieldNodeVersion
-	m.cycleNext()
+	changed = m.ApplyPickerValue(fieldPHPVersion, "8.4")
+	assert.False(t, changed)
+	assert.False(t, m.modified)
+}
+
+func TestConfigModel_ApplyPickerValue_TextField(t *testing.T) {
+	m := NewConfigModel(nil)
+	m.profiler = indexOf(profilers, "tideways", 0)
+
+	changed := m.ApplyPickerValue(fieldTidewaysAPIKey, "secret-key")
+	assert.True(t, changed)
+	assert.Equal(t, "secret-key", m.tidewaysAPIKey.Value())
 	assert.True(t, m.modified)
 }
 

--- a/internal/devtui/task_runner.go
+++ b/internal/devtui/task_runner.go
@@ -1,0 +1,66 @@
+package devtui
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func (m *Model) runTask(title string, taskFn func() (*exec.Cmd, error)) tea.Cmd {
+	m.phase = phaseTask
+	m.taskTitle = title
+	m.taskDone = false
+	m.taskErr = nil
+	m.overlayLines = nil
+
+	ch := make(chan string, streamBufferSize)
+	m.dockerOutChan = ch
+
+	doneCmd := func() tea.Msg {
+		cmd, err := taskFn()
+		if err != nil {
+			close(ch)
+			return taskDoneMsg{err: err}
+		}
+		err = streamCmdOutput(cmd, ch, true)
+		return taskDoneMsg{err: err}
+	}
+
+	return tea.Batch(readFromChan(ch), doneCmd)
+}
+
+func (m *Model) runAdminBuild() tea.Cmd {
+	return m.runSelfCommand("Building Administration...", "project", "admin-build")
+}
+
+func (m *Model) runStorefrontBuild() tea.Cmd {
+	return m.runSelfCommand("Building Storefront...", "project", "storefront-build")
+}
+
+func (m *Model) runSelfCommand(title string, args ...string) tea.Cmd {
+	projectRoot := m.projectRoot
+	dockerMode := m.dockerMode
+
+	return m.runTask(title, func() (*exec.Cmd, error) {
+		selfBin, err := os.Executable()
+		if err != nil {
+			return nil, err
+		}
+		cmd := exec.CommandContext(context.Background(), selfBin, append(args, projectRoot)...)
+		if dockerMode {
+			cmd.Dir = projectRoot
+		}
+		return cmd, nil
+	})
+}
+
+func (m *Model) runCacheClear() tea.Cmd {
+	e := m.executor
+	return func() tea.Msg {
+		cmd := e.ConsoleCommand(context.Background(), "cache:clear")
+		_ = cmd.Run()
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Replace inline ←/→ cycling on the Config tab with a centered Enter-to-open modal picker (list for selects, text input for credentials).
- Introduce a `Modal` interface and route the command palette, value picker, and stop-confirm dialog through it; lifecycle phases (Docker start/stop, install, task runner) remain separate.
- Split `model_update.go` (565 → 185 lines) into `lifecycle.go`, `install_wizard.go`, `task_runner.go`, `keys.go`, and `overlay_*.go` so each file owns one concern.

## Test plan
- [ ] Open the Config tab, press Enter on PHP Version / Profiler / Node Version — list modal appears, ↑/↓ chooses, Enter confirms, Esc cancels.
- [ ] Switch profiler to Blackfire/Tideways, press Enter on a credential field — text modal appears, Enter saves the value.
- [ ] Save & Regenerate still works (Enter on the Save row when modified).
- [ ] Ctrl+P opens the command palette and executing a command still works.
- [ ] In Docker mode, q / Ctrl+C still triggers the stop-confirm dialog.