### PR TITLE
Configure prerelease handling in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,7 @@ release:
   github:
     owner: shopware
     name: shopware-cli
+  prerelease: auto
 
 dockers_v2:
   - id: php-85
@@ -43,7 +44,7 @@ dockers_v2:
       - "ghcr.io/shopware/shopware-cli"
     tags:
       - "{{ .Version }}-php-8.5"
-      - "latest-php-8.5"
+      - '{{ if not .Prerelease }}latest-php-8.5{{ end }}'
     build_args:
       PHP_VERSION: "8.5"
     platforms:
@@ -55,7 +56,7 @@ dockers_v2:
       - "ghcr.io/shopware/shopware-cli"
     tags:
       - "{{ .Version }}-php-8.4"
-      - "latest-php-8.4"
+      - '{{ if not .Prerelease }}latest-php-8.4{{ end }}'
     build_args:
       PHP_VERSION: "8.4"
     platforms:
@@ -67,9 +68,9 @@ dockers_v2:
       - "ghcr.io/shopware/shopware-cli"
     tags:
       - "{{ .Version }}-php-8.3"
-      - "latest-php-8.3"
+      - '{{ if not .Prerelease }}latest-php-8.3{{ end }}'
       - "{{ .Version }}"
-      - "latest"
+      - '{{ if not .Prerelease }}latest{{ end }}'
     build_args:
       PHP_VERSION: "8.3"
     platforms:
@@ -81,7 +82,7 @@ dockers_v2:
       - "ghcr.io/shopware/shopware-cli"
     tags:
       - "{{ .Version }}-php-8.2"
-      - "latest-php-8.2"
+      - '{{ if not .Prerelease }}latest-php-8.2{{ end }}'
     build_args:
       PHP_VERSION: "8.2"
     platforms:
@@ -94,7 +95,7 @@ dockers_v2:
     dockerfile: Dockerfile.bin
     tags:
       - "bin-{{ .Version }}"
-      - "bin"
+      - '{{ if not .Prerelease }}bin{{ end }}'
     platforms:
       - "linux/amd64"
       - "linux/arm64"
@@ -150,6 +151,7 @@ aurs:
   - homepage: https://developer.shopware.com/
     description: A cli which contains handy helpful commands for daily Shopware tasks
     license: MIT
+    disable: '{{ .Prerelease }}'
     maintainers:
       - "Soner Sayakci <s.sayakci@shopware.com>"
       - "Max <max@swk-web.com>"
@@ -176,6 +178,7 @@ aurs:
 
 nix:
   - name: shopware-cli
+    disable: '{{ .Prerelease }}'
     repository:
       owner: FriendsOfShopware
       name: nur-packages
@@ -215,6 +218,7 @@ nfpms:
 
 homebrew_casks:
   - name: shopware-cli
+    disable: '{{ .Prerelease }}'
     repository:
       owner: shopware
       name: homebrew-tap
@@ -241,6 +245,7 @@ npms:
     repository: https://github.com/shopware/shopware-cli
     bugs: https://github.com/shopware/shopware-cli/issues
     access: public
+    tag: '{{ if .Prerelease }}prerelease{{ else }}latest{{ end }}'
 
 notarize:
   macos:


### PR DESCRIPTION
## Summary
This PR updates the GoReleaser configuration to properly handle prerelease versions by conditionally tagging and publishing artifacts based on whether a release is marked as a prerelease.

## Key Changes
- Enable automatic prerelease detection by adding `prerelease: auto` to the release configuration
- Update Docker image tags to only apply "latest" tags for stable releases (not prereleases):
  - `latest-php-8.5`, `latest-php-8.4`, `latest-php-8.3`, `latest-php-8.2`
  - `latest` and `bin` tags
- Disable publishing to package managers for prerelease versions:
  - AUR (Arch User Repository)
  - Nix package manager
  - Homebrew Casks
- Set appropriate npm tag (`prerelease` for prerelease versions, `latest` for stable releases)

## Implementation Details
- Uses GoReleaser's template syntax `{{ if not .Prerelease }}...{{ end }}` to conditionally include tags
- Leverages the `disable` field with `{{ .Prerelease }}` to skip publishing to certain package managers during prerelease builds
- Ensures that only stable releases get the "latest" tags on Docker registries and npm, preventing users from accidentally installing prerelease versions

https://claude.ai/code/session_01CbueeEQt6r2bwYD4sLnrcQ