### PR TITLE
Add staging mode configuration to deployment settings

### DIFF
--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -330,6 +330,15 @@ type ConfigDeployment struct {
 		Id     string `yaml:"id" jsonschema:"required"`
 		Script string `yaml:"script" jsonschema:"required"`
 	} `yaml:"one-time-tasks"`
+
+	// Staging mode configuration for the deployment
+	Staging *ConfigDeploymentStaging `yaml:"staging,omitempty"`
+}
+
+// ConfigDeploymentStaging defines staging mode configuration.
+type ConfigDeploymentStaging struct {
+	// When enabled, staging setup commands will be executed during installation and upgrade
+	Enabled bool `yaml:"enabled,omitempty"`
 }
 
 type ConfigDeploymentOverrides map[string]struct {

--- a/shopware-project-schema.json
+++ b/shopware-project-schema.json
@@ -140,7 +140,7 @@
         },
         "asset_caching": {
           "type": "boolean",
-          "description": "When enabled, built assets are cached locally and restored on subsequent builds when sources haven't changed"
+          "description": "When enabled, built assets are cached and restored on subsequent builds when sources haven't changed"
         },
         "hooks": {
           "$ref": "#/$defs/ConfigBuildHooks",
@@ -331,6 +331,10 @@
             ]
           },
           "type": "array"
+        },
+        "staging": {
+          "$ref": "#/$defs/ConfigDeploymentStaging",
+          "description": "Staging mode configuration for the deployment"
         }
       },
       "additionalProperties": false,
@@ -359,6 +363,17 @@
       },
       "type": "object",
       "title": "Extension overrides"
+    },
+    "ConfigDeploymentStaging": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "When enabled, staging setup commands will be executed during installation and upgrade"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ConfigDeploymentStaging defines staging mode configuration."
     },
     "ConfigDump": {
       "properties": {


### PR DESCRIPTION
## Summary
This PR adds support for staging mode configuration in the deployment settings, allowing users to control whether staging setup commands are executed during installation and upgrade processes.

## Key Changes
- Added `ConfigDeploymentStaging` struct to `internal/shop/config.go` with an `Enabled` boolean field to control staging setup command execution
- Extended `ConfigDeployment` struct to include an optional `Staging` field referencing the new staging configuration
- Updated the JSON schema (`shopware-project-schema.json`) to include the new `ConfigDeploymentStaging` definition with proper type and description
- Added `staging` property to the deployment configuration schema
- Minor documentation improvement: removed "locally" from asset caching description for clarity

## Implementation Details
- The `Staging` field is optional (uses `omitempty` tag) to maintain backward compatibility
- The staging configuration is defined as a separate struct for better organization and potential future extensibility
- Both the Go code and JSON schema have been updated consistently with matching descriptions

https://claude.ai/code/session_01CHUaF3xNhgHWHbj13KetiD