### PR TITLE
Track additional project creation options in analytics

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -461,6 +461,11 @@ var projectCreateCmd = &cobra.Command{
 			}
 		}
 
+		// @todo: it's broken in paas deployments, the paas recipe configures Elasticsearch and it's difficult to do it only when elasticsearch is available.
+		if selectedDeployment == packagist.DeploymentShopwarePaaS {
+			withElasticsearch = true
+		}
+
 		go tracking.Track(cmd.Context(), "project.create", map[string]string{
 			"version":            selectedVersion,
 			"deployment":         selectedDeployment,
@@ -481,11 +486,6 @@ var projectCreateCmd = &cobra.Command{
 		}
 
 		logging.FromContext(cmd.Context()).Infof("Setting up Shopware %s", chooseVersion)
-
-		// @todo: it's broken in paas deployments, the paas recipe configures Elasticsearch and it's difficult to do it only when elasticsearch is available.
-		if selectedDeployment == packagist.DeploymentShopwarePaaS {
-			withElasticsearch = true
-		}
 
 		composerJson, err := packagist.GenerateComposerJson(cmd.Context(), packagist.ComposerJsonOptions{
 			Version:          chooseVersion,

--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -462,10 +462,13 @@ var projectCreateCmd = &cobra.Command{
 		}
 
 		go tracking.Track(cmd.Context(), "project.create", map[string]string{
-			"version":    selectedVersion,
-			"deployment": selectedDeployment,
-			"ci":         selectedCI,
-			"docker":     fmt.Sprintf("%v", useDocker),
+			"version":            selectedVersion,
+			"deployment":         selectedDeployment,
+			"ci":                 selectedCI,
+			"docker":             fmt.Sprintf("%v", useDocker),
+			"with_elasticsearch": fmt.Sprintf("%v", withElasticsearch),
+			"with_amqp":          fmt.Sprintf("%v", withAMQP),
+			"interactive":        fmt.Sprintf("%v", interactive),
 		})
 
 		chooseVersion := resolveVersion(selectedVersion, filteredVersions)


### PR DESCRIPTION
## Summary
Enhanced project creation analytics tracking to capture additional configuration options that users select during the project setup process.

## Key Changes
- Added tracking for `with_elasticsearch` flag to monitor Elasticsearch adoption in new projects
- Added tracking for `with_amqp` flag to monitor message queue adoption in new projects
- Added tracking for `interactive` flag to understand user interaction patterns
- Aligned formatting of all tracking parameters for consistency (using consistent spacing in the map)

## Implementation Details
The new tracking parameters are formatted as string representations of boolean values using `fmt.Sprintf("%v", ...)`, consistent with the existing `docker` parameter. This allows the analytics backend to track which optional services and features users are selecting when creating new projects.

https://claude.ai/code/session_013sc5pc41FZv6iZS8DrmB5T