### PR TITLE
feat: warn about known security advisories before project creation

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -438,6 +438,35 @@ var projectCreateCmd = &cobra.Command{
 			return fmt.Errorf("missing required dependencies")
 		}
 
+		advisories, err := packagist.GetShopwareSecurityAdvisories(cmd.Context())
+		if err != nil {
+			logging.FromContext(cmd.Context()).Warnf("Could not fetch security advisories: %v", err)
+		}
+		matchingAdvisories := packagist.FilterAdvisoriesForVersion(advisories, chooseVersion)
+		if len(matchingAdvisories) > 0 {
+			fmt.Fprintln(os.Stderr, renderSecurityAdvisories(chooseVersion, matchingAdvisories))
+
+			if interactive {
+				var continueAnyway string
+				if err := huh.NewForm(huh.NewGroup(
+					tui.NewYesNo().
+						Title(fmt.Sprintf("Shopware %s is affected by %d known security advisor%s", chooseVersion, len(matchingAdvisories), pluralize(len(matchingAdvisories), "y", "ies"))).
+						Description("Continuing will disable composer's audit blocking (--no-audit) so installation can proceed. Do you want to continue anyway?").
+						Value(&continueAnyway),
+				)).Run(); err != nil {
+					return err
+				}
+
+				if continueAnyway == tui.No {
+					return fmt.Errorf("project creation cancelled")
+				}
+
+				noAudit = true
+			} else if !noAudit {
+				return fmt.Errorf("shopware %s is affected by known security advisories; re-run with --no-audit to proceed", chooseVersion)
+			}
+		}
+
 		incompatibilities := system.CheckIncompatibilities(useDocker, projectFolder)
 
 		for _, incompatibility := range incompatibilities {
@@ -615,6 +644,41 @@ var projectCreateCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func renderSecurityAdvisories(chosenVersion string, advisories []packagist.SecurityAdvisory) string {
+	var b strings.Builder
+
+	b.WriteString(tui.RedText.Bold(true).Render(fmt.Sprintf("Security Advisories for Shopware %s", chosenVersion)))
+	b.WriteString("\n\n")
+
+	warn := tui.YellowText.Render("⚠")
+	for _, a := range advisories {
+		severity := strings.ToUpper(a.Severity)
+		if severity == "" {
+			severity = "UNKNOWN"
+		}
+		fmt.Fprintf(&b, "  %s [%s] %s\n", warn, tui.BoldText.Render(severity), a.Title)
+		if a.CVE != "" {
+			fmt.Fprintf(&b, "    %s: %s\n", tui.DimText.Render("CVE"), a.CVE)
+		}
+		if a.Link != "" {
+			fmt.Fprintf(&b, "    %s\n", tui.BlueText.Render(a.Link))
+		}
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(tui.BlueColor).
+		Padding(1, 2).
+		Render(strings.TrimRight(b.String(), "\n"))
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
 }
 
 func resolveVersion(selectedVersion string, filteredVersions []*version.Version) string {

--- a/internal/packagist/advisories.go
+++ b/internal/packagist/advisories.go
@@ -1,0 +1,98 @@
+package packagist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/shyim/go-version"
+
+	"github.com/shopware/shopware-cli/logging"
+)
+
+// SecurityAdvisory describes a single packagist security advisory for a package.
+type SecurityAdvisory struct {
+	AdvisoryID       string `json:"advisoryId"`
+	PackageName      string `json:"packageName"`
+	RemoteID         string `json:"remoteId"`
+	Title            string `json:"title"`
+	Link             string `json:"link"`
+	CVE              string `json:"cve"`
+	AffectedVersions string `json:"affectedVersions"`
+	Source           string `json:"source"`
+	ReportedAt       string `json:"reportedAt"`
+	Severity         string `json:"severity"`
+}
+
+// Affects reports whether the given version is covered by this advisory's
+// affectedVersions constraint. The packagist API uses `|` to separate OR
+// branches; each branch is an AND of comma-separated constraints.
+func (a SecurityAdvisory) Affects(targetVersion string) bool {
+	v, err := version.NewVersion(strings.TrimPrefix(targetVersion, "v"))
+	if err != nil {
+		return false
+	}
+
+	for _, branch := range strings.Split(a.AffectedVersions, "|") {
+		branch = strings.TrimSpace(branch)
+		if branch == "" {
+			continue
+		}
+		cs, err := version.NewConstraint(branch)
+		if err != nil {
+			continue
+		}
+		if cs.Check(v) {
+			return true
+		}
+	}
+	return false
+}
+
+type advisoriesResponse struct {
+	Advisories map[string][]SecurityAdvisory `json:"advisories"`
+}
+
+// GetShopwareSecurityAdvisories fetches all known security advisories for
+// shopware/core from packagist.
+func GetShopwareSecurityAdvisories(ctx context.Context) ([]SecurityAdvisory, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://packagist.org/api/security-advisories/?packages%5B%5D=shopware/core", http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create advisories request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Shopware CLI")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch advisories: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logging.FromContext(ctx).Errorf("Cannot close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch advisories: %s", resp.Status)
+	}
+
+	var parsed advisoriesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode advisories: %w", err)
+	}
+
+	return parsed.Advisories["shopware/core"], nil
+}
+
+// FilterAdvisoriesForVersion returns only the advisories that affect the given version.
+func FilterAdvisoriesForVersion(advisories []SecurityAdvisory, chosenVersion string) []SecurityAdvisory {
+	var matching []SecurityAdvisory
+	for _, a := range advisories {
+		if a.Affects(chosenVersion) {
+			matching = append(matching, a)
+		}
+	}
+	return matching
+}

--- a/internal/packagist/advisories_test.go
+++ b/internal/packagist/advisories_test.go
@@ -1,0 +1,49 @@
+package packagist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecurityAdvisoryAffects(t *testing.T) {
+	a := SecurityAdvisory{
+		AffectedVersions: "<6.6.10.15|>=6.7.0.0,<6.7.8.1",
+	}
+
+	t.Run("first branch matches", func(t *testing.T) {
+		assert.True(t, a.Affects("6.6.10.14"))
+	})
+
+	t.Run("second branch matches", func(t *testing.T) {
+		assert.True(t, a.Affects("6.7.5.0"))
+	})
+
+	t.Run("between branches does not match", func(t *testing.T) {
+		assert.False(t, a.Affects("6.6.10.15"))
+	})
+
+	t.Run("above all branches does not match", func(t *testing.T) {
+		assert.False(t, a.Affects("6.7.8.1"))
+	})
+
+	t.Run("version with v prefix", func(t *testing.T) {
+		assert.True(t, a.Affects("v6.6.10.14"))
+	})
+
+	t.Run("invalid version is not affected", func(t *testing.T) {
+		assert.False(t, a.Affects("not-a-version"))
+	})
+}
+
+func TestFilterAdvisoriesForVersion(t *testing.T) {
+	advisories := []SecurityAdvisory{
+		{Title: "A", AffectedVersions: "<6.6.10.15"},
+		{Title: "B", AffectedVersions: ">=6.7.0.0,<6.7.8.1"},
+		{Title: "C", AffectedVersions: ">=7.0.0.0"},
+	}
+
+	matching := FilterAdvisoriesForVersion(advisories, "6.7.5.0")
+	assert.Len(t, matching, 1)
+	assert.Equal(t, "B", matching[0].Title)
+}


### PR DESCRIPTION
## Summary

<img width="2078" height="926" alt="image" src="https://github.com/user-attachments/assets/393686af-5fe2-49b7-9168-de505c80126d" />


- Fetches packagist security advisories for `shopware/core` and filters to the chosen version before any folder is created.
- Renders a styled block listing severity, title, CVE, and link for each matching advisory.
- Interactive mode prompts "Continue anyway?" — yes auto-enables `--no-audit` so composer install proceeds; no cancels.
- Non-interactive mode aborts unless `--no-audit` was already passed.
- Network errors are non-fatal (logged as a warning) so a packagist outage does not block project creation.

## Test plan
- [ ] `go test ./internal/packagist/... ./cmd/project/...`
- [ ] `shopware-cli project create test-vuln 6.6.10.14` (a version known to have advisories) — verify the styled block and the interactive prompt
- [ ] Same command with `--no-interaction` — verify it aborts unless `--no-audit` is passed
- [ ] `shopware-cli project create test-clean latest` — verify no advisory block appears for the latest version