### PR TITLE
feat: hardcode Node.js to 24 and remove configurability

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -720,7 +720,7 @@ func runComposerInstall(ctx context.Context, projectFolder string, useDocker boo
 		}
 
 		dockerArgs = append(dockerArgs,
-			"ghcr.io/shopware/docker-dev:php8.3-node22-caddy",
+			"ghcr.io/shopware/docker-dev:php8.3-node24-caddy",
 			"composer", "install", "--no-interaction")
 
 		cmdInstall = exec.CommandContext(ctx, "docker", dockerArgs...)

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -20,7 +20,6 @@ const (
 	fieldBlackfireServerID
 	fieldBlackfireServerToken
 	fieldTidewaysAPIKey
-	fieldNodeVersion
 	fieldSave
 	fieldCount // sentinel – number of fields
 )
@@ -33,18 +32,16 @@ const (
 )
 
 var (
-	phpVersions  = []string{"8.2", "8.3", "8.4", "8.5"}
-	nodeVersions = []string{"22", "24"}
-	profilers    = []string{"", "xdebug", profilerBlackfire, profilerTideways, "pcov", "spx"}
+	phpVersions = []string{"8.2", "8.3", "8.4", "8.5"}
+	profilers   = []string{"", "xdebug", profilerBlackfire, profilerTideways, "pcov", "spx"}
 )
 
 // ConfigModel holds the state for the Environment Config tab.
 type ConfigModel struct {
 	cursor configField
 
-	phpVersion  int // index into phpVersions
-	nodeVersion int // index into nodeVersions
-	profiler    int // index into profilers
+	phpVersion int // index into phpVersions
+	profiler   int // index into profilers
 
 	blackfireServerID    textinput.Model
 	blackfireServerToken textinput.Model
@@ -64,17 +61,12 @@ func NewConfigModel(cfg *shop.Config) ConfigModel {
 		phpVersion: defaultPHPVersionIndex,
 	}
 
-	if cfg != nil && cfg.Docker != nil {
-		if cfg.Docker.PHP != nil {
-			m.phpVersion = indexOf(phpVersions, cfg.Docker.PHP.Version, defaultPHPVersionIndex) // default 8.3
-			m.profiler = indexOf(profilers, cfg.Docker.PHP.Profiler, 0)
-			m.blackfireServerID = newConfigInput("Server ID", cfg.Docker.PHP.BlackfireServerID)
-			m.blackfireServerToken = newConfigInput("Server Token", cfg.Docker.PHP.BlackfireServerToken)
-			m.tidewaysAPIKey = newConfigInput("API Key", cfg.Docker.PHP.TidewaysAPIKey)
-		}
-		if cfg.Docker.Node != nil {
-			m.nodeVersion = indexOf(nodeVersions, cfg.Docker.Node.Version, 0)
-		}
+	if cfg != nil && cfg.Docker != nil && cfg.Docker.PHP != nil {
+		m.phpVersion = indexOf(phpVersions, cfg.Docker.PHP.Version, defaultPHPVersionIndex) // default 8.3
+		m.profiler = indexOf(profilers, cfg.Docker.PHP.Profiler, 0)
+		m.blackfireServerID = newConfigInput("Server ID", cfg.Docker.PHP.BlackfireServerID)
+		m.blackfireServerToken = newConfigInput("Server Token", cfg.Docker.PHP.BlackfireServerToken)
+		m.tidewaysAPIKey = newConfigInput("API Key", cfg.Docker.PHP.TidewaysAPIKey)
 	}
 
 	// Ensure text inputs are initialized even if config was nil.
@@ -142,8 +134,6 @@ func (m ConfigModel) PickerForCursor() Modal {
 	switch m.cursor { //nolint:exhaustive
 	case fieldPHPVersion:
 		return newListPicker(fieldPHPVersion, "PHP Version", phpVersions, nil, m.phpVersion)
-	case fieldNodeVersion:
-		return newListPicker(fieldNodeVersion, "Node.js Version", nodeVersions, nil, m.nodeVersion)
 	case fieldProfiler:
 		labels := make([]string, len(profilers))
 		for i, p := range profilers {
@@ -173,12 +163,6 @@ func (m *ConfigModel) ApplyPickerValue(field configField, value string) bool {
 		idx := indexOf(phpVersions, value, m.phpVersion)
 		if idx != m.phpVersion {
 			m.phpVersion = idx
-			changed = true
-		}
-	case fieldNodeVersion:
-		idx := indexOf(nodeVersions, value, m.nodeVersion)
-		if idx != m.nodeVersion {
-			m.nodeVersion = idx
 			changed = true
 		}
 	case fieldProfiler:
@@ -244,7 +228,7 @@ func (m ConfigModel) isFieldVisible(f configField) bool {
 		return profilerName == profilerBlackfire
 	case fieldTidewaysAPIKey:
 		return profilerName == profilerTideways
-	case fieldPHPVersion, fieldProfiler, fieldNodeVersion, fieldSave, fieldCount:
+	case fieldPHPVersion, fieldProfiler, fieldSave, fieldCount:
 		return true
 	}
 	return true
@@ -259,12 +243,8 @@ func (m ConfigModel) ApplyToConfig(cfg *shop.Config) {
 	if cfg.Docker.PHP == nil {
 		cfg.Docker.PHP = &shop.ConfigDockerPHP{}
 	}
-	if cfg.Docker.Node == nil {
-		cfg.Docker.Node = &shop.ConfigDockerNode{}
-	}
 
 	cfg.Docker.PHP.Version = phpVersions[m.phpVersion]
-	cfg.Docker.Node.Version = nodeVersions[m.nodeVersion]
 	cfg.Docker.PHP.Profiler = profilers[m.profiler]
 
 	// Credentials are stored in the local config file, not here.
@@ -319,13 +299,6 @@ func (m ConfigModel) View(width, height int) string {
 	if profilerName == profilerTideways {
 		s.WriteString(m.renderInput(fieldTidewaysAPIKey, "API Key", m.tidewaysAPIKey, selectedArrow, normalIndent))
 	}
-
-	s.WriteString(divider)
-
-	// --- Node Settings ---
-	s.WriteString(tui.TitleStyle.Render("Node.js"))
-	s.WriteString("\n")
-	s.WriteString(m.renderSelect(fieldNodeVersion, "Version", nodeVersions[m.nodeVersion], selectedArrow, normalIndent))
 
 	s.WriteString(divider)
 

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -11,9 +11,8 @@ import (
 func TestNewConfigModel_NilConfig(t *testing.T) {
 	m := NewConfigModel(nil)
 
-	assert.Equal(t, 1, m.phpVersion)  // default 8.3 (index 1)
-	assert.Equal(t, 0, m.nodeVersion) // default 22 (index 0)
-	assert.Equal(t, 0, m.profiler)    // default none (index 0)
+	assert.Equal(t, 1, m.phpVersion) // default 8.3 (index 1)
+	assert.Equal(t, 0, m.profiler)   // default none (index 0)
 	assert.False(t, m.saved)
 	assert.False(t, m.modified)
 }
@@ -26,31 +25,25 @@ func TestNewConfigModel_WithConfig(t *testing.T) {
 				Profiler:          "blackfire",
 				BlackfireServerID: "my-server-id",
 			},
-			Node: &shop.ConfigDockerNode{
-				Version: "24",
-			},
 		},
 	}
 
 	m := NewConfigModel(cfg)
 
-	assert.Equal(t, 0, m.phpVersion)  // 8.2 is index 0
-	assert.Equal(t, 1, m.nodeVersion) // 24 is index 1
-	assert.Equal(t, 2, m.profiler)    // blackfire is index 2
+	assert.Equal(t, 0, m.phpVersion) // 8.2 is index 0
+	assert.Equal(t, 2, m.profiler)   // blackfire is index 2
 	assert.Equal(t, "my-server-id", m.blackfireServerID.Value())
 }
 
 func TestConfigModel_ApplyToConfig(t *testing.T) {
 	cfg := &shop.Config{}
 	m := NewConfigModel(nil)
-	m.phpVersion = 2  // 8.4
-	m.nodeVersion = 1 // 24
-	m.profiler = 1    // xdebug
+	m.phpVersion = 2 // 8.4
+	m.profiler = 1   // xdebug
 
 	m.ApplyToConfig(cfg)
 
 	assert.Equal(t, "8.4", cfg.Docker.PHP.Version)
-	assert.Equal(t, "24", cfg.Docker.Node.Version)
 	assert.Equal(t, "xdebug", cfg.Docker.PHP.Profiler)
 	assert.Empty(t, cfg.Docker.PHP.BlackfireServerID)
 }
@@ -133,18 +126,27 @@ func TestConfigModel_CursorNavigation(t *testing.T) {
 	m.moveCursorDown()
 	assert.Equal(t, fieldProfiler, m.cursor)
 
-	// Should skip hidden credential fields to Node Version.
+	// Should skip hidden credential fields straight to Save.
 	m.moveCursorDown()
-	assert.Equal(t, fieldNodeVersion, m.cursor, "should skip hidden fields to Node Version")
-
-	m.moveCursorDown()
-	assert.Equal(t, fieldSave, m.cursor)
-
-	m.moveCursorUp()
-	assert.Equal(t, fieldNodeVersion, m.cursor, "should go back to Node Version")
+	assert.Equal(t, fieldSave, m.cursor, "should skip hidden fields to Save")
 
 	m.moveCursorUp()
 	assert.Equal(t, fieldProfiler, m.cursor, "should skip hidden fields going up")
+}
+
+func TestConfigModel_CursorNavigation_BlackfireVisible(t *testing.T) {
+	m := NewConfigModel(nil)
+	m.profiler = indexOf(profilers, "blackfire", 0)
+
+	assert.Equal(t, fieldPHPVersion, m.cursor)
+	m.moveCursorDown()
+	assert.Equal(t, fieldProfiler, m.cursor)
+	m.moveCursorDown()
+	assert.Equal(t, fieldBlackfireServerID, m.cursor)
+	m.moveCursorDown()
+	assert.Equal(t, fieldBlackfireServerToken, m.cursor)
+	m.moveCursorDown()
+	assert.Equal(t, fieldSave, m.cursor)
 }
 
 func TestConfigModel_PickerForCursor_Select(t *testing.T) {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -11,10 +11,13 @@ import (
 	"github.com/shopware/shopware-cli/internal/shop"
 )
 
+// nodeVersion is the Node.js version baked into the dev container image. It
+// is no longer user-configurable: only one version is supported at a time.
+const nodeVersion = "24"
+
 // ComposeOptions holds configuration for generating the compose file.
 type ComposeOptions struct {
 	PHPVersion           string
-	NodeVersion          string
 	PHPProfiler          string
 	BlackfireServerID    string
 	BlackfireServerToken string
@@ -26,13 +29,6 @@ func (o *ComposeOptions) phpVersion() string {
 		return o.PHPVersion
 	}
 	return "8.3"
-}
-
-func (o *ComposeOptions) nodeVersion() string {
-	if o != nil && o.NodeVersion != "" {
-		return o.NodeVersion
-	}
-	return "22"
 }
 
 // ComposeOptionsFromConfig creates ComposeOptions from a shop.Config.
@@ -47,9 +43,6 @@ func ComposeOptionsFromConfig(cfg *shop.Config) *ComposeOptions {
 		opts.BlackfireServerID = cfg.Docker.PHP.BlackfireServerID
 		opts.BlackfireServerToken = cfg.Docker.PHP.BlackfireServerToken
 		opts.TidewaysAPIKey = cfg.Docker.PHP.TidewaysAPIKey
-	}
-	if cfg.Docker.Node != nil {
-		opts.NodeVersion = cfg.Docker.Node.Version
 	}
 	return opts
 }
@@ -124,7 +117,7 @@ func buildCompose(hasAMQP, hasElasticsearch bool, opts *ComposeOptions) yaml.Nod
 	}
 
 	web := newMappingNode()
-	addKeyValue(web, "image", fmt.Sprintf("ghcr.io/shopware/docker-dev:php%s-node%s-caddy", opts.phpVersion(), opts.nodeVersion()))
+	addKeyValue(web, "image", fmt.Sprintf("ghcr.io/shopware/docker-dev:php%s-node%s-caddy", opts.phpVersion(), nodeVersion))
 	addKeyValueNode(web, "ports", newSequenceNode(
 		"8000:8000", "8080:8080", "9999:9999", "9998:9998", "5173:5173", "5773:5773",
 	))

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -28,7 +28,7 @@ func TestGenerateComposeFile(t *testing.T) {
 		assert.Contains(t, compose, "adminer:")
 		assert.Contains(t, compose, "mailer:")
 		assert.Contains(t, compose, "db-data:")
-		assert.Contains(t, compose, "ghcr.io/shopware/docker-dev:php8.3-node22-caddy")
+		assert.Contains(t, compose, "ghcr.io/shopware/docker-dev:php8.3-node24-caddy")
 		assert.Contains(t, compose, "mariadb:11.8")
 		assert.Contains(t, compose, "mailpit")
 		assert.NotContains(t, compose, "lavinmq")
@@ -94,24 +94,8 @@ func TestGenerateComposeFile(t *testing.T) {
 		assert.NoError(t, err)
 
 		compose := string(result)
-		assert.Contains(t, compose, "ghcr.io/shopware/docker-dev:php8.2-node22-caddy")
+		assert.Contains(t, compose, "ghcr.io/shopware/docker-dev:php8.2-node24-caddy")
 		assert.NotContains(t, compose, "php8.3")
-	})
-
-	t.Run("custom node version", func(t *testing.T) {
-		t.Parallel()
-		lock := &packagist.ComposerLock{
-			Packages: []packagist.ComposerLockPackage{
-				{Name: "shopware/core", Version: "6.6.0.0"},
-			},
-		}
-
-		result, err := GenerateComposeFile(lock, &ComposeOptions{NodeVersion: "24"})
-		assert.NoError(t, err)
-
-		compose := string(result)
-		assert.Contains(t, compose, "ghcr.io/shopware/docker-dev:php8.3-node24-caddy")
-		assert.NotContains(t, compose, "node22")
 	})
 
 	t.Run("with php profiler", func(t *testing.T) {

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -419,8 +419,6 @@ type ConfigValidationIgnoreExtension struct {
 type ConfigDocker struct {
 	// PHP configuration for the Docker dev image
 	PHP *ConfigDockerPHP `yaml:"php,omitempty"`
-	// Node.js configuration for the Docker dev image
-	Node *ConfigDockerNode `yaml:"node,omitempty"`
 }
 
 type ConfigDockerPHP struct {
@@ -496,11 +494,6 @@ func (ConfigDockerPHP) JSONSchema() *jsonschema.Schema {
 			},
 		},
 	}
-}
-
-type ConfigDockerNode struct {
-	// Node.js version (e.g. "22", "24"). Defaults to "22".
-	Version string `yaml:"version,omitempty" jsonschema:"enum=22,enum=24"`
 }
 
 type ConfigImageProxy struct {

--- a/shopware-project-schema.json
+++ b/shopware-project-schema.json
@@ -151,7 +151,7 @@
         },
         "asset_caching": {
           "type": "boolean",
-          "description": "When enabled, built assets are cached locally and restored on subsequent builds when sources haven't changed"
+          "description": "When enabled, built assets are cached and restored on subsequent builds when sources haven't changed"
         },
         "hooks": {
           "$ref": "#/$defs/ConfigBuildHooks",
@@ -376,24 +376,6 @@
         "php": {
           "$ref": "#/$defs/ConfigDockerPHP",
           "description": "PHP configuration for the Docker dev image"
-        },
-        "node": {
-          "$ref": "#/$defs/ConfigDockerNode",
-          "description": "Node.js configuration for the Docker dev image"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ConfigDockerNode": {
-      "properties": {
-        "version": {
-          "type": "string",
-          "enum": [
-            "22",
-            "24"
-          ],
-          "description": "Node.js version (e.g. \"22\", \"24\"). Defaults to \"22\"."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- Remove \`docker.node\` from the project config schema (\`ConfigDockerNode\` struct, JSON schema entry).
- Remove the Node.js section from the devtui Config tab.
- Hardcode \`node24\` in the dev container image string used by both compose generation and \`project create\`.

## Breaking change
Any \`.shopware-project.yml\` with \`docker.node.version: 22\` will now be ignored (the field no longer parses). Projects pinned to Node 22 will silently move to Node 24.

## Test plan
- [ ] \`go test ./...\` passes (compose generator now always emits \`node24\`).
- [ ] \`shopware-cli project create\` uses the \`node24\` dev container image.
- [ ] devtui Config tab no longer shows a Node.js section; only PHP and profiler remain.