### PR TITLE
feat(devtui): add migration setup wizard for project dev

### DIFF
--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -31,9 +31,45 @@ var projectDevCmd = &cobra.Command{
 	Short: "Start the development environment",
 	Long:  "Start the development environment. Launches the interactive TUI dashboard when run in a terminal, or starts containers in the background otherwise.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := setupDevEnvironment(cmd)
+		projectRoot, err := findClosestShopwareProject()
 		if err != nil {
 			return err
+		}
+
+		cfg, err := shop.ReadConfig(cmd.Context(), projectConfigPath, true)
+		if err != nil {
+			return err
+		}
+
+		// If the compatibility date is too old, offer to set up dev mode via the TUI
+		if cfg.IsCompatibilityDateBefore(shop.CompatibilityDevMode) {
+			if !isatty.IsTerminal(os.Stdin.Fd()) {
+				return shop.ErrDevModeNotSupported
+			}
+			return runSetupGuideTUI(projectRoot, cfg)
+		}
+
+		envCfg, err := cfg.ResolveEnvironment(environmentName)
+		if err != nil {
+			return err
+		}
+
+		exec, err := executor.New(projectRoot, envCfg, cfg)
+		if err != nil {
+			return err
+		}
+
+		if exec.Type() == executor.TypeDocker {
+			if err := dockerpkg.WriteComposeFile(projectRoot, dockerpkg.ComposeOptionsFromConfig(cfg)); err != nil {
+				return err
+			}
+		}
+
+		env := &devEnvironment{
+			projectRoot: projectRoot,
+			cfg:         cfg,
+			envCfg:      envCfg,
+			executor:    exec,
 		}
 
 		if !isatty.IsTerminal(os.Stdin.Fd()) {
@@ -68,6 +104,25 @@ var projectDevStopCmd = &cobra.Command{
 
 		return env.stop(cmd)
 	},
+}
+
+func runSetupGuideTUI(projectRoot string, cfg *shop.Config) error {
+	envCfg := &shop.EnvironmentConfig{Type: "docker", URL: "http://127.0.0.1:8000"}
+	exec, err := executor.New(projectRoot, envCfg, cfg)
+	if err != nil {
+		return err
+	}
+
+	m := devtui.NewSetupGuide(devtui.Options{
+		ProjectRoot: projectRoot,
+		Config:      cfg,
+		EnvConfig:   envCfg,
+		Executor:    exec,
+	})
+
+	p := tea.NewProgram(m)
+	_, err = p.Run()
+	return err
 }
 
 func setupDevEnvironment(cmd *cobra.Command) (*devEnvironment, error) {

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -127,7 +127,7 @@ func NewSetupGuide(opts Options) Model {
 	m := New(opts)
 	m.phase = phaseSetupGuide
 	m.dockerMode = true // setup guide always creates Docker env
-	m.setupGuide = newSetupGuide()
+	m.setupGuide = newSetupGuide(opts.ProjectRoot)
 	return m
 }
 

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -38,6 +38,7 @@ const (
 	phaseInstallPrompt
 	phaseInstalling
 	phaseTask
+	phaseSetupGuide
 )
 
 type Options struct {
@@ -71,6 +72,7 @@ type Model struct {
 	taskDone       bool
 	taskErr        error
 	watchers       map[string]*executor.Process
+	setupGuide     setupGuide
 }
 
 type dockerAlreadyRunningMsg struct{}
@@ -119,7 +121,20 @@ func New(opts Options) Model {
 	}
 }
 
+// NewSetupGuide creates a Model that starts in the setup guide phase
+// for projects that don't yet have a development environment configured.
+func NewSetupGuide(opts Options) Model {
+	m := New(opts)
+	m.phase = phaseSetupGuide
+	m.dockerMode = true // setup guide always creates Docker env
+	m.setupGuide = newSetupGuide()
+	return m
+}
+
 func (m Model) Init() tea.Cmd {
+	if m.phase == phaseSetupGuide {
+		return nil
+	}
 	if m.dockerMode {
 		return checkContainersRunning(m.projectRoot)
 	}

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -7,6 +7,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
+	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
 )
 
@@ -15,6 +17,10 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		next, cmd := m.modal.Update(msg)
 		m.modal = next
 		return m, cmd
+	}
+
+	if m.phase == phaseSetupGuide {
+		return m.updateSetupGuide(msg)
 	}
 
 	if m.phase == phaseInstallPrompt {
@@ -181,4 +187,89 @@ func (m *Model) stopWatcher(name string) tea.Cmd {
 
 		return watcherStoppedMsg{name: name}
 	}
+}
+
+func (m Model) updateSetupGuide(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	newGuide, cmd := m.setupGuide.update(msg)
+	m.setupGuide = newGuide
+
+	// Ctrl+C on any step quits the app
+	if msg.String() == keyCtrlC {
+		return m, tea.Quit
+	}
+
+	// User confirmed the review step → write config files
+	if m.setupGuide.step == setupStepReview && msg.String() == keyEnter && m.setupGuide.confirmYes {
+		return m.saveSetupGuide()
+	}
+
+	// User pressed Enter on the done screen → start docker containers.
+	// If the previous save errored, stay on the done screen so the user can read it.
+	if m.setupGuide.step == setupStepDone && msg.String() == keyEnter && m.setupGuide.err == nil {
+		return m.startAfterSetupGuide()
+	}
+
+	return m, cmd
+}
+
+func (m Model) saveSetupGuide() (tea.Model, tea.Cmd) {
+	m.setupGuide.applyToConfig(m.config)
+	if err := shop.WriteConfig(m.config, m.projectRoot); err != nil {
+		m.setupGuide.err = err
+		m.setupGuide.step = setupStepDone
+		return m, nil
+	}
+
+	if localCfg := m.setupGuide.localConfig(); localCfg != nil {
+		if err := shop.WriteLocalConfig(localCfg, m.projectRoot); err != nil {
+			m.setupGuide.err = err
+			m.setupGuide.step = setupStepDone
+			return m, nil
+		}
+	}
+
+	m.setupGuide.step = setupStepDone
+	return m, nil
+}
+
+func (m Model) startAfterSetupGuide() (tea.Model, tea.Cmd) {
+	envCfg, err := m.config.ResolveEnvironment("")
+	if err != nil {
+		m.setupGuide.err = err
+		return m, nil
+	}
+	m.envConfig = envCfg
+
+	exec, err := executor.New(m.projectRoot, envCfg, m.config)
+	if err != nil {
+		m.setupGuide.err = err
+		return m, nil
+	}
+	m.executor = exec
+
+	if m.executor.Type() == executor.TypeDocker {
+		if err := dockerpkg.WriteComposeFile(m.projectRoot, dockerpkg.ComposeOptionsFromConfig(m.config)); err != nil {
+			m.setupGuide.err = err
+			return m, nil
+		}
+	}
+
+	m.phase = phaseStarting
+	m.overlayLines = nil
+	m.dockerShowLogs = false
+	m.dockerSpinner = newBrandSpinner()
+
+	shopURL := m.config.URL
+	if m.envConfig.URL != "" {
+		shopURL = m.envConfig.URL
+	}
+	var username, password string
+	if m.envConfig.AdminApi != nil {
+		username = m.envConfig.AdminApi.Username
+		password = m.envConfig.AdminApi.Password
+	}
+	m.general = NewGeneralModel(m.executor.Type(), shopURL, username, password, m.projectRoot, m.executor)
+	m.configTab = NewConfigModel(m.config)
+
+	return m, tea.Batch(m.dockerSpinner.Tick, m.startContainers())
 }

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -198,9 +198,13 @@ func (m Model) updateSetupGuide(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 
-	// User confirmed the review step → write config files
-	if m.setupGuide.step == setupStepReview && msg.String() == keyEnter && m.setupGuide.confirmYes {
-		return m.saveSetupGuide()
+	// User pressed Enter on the review step. confirmYes=true saves and
+	// continues, confirmYes=false picks the Quit button and exits the wizard.
+	if m.setupGuide.step == setupStepReview && msg.String() == keyEnter {
+		if m.setupGuide.confirmYes {
+			return m.saveSetupGuide()
+		}
+		return m, tea.Quit
 	}
 
 	// User pressed Enter on the done screen → start docker containers.
@@ -234,10 +238,40 @@ func (m Model) saveSetupGuide() (tea.Model, tea.Cmd) {
 			m.setupGuide.step = setupStepDone
 			return m, nil
 		}
+		// Mirror the just-written profiler secrets onto the in-memory config
+		// so the first generated compose.yaml wires them up. They remain in
+		// .shopware-project.local.yml (not the committed config); this is
+		// only the runtime view ReadConfig would have produced on next launch.
+		mergeLocalProfilerSecrets(m.config, localCfg)
 	}
 
 	m.setupGuide.step = setupStepDone
 	return m, nil
+}
+
+// mergeLocalProfilerSecrets copies profiler credential fields from the
+// .shopware-project.local.yml partial config onto the main runtime config.
+// Only profiler secrets are merged — other fields are intentionally left as
+// the project-level config defines them.
+func mergeLocalProfilerSecrets(dst, src *shop.Config) {
+	if src == nil || src.Docker == nil || src.Docker.PHP == nil {
+		return
+	}
+	if dst.Docker == nil {
+		dst.Docker = &shop.ConfigDocker{}
+	}
+	if dst.Docker.PHP == nil {
+		dst.Docker.PHP = &shop.ConfigDockerPHP{}
+	}
+	if v := src.Docker.PHP.BlackfireServerID; v != "" {
+		dst.Docker.PHP.BlackfireServerID = v
+	}
+	if v := src.Docker.PHP.BlackfireServerToken; v != "" {
+		dst.Docker.PHP.BlackfireServerToken = v
+	}
+	if v := src.Docker.PHP.TidewaysAPIKey; v != "" {
+		dst.Docker.PHP.TidewaysAPIKey = v
+	}
 }
 
 func (m Model) startAfterSetupGuide() (tea.Model, tea.Cmd) {

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -220,6 +220,14 @@ func (m Model) saveSetupGuide() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	changed, err := ensureDeploymentHelper(m.projectRoot)
+	if err != nil {
+		m.setupGuide.err = err
+		m.setupGuide.step = setupStepDone
+		return m, nil
+	}
+	m.setupGuide.deploymentHelperAdded = changed
+
 	if localCfg := m.setupGuide.localConfig(); localCfg != nil {
 		if err := shop.WriteLocalConfig(localCfg, m.projectRoot); err != nil {
 			m.setupGuide.err = err

--- a/internal/devtui/model_view.go
+++ b/internal/devtui/model_view.go
@@ -25,6 +25,8 @@ func (m Model) View() tea.View {
 		v.Content = m.renderPhase()
 	case phaseTask:
 		v.Content = m.renderDockerLogs(m.taskTitle, "")
+	case phaseSetupGuide:
+		v.Content = m.renderSetupGuide()
 	}
 
 	if m.modal != nil {
@@ -151,7 +153,8 @@ func (m Model) renderPhase() string {
 		}
 		content.WriteString(tui.RenderPhaseCard(strings.TrimRight(card.String(), "\n")))
 		footerHint = tui.ShortcutBadge("l", "Toggle logs")
-	case phaseDashboard, phaseTask:
+	case phaseDashboard, phaseTask, phaseSetupGuide:
+		// Rendered by the outer View() dispatch, not here.
 	}
 
 	return renderPhaseLayout(content.String(), m.width, m.height, footerHint)
@@ -193,6 +196,12 @@ func renderPhaseLayout(content string, width, height int, footerHint string) str
 	normalized := lipgloss.NewStyle().Width(contentWidth).Render(content)
 
 	return header + "\n" + contentBox.Render(normalized) + "\n" + footer
+}
+
+func (m Model) renderSetupGuide() string {
+	footerHint := m.setupGuide.footerHint()
+	cardContent := m.setupGuide.viewContent()
+	return renderPhaseLayout(cardContent, m.width, m.height, footerHint)
 }
 
 func (m Model) renderDockerLogs(title, footerHint string) string {

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -1,0 +1,638 @@
+package devtui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+type setupStep int
+
+const (
+	setupStepWelcome setupStep = iota
+	setupStepAdminUser
+	setupStepAdminPassword
+	setupStepDockerPHP
+	setupStepDockerProfiler
+	setupStepProfilerCreds
+	setupStepReview
+	setupStepDone
+)
+
+var (
+	phpVersionChoices = []string{"8.2", "8.3", "8.4", "8.5"}
+	profilerChoices   = []string{"none", "xdebug", "blackfire", "tideways", "pcov", "spx"}
+)
+
+// profilerNeedsCreds reports whether the given profiler choice requires
+// additional credentials to be collected from the user.
+func profilerNeedsCreds(profiler string) bool {
+	return profiler == "blackfire" || profiler == "tideways"
+}
+
+type setupGuide struct {
+	step                 setupStep
+	phpCursor            int
+	profilerCursor       int
+	confirmYes           bool
+	url                  textinput.Model
+	username             textinput.Model
+	password             textinput.Model
+	showPassword         bool
+	blackfireServerID    textinput.Model
+	blackfireServerToken textinput.Model
+	tidewaysAPIKey       textinput.Model
+
+	err error
+}
+
+// setupGuideConfig holds the final configuration values chosen by the user.
+type setupGuideConfig struct {
+	url                  string
+	username             string
+	password             string
+	phpVersion           string
+	profiler             string
+	blackfireServerID    string
+	blackfireServerToken string
+	tidewaysAPIKey       string
+}
+
+func newSetupGuide() setupGuide {
+	urlInput := textinput.New()
+	urlInput.Placeholder = "http://127.0.0.1:8000"
+	urlInput.CharLimit = 256
+	urlInput.Prompt = ""
+	urlInput.SetValue("http://127.0.0.1:8000")
+
+	usernameInput := textinput.New()
+	usernameInput.Placeholder = "admin"
+	usernameInput.CharLimit = 64
+	usernameInput.Prompt = ""
+	usernameInput.SetValue("admin")
+
+	passwordInput := textinput.New()
+	passwordInput.Placeholder = "shopware"
+	passwordInput.CharLimit = 64
+	passwordInput.Prompt = ""
+	passwordInput.EchoMode = textinput.EchoPassword
+	passwordInput.SetValue("shopware")
+
+	blackfireIDInput := textinput.New()
+	blackfireIDInput.Placeholder = "Server ID"
+	blackfireIDInput.CharLimit = 128
+	blackfireIDInput.Prompt = ""
+
+	blackfireTokenInput := textinput.New()
+	blackfireTokenInput.Placeholder = "Server Token"
+	blackfireTokenInput.CharLimit = 128
+	blackfireTokenInput.Prompt = ""
+
+	tidewaysKeyInput := textinput.New()
+	tidewaysKeyInput.Placeholder = "API Key"
+	tidewaysKeyInput.CharLimit = 128
+	tidewaysKeyInput.Prompt = ""
+
+	return setupGuide{
+		step:                 setupStepWelcome,
+		phpCursor:            1, // Default to 8.3
+		profilerCursor:       0, // Default to none
+		confirmYes:           true,
+		url:                  urlInput,
+		username:             usernameInput,
+		password:             passwordInput,
+		blackfireServerID:    blackfireIDInput,
+		blackfireServerToken: blackfireTokenInput,
+		tidewaysAPIKey:       tidewaysKeyInput,
+	}
+}
+
+func (sg *setupGuide) currentConfig() setupGuideConfig {
+	profiler := profilerChoices[sg.profilerCursor]
+	if profiler == "none" {
+		profiler = ""
+	}
+	return setupGuideConfig{
+		url:                  sg.url.Value(),
+		username:             sg.username.Value(),
+		password:             sg.password.Value(),
+		phpVersion:           phpVersionChoices[sg.phpCursor],
+		profiler:             profiler,
+		blackfireServerID:    sg.blackfireServerID.Value(),
+		blackfireServerToken: sg.blackfireServerToken.Value(),
+		tidewaysAPIKey:       sg.tidewaysAPIKey.Value(),
+	}
+}
+
+func (sg *setupGuide) applyToConfig(cfg *shop.Config) {
+	c := sg.currentConfig()
+
+	// Always update compatibility_date to support dev mode
+	cfg.CompatibilityDate = shop.CompatibilityDevMode
+
+	// Set URL at top level for backwards compatibility
+	if cfg.URL == "" {
+		cfg.URL = c.url
+	}
+
+	// Set up local environment as Docker
+	envCfg := &shop.EnvironmentConfig{
+		Type: "docker",
+		URL:  c.url,
+	}
+	if c.username != "" || c.password != "" {
+		envCfg.AdminApi = &shop.ConfigAdminApi{
+			Username: c.username,
+			Password: c.password,
+		}
+	}
+	if cfg.Environments == nil {
+		cfg.Environments = make(map[string]*shop.EnvironmentConfig)
+	}
+	cfg.Environments["local"] = envCfg
+
+	// Set Docker config
+	if cfg.Docker == nil {
+		cfg.Docker = &shop.ConfigDocker{}
+	}
+	if cfg.Docker.PHP == nil {
+		cfg.Docker.PHP = &shop.ConfigDockerPHP{}
+	}
+	cfg.Docker.PHP.Version = c.phpVersion
+	cfg.Docker.PHP.Profiler = c.profiler
+}
+
+// localConfig returns a partial Config containing secrets that should be
+// written to .shopware-project.local.yml. Profilers without external
+// credentials (none, xdebug, pcov, spx) return nil.
+func (sg *setupGuide) localConfig() *shop.Config {
+	c := sg.currentConfig()
+	switch c.profiler {
+	case "blackfire":
+		return &shop.Config{
+			Docker: &shop.ConfigDocker{
+				PHP: &shop.ConfigDockerPHP{
+					BlackfireServerID:    c.blackfireServerID,
+					BlackfireServerToken: c.blackfireServerToken,
+				},
+			},
+		}
+	case "tideways":
+		return &shop.Config{
+			Docker: &shop.ConfigDocker{
+				PHP: &shop.ConfigDockerPHP{
+					TidewaysAPIKey: c.tidewaysAPIKey,
+				},
+			},
+		}
+	}
+	return nil
+}
+
+// update handles key events for the setup guide.
+// Ctrl+C is handled centrally by updateKeyPress, so individual steps
+// should not handle it — they just need to handle their own navigation keys.
+func (sg *setupGuide) update(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	switch sg.step {
+	case setupStepWelcome:
+		return sg.updateWelcome(msg)
+	case setupStepAdminUser:
+		return sg.updateAdminUser(msg)
+	case setupStepAdminPassword:
+		return sg.updateAdminPassword(msg)
+	case setupStepDockerPHP:
+		return sg.updateDockerPHP(msg)
+	case setupStepDockerProfiler:
+		return sg.updateDockerProfiler(msg)
+	case setupStepProfilerCreds:
+		return sg.updateProfilerCreds(msg)
+	case setupStepReview:
+		return sg.updateReview(msg)
+	case setupStepDone:
+		// Handled by updateKeyPress to transition to Docker startup
+		return *sg, nil
+	}
+	return *sg, nil
+}
+
+func (sg *setupGuide) updateWelcome(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	switch msg.String() {
+	case keyLeft, "h":
+		sg.confirmYes = true
+	case keyRight, "l":
+		sg.confirmYes = false
+	case keyTab:
+		sg.confirmYes = !sg.confirmYes
+	case keyEnter:
+		if sg.confirmYes {
+			sg.step = setupStepAdminUser
+			sg.username.Focus()
+			return *sg, textinput.Blink
+		}
+		return *sg, tea.Quit
+	}
+	return *sg, nil
+}
+
+func (sg *setupGuide) updateAdminUser(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	if msg.String() == keyEnter {
+		sg.username.Blur()
+		sg.step = setupStepAdminPassword
+		sg.password.Focus()
+		return *sg, textinput.Blink
+	}
+	var cmd tea.Cmd
+	sg.username, cmd = sg.username.Update(msg)
+	return *sg, cmd
+}
+
+func (sg *setupGuide) updateAdminPassword(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	switch msg.String() {
+	case keyEnter:
+		sg.password.Blur()
+		sg.step = setupStepDockerPHP
+		return *sg, nil
+	case keyTab:
+		sg.showPassword = !sg.showPassword
+		if sg.showPassword {
+			sg.password.EchoMode = textinput.EchoNormal
+		} else {
+			sg.password.EchoMode = textinput.EchoPassword
+		}
+		return *sg, nil
+	}
+	var cmd tea.Cmd
+	sg.password, cmd = sg.password.Update(msg)
+	return *sg, cmd
+}
+
+func (sg *setupGuide) updateDockerPHP(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	switch msg.String() {
+	case keyUp, keyK:
+		if sg.phpCursor > 0 {
+			sg.phpCursor--
+		}
+	case keyDown, keyJ:
+		if sg.phpCursor < len(phpVersionChoices)-1 {
+			sg.phpCursor++
+		}
+	case keyEnter:
+		sg.step = setupStepDockerProfiler
+		return *sg, nil
+	}
+	return *sg, nil
+}
+
+func (sg *setupGuide) updateDockerProfiler(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	switch msg.String() {
+	case keyUp, keyK:
+		if sg.profilerCursor > 0 {
+			sg.profilerCursor--
+		}
+	case keyDown, keyJ:
+		if sg.profilerCursor < len(profilerChoices)-1 {
+			sg.profilerCursor++
+		}
+	case keyEnter:
+		profiler := profilerChoices[sg.profilerCursor]
+		if !profilerNeedsCreds(profiler) {
+			sg.step = setupStepReview
+			return *sg, nil
+		}
+		sg.step = setupStepProfilerCreds
+		switch profiler {
+		case "blackfire":
+			sg.blackfireServerID.Focus()
+		case "tideways":
+			sg.tidewaysAPIKey.Focus()
+		}
+		return *sg, textinput.Blink
+	}
+	return *sg, nil
+}
+
+func (sg *setupGuide) updateProfilerCreds(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	if sg.blackfireServerID.Focused() {
+		if msg.String() == keyEnter {
+			sg.blackfireServerID.Blur()
+			sg.blackfireServerToken.Focus()
+			return *sg, textinput.Blink
+		}
+		var cmd tea.Cmd
+		sg.blackfireServerID, cmd = sg.blackfireServerID.Update(msg)
+		return *sg, cmd
+	}
+
+	if sg.blackfireServerToken.Focused() {
+		if msg.String() == keyEnter {
+			sg.blackfireServerToken.Blur()
+			sg.step = setupStepReview
+			return *sg, nil
+		}
+		var cmd tea.Cmd
+		sg.blackfireServerToken, cmd = sg.blackfireServerToken.Update(msg)
+		return *sg, cmd
+	}
+
+	if sg.tidewaysAPIKey.Focused() {
+		if msg.String() == keyEnter {
+			sg.tidewaysAPIKey.Blur()
+			sg.step = setupStepReview
+			return *sg, nil
+		}
+		var cmd tea.Cmd
+		sg.tidewaysAPIKey, cmd = sg.tidewaysAPIKey.Update(msg)
+		return *sg, cmd
+	}
+
+	return *sg, nil
+}
+
+func (sg *setupGuide) updateReview(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+	switch msg.String() {
+	case keyLeft, "h":
+		sg.confirmYes = true
+	case keyRight, "l":
+		sg.confirmYes = false
+	case keyTab:
+		sg.confirmYes = !sg.confirmYes
+	case keyEnter:
+		return *sg, nil // Handled by updateKeyPress to trigger write
+	}
+	return *sg, nil
+}
+
+func (sg setupGuide) viewContent() string {
+	switch sg.step {
+	case setupStepWelcome:
+		return sg.viewWelcome()
+	case setupStepAdminUser:
+		return sg.viewAdminUser()
+	case setupStepAdminPassword:
+		return sg.viewAdminPassword()
+	case setupStepDockerPHP:
+		return sg.viewDockerPHP()
+	case setupStepDockerProfiler:
+		return sg.viewDockerProfiler()
+	case setupStepProfilerCreds:
+		return sg.viewProfilerCreds()
+	case setupStepReview:
+		return sg.viewReview()
+	case setupStepDone:
+		return sg.viewDone()
+	}
+	return ""
+}
+
+func stepBadge(stepNum, totalSteps int) string {
+	return tui.TextBadge(fmt.Sprintf("Step %d/%d", stepNum, totalSteps))
+}
+
+func (sg setupGuide) totalSteps() int {
+	return 4 // admin, password, docker-php, review
+}
+
+func (sg setupGuide) viewWelcome() string {
+	var b strings.Builder
+	b.WriteString(tui.TextBadge("Setup"))
+	b.WriteString("\n\n")
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(tui.BrandColor).Render("Set up Docker development environment"))
+	b.WriteString("\n\n")
+	b.WriteString(tui.DimStyle.Render("This project needs a development environment configuration"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("before you can use "))
+	b.WriteString(tui.BoldText.Render("shopware-cli project dev"))
+	b.WriteString(tui.DimStyle.Render("."))
+	b.WriteString("\n\n")
+	b.WriteString(tui.DimStyle.Render("The setup will create a Docker-based local environment"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("with the following services:"))
+	b.WriteString("\n\n")
+	b.WriteString(tui.DimStyle.Render("  • ") + valueStyle.Render("Shopware") + tui.DimStyle.Render(" — your shop at http://127.0.0.1:8000"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("  • ") + valueStyle.Render("Adminer") + tui.DimStyle.Render(" — database GUI"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("  • ") + valueStyle.Render("Mailpit") + tui.DimStyle.Render(" — email testing"))
+	b.WriteString("\n\n")
+	b.WriteString(tui.DimStyle.Render("This will create a "))
+	b.WriteString(tui.BoldText.Render(".shopware-project.yml"))
+	b.WriteString(tui.DimStyle.Render(" configuration file."))
+	b.WriteString("\n\n")
+	b.WriteString(renderConfirmButtons("Start setup", "Quit", sg.confirmYes))
+	b.WriteString("\n\n")
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) viewAdminUser() string {
+	var b strings.Builder
+	b.WriteString(stepBadge(1, sg.totalSteps()))
+	b.WriteString("\n\n")
+	b.WriteString(tui.TitleStyle.Render("Admin Username"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("Username for the Shopware admin panel and API access."))
+	b.WriteString("\n\n")
+	b.WriteString(sg.username.View())
+	b.WriteString("\n\n")
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) viewAdminPassword() string {
+	var b strings.Builder
+	b.WriteString(stepBadge(1, sg.totalSteps()))
+	b.WriteString("\n\n")
+	b.WriteString(tui.TitleStyle.Render("Admin Password"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("Password for the Shopware admin panel and API access."))
+	b.WriteString("\n\n")
+	b.WriteString(sg.password.View())
+	b.WriteString("\n\n")
+	b.WriteString(renderShowPasswordCheckbox(sg.showPassword, false))
+	b.WriteString("\n\n")
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) viewDockerPHP() string {
+	var b strings.Builder
+	b.WriteString(stepBadge(2, sg.totalSteps()))
+	b.WriteString("\n\n")
+	b.WriteString(tui.TitleStyle.Render("Docker Configuration"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("Select the PHP version for your Docker containers."))
+	b.WriteString("\n\n")
+
+	opts := make([]tui.SelectOption, len(phpVersionChoices))
+	for i, v := range phpVersionChoices {
+		opts[i] = tui.SelectOption{Label: "PHP " + v}
+	}
+	b.WriteString(tui.RenderSelectList("PHP Version", "", opts, sg.phpCursor))
+	b.WriteString("\n")
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) viewDockerProfiler() string {
+	var b strings.Builder
+	b.WriteString(stepBadge(3, sg.totalSteps()))
+	b.WriteString("\n\n")
+	b.WriteString(tui.TitleStyle.Render("PHP Profiler"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("Optionally enable a profiler for debugging."))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("Can be changed later in the Config tab."))
+	b.WriteString("\n\n")
+
+	opts := make([]tui.SelectOption, len(profilerChoices))
+	for i, p := range profilerChoices {
+		label := p
+		desc := ""
+		switch p {
+		case "none":
+			label = "None"
+			desc = "recommended"
+		case "xdebug":
+			desc = "step debugging"
+		}
+		opts[i] = tui.SelectOption{Label: label, Detail: desc}
+	}
+	b.WriteString(tui.RenderSelectList("Profiler", "", opts, sg.profilerCursor))
+	b.WriteString("\n")
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) viewProfilerCreds() string {
+	var b strings.Builder
+	b.WriteString(stepBadge(4, sg.totalSteps()))
+	b.WriteString("\n\n")
+
+	switch {
+	case sg.blackfireServerID.Focused():
+		b.WriteString(tui.TitleStyle.Render("Blackfire Configuration"))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("Enter your Blackfire Server ID from your Blackfire account."))
+		b.WriteString("\n\n")
+		b.WriteString(sg.blackfireServerID.View())
+	case sg.blackfireServerToken.Focused():
+		b.WriteString(tui.TitleStyle.Render("Blackfire Configuration"))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("Enter your Blackfire Server Token."))
+		b.WriteString("\n\n")
+		b.WriteString(sg.blackfireServerToken.View())
+	case sg.tidewaysAPIKey.Focused():
+		b.WriteString(tui.TitleStyle.Render("Tideways Configuration"))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("Enter your Tideways API key."))
+		b.WriteString("\n\n")
+		b.WriteString(sg.tidewaysAPIKey.View())
+	}
+
+	b.WriteString("\n\n")
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) viewReview() string {
+	c := sg.currentConfig()
+	var b strings.Builder
+	b.WriteString(stepBadge(4, sg.totalSteps()))
+	b.WriteString("\n\n")
+	b.WriteString(tui.TitleStyle.Render("Review Configuration"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("The following configuration will be written."))
+	b.WriteString("\n\n")
+
+	divider := tui.SectionDivider(60)
+	b.WriteString(tui.KVRow("Environment", activeBadgeStyle.Render("Docker")))
+	b.WriteString(tui.KVRow("Shop URL", urlStyle.Render(c.url)))
+	b.WriteString(tui.KVRow("Username", valueStyle.Render(c.username)))
+	b.WriteString(tui.KVRow("Password", secretStyle.Render(strings.Repeat("•", len(c.password)))))
+	b.WriteString(divider)
+	b.WriteString(tui.KVRow("PHP Version", valueStyle.Render("PHP "+c.phpVersion)))
+	profilerLabel := c.profiler
+	if profilerLabel == "" {
+		profilerLabel = "none"
+	}
+	b.WriteString(tui.KVRow("Profiler", valueStyle.Render(profilerLabel)))
+
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("This will create:"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("  • ") + tui.BoldText.Render(".shopware-project.yml"))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("  • ") + tui.BoldText.Render("compose.yaml"))
+	b.WriteString("\n")
+
+	if c.profiler == "blackfire" || c.profiler == "tideways" {
+		b.WriteString(tui.DimStyle.Render("  • ") + tui.BoldText.Render(".shopware-project.local.yml"))
+		b.WriteString(tui.DimStyle.Render(" (secrets only)"))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(renderConfirmButtons("Save & start", "Quit", sg.confirmYes))
+	b.WriteString("\n\n")
+
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) viewDone() string {
+	var b strings.Builder
+	if sg.err != nil {
+		b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(tui.ErrorColor).Render("Configuration failed"))
+		b.WriteString("\n\n")
+		b.WriteString(errorStyle.Render(sg.err.Error()))
+		b.WriteString("\n\n")
+		b.WriteString(tui.DimStyle.Render("You can manually create ") + tui.BoldText.Render(".shopware-project.yml"))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("or try again with shopware-cli project dev"))
+	} else {
+		b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(tui.SuccessColor).Render("✓ Configuration saved"))
+		b.WriteString("\n\n")
+		b.WriteString(tui.DimStyle.Render("Your project is now configured for Docker development."))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("The environment will start on the next screen."))
+	}
+	b.WriteString("\n\n")
+	return tui.RenderPhaseCard(b.String())
+}
+
+func (sg setupGuide) footerHint() string {
+	// phaseHeaderFooter always appends a "ctrl+c Exit" badge, so don't
+	// repeat it here.
+	switch sg.step {
+	case setupStepWelcome:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "←/→", Label: "Select"},
+			tui.Shortcut{Key: "enter", Label: "Confirm"},
+		)
+	case setupStepAdminUser:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "enter", Label: "Continue"},
+		)
+	case setupStepAdminPassword:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "tab", Label: "Show password"},
+			tui.Shortcut{Key: "enter", Label: "Continue"},
+		)
+	case setupStepDockerPHP, setupStepDockerProfiler:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "↑/↓", Label: "Select"},
+			tui.Shortcut{Key: "enter", Label: "Continue"},
+		)
+	case setupStepProfilerCreds:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "enter", Label: "Continue"},
+		)
+	case setupStepReview:
+		return tui.ShortcutBar(
+			tui.Shortcut{Key: "←/→", Label: "Select"},
+			tui.Shortcut{Key: "enter", Label: "Confirm"},
+		)
+	case setupStepDone:
+		return tui.ShortcutBar(tui.Shortcut{Key: "enter", Label: "Continue"})
+	}
+	return ""
+}

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -2,6 +2,7 @@ package devtui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -37,19 +38,20 @@ func profilerNeedsCreds(profiler string) bool {
 }
 
 type setupGuide struct {
-	step                 setupStep
-	phpVersions          []string // PHP versions compatible with the project
-	phpConstraint        string   // raw constraint string, for display ("" if none)
-	phpCursor            int
-	profilerCursor       int
-	confirmYes           bool
-	url                  textinput.Model
-	username             textinput.Model
-	password             textinput.Model
-	showPassword         bool
-	blackfireServerID    textinput.Model
-	blackfireServerToken textinput.Model
-	tidewaysAPIKey       textinput.Model
+	step                  setupStep
+	phpVersions           []string // PHP versions compatible with the project
+	phpConstraint         string   // raw constraint string, for display ("" if none)
+	phpCursor             int
+	profilerCursor        int
+	confirmYes            bool
+	deploymentHelperAdded bool // composer.json was updated to require shopware/deployment-helper
+	url                   textinput.Model
+	username              textinput.Model
+	password              textinput.Model
+	showPassword          bool
+	blackfireServerID     textinput.Model
+	blackfireServerToken  textinput.Model
+	tidewaysAPIKey        textinput.Model
 
 	err error
 }
@@ -204,6 +206,45 @@ func (sg *setupGuide) applyToConfig(cfg *shop.Config) {
 	}
 	cfg.Docker.PHP.Version = c.phpVersion
 	cfg.Docker.PHP.Profiler = c.profiler
+}
+
+// ensureDeploymentHelper adds shopware/deployment-helper to the project's
+// composer.json require block when it's missing. New projects created via
+// `shopware-cli project create` pin this package; older projects being
+// migrated to dev mode need it added so devtui can run
+// `vendor/bin/shopware-deployment-helper`.
+//
+// Returns true when composer.json was changed and the user should re-run
+// `composer install` (or `composer update`) to pull the package in.
+// Errors reading or writing composer.json are returned to the caller;
+// a missing composer.json is treated as nothing-to-do (returns false, nil).
+func ensureDeploymentHelper(projectRoot string) (changed bool, err error) {
+	composerPath := filepath.Join(projectRoot, "composer.json")
+	if _, statErr := os.Stat(composerPath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, statErr
+	}
+
+	cj, err := packagist.ReadComposerJson(composerPath)
+	if err != nil {
+		return false, err
+	}
+
+	if cj.HasPackage("shopware/deployment-helper") || cj.HasPackageDev("shopware/deployment-helper") {
+		return false, nil
+	}
+
+	if cj.Require == nil {
+		cj.Require = packagist.ComposerPackageLink{}
+	}
+	cj.Require["shopware/deployment-helper"] = "*"
+
+	if err := cj.Save(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // localConfig returns a partial Config containing secrets that should be
@@ -670,6 +711,20 @@ func (sg setupGuide) viewDone() string {
 		b.WriteString(tui.DimStyle.Render("Your project is now configured for Docker development."))
 		b.WriteString("\n")
 		b.WriteString(tui.DimStyle.Render("The environment will start on the next screen."))
+
+		if sg.deploymentHelperAdded {
+			b.WriteString("\n\n")
+			b.WriteString(tui.BoldText.Render("Note: "))
+			b.WriteString(tui.DimStyle.Render("Added "))
+			b.WriteString(valueStyle.Render("shopware/deployment-helper"))
+			b.WriteString(tui.DimStyle.Render(" to "))
+			b.WriteString(tui.BoldText.Render("composer.json"))
+			b.WriteString(tui.DimStyle.Render("."))
+			b.WriteString("\n")
+			b.WriteString(tui.DimStyle.Render("Run "))
+			b.WriteString(tui.BoldText.Render("composer update shopware/deployment-helper"))
+			b.WriteString(tui.DimStyle.Render(" before installing Shopware."))
+		}
 	}
 	b.WriteString("\n\n")
 	return tui.RenderPhaseCard(b.String())

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -2,12 +2,15 @@ package devtui
 
 import (
 	"fmt"
+	"path/filepath"
+	"slices"
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/shopware/shopware-cli/internal/packagist"
 	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
@@ -25,10 +28,7 @@ const (
 	setupStepDone
 )
 
-var (
-	phpVersionChoices = []string{"8.2", "8.3", "8.4", "8.5"}
-	profilerChoices   = []string{"none", "xdebug", "blackfire", "tideways", "pcov", "spx"}
-)
+var profilerChoices = []string{"none", "xdebug", "blackfire", "tideways", "pcov", "spx"}
 
 // profilerNeedsCreds reports whether the given profiler choice requires
 // additional credentials to be collected from the user.
@@ -38,6 +38,8 @@ func profilerNeedsCreds(profiler string) bool {
 
 type setupGuide struct {
 	step                 setupStep
+	phpVersions          []string // PHP versions compatible with the project
+	phpConstraint        string   // raw constraint string, for display ("" if none)
 	phpCursor            int
 	profilerCursor       int
 	confirmYes           bool
@@ -64,7 +66,39 @@ type setupGuideConfig struct {
 	tidewaysAPIKey       string
 }
 
-func newSetupGuide() setupGuide {
+// resolvePHPVersions reads composer.lock from projectRoot and returns the
+// supported PHP versions that satisfy shopware/core (or shopware/platform)'s
+// require.php, the index of the highest compatible version (best default),
+// and the raw constraint string for display. If composer.lock is missing or
+// the Shopware package declares no PHP requirement, all SupportedPHPVersions
+// are returned.
+func resolvePHPVersions(projectRoot string) (versions []string, defaultIdx int, constraint string) {
+	versions = append([]string(nil), packagist.SupportedPHPVersions...)
+	defaultIdx = len(versions) - 1
+
+	lock, err := packagist.ReadComposerLock(filepath.Join(projectRoot, "composer.lock"))
+	if err != nil {
+		return versions, defaultIdx, ""
+	}
+
+	c := lock.ShopwarePHPConstraint()
+	if c == nil {
+		return versions, defaultIdx, ""
+	}
+
+	filtered := c.SupportedVersions()
+	if len(filtered) == 0 {
+		return versions, defaultIdx, c.String()
+	}
+
+	idx := slices.Index(filtered, c.HighestSupported())
+	if idx < 0 {
+		idx = len(filtered) - 1
+	}
+	return filtered, idx, c.String()
+}
+
+func newSetupGuide(projectRoot string) setupGuide {
 	urlInput := textinput.New()
 	urlInput.Placeholder = "http://127.0.0.1:8000"
 	urlInput.CharLimit = 256
@@ -99,9 +133,13 @@ func newSetupGuide() setupGuide {
 	tidewaysKeyInput.CharLimit = 128
 	tidewaysKeyInput.Prompt = ""
 
+	phpVersions, phpCursor, phpConstraint := resolvePHPVersions(projectRoot)
+
 	return setupGuide{
 		step:                 setupStepWelcome,
-		phpCursor:            1, // Default to 8.3
+		phpVersions:          phpVersions,
+		phpConstraint:        phpConstraint,
+		phpCursor:            phpCursor,
 		profilerCursor:       0, // Default to none
 		confirmYes:           true,
 		url:                  urlInput,
@@ -122,7 +160,7 @@ func (sg *setupGuide) currentConfig() setupGuideConfig {
 		url:                  sg.url.Value(),
 		username:             sg.username.Value(),
 		password:             sg.password.Value(),
-		phpVersion:           phpVersionChoices[sg.phpCursor],
+		phpVersion:           sg.phpVersions[sg.phpCursor],
 		profiler:             profiler,
 		blackfireServerID:    sg.blackfireServerID.Value(),
 		blackfireServerToken: sg.blackfireServerToken.Value(),
@@ -279,7 +317,7 @@ func (sg *setupGuide) updateDockerPHP(msg tea.KeyPressMsg) (setupGuide, tea.Cmd)
 			sg.phpCursor--
 		}
 	case keyDown, keyJ:
-		if sg.phpCursor < len(phpVersionChoices)-1 {
+		if sg.phpCursor < len(sg.phpVersions)-1 {
 			sg.phpCursor++
 		}
 	case keyEnter:
@@ -497,10 +535,15 @@ func (sg setupGuide) viewDockerPHP() string {
 	b.WriteString(tui.TitleStyle.Render("Docker Configuration"))
 	b.WriteString("\n")
 	b.WriteString(tui.DimStyle.Render("Select the PHP version for your Docker containers."))
+	if sg.phpConstraint != "" {
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("Filtered by shopware/core require.php: "))
+		b.WriteString(valueStyle.Render(sg.phpConstraint))
+	}
 	b.WriteString("\n\n")
 
-	opts := make([]tui.SelectOption, len(phpVersionChoices))
-	for i, v := range phpVersionChoices {
+	opts := make([]tui.SelectOption, len(sg.phpVersions))
+	for i, v := range sg.phpVersions {
 		opts[i] = tui.SelectOption{Label: "PHP " + v}
 	}
 	b.WriteString(tui.RenderSelectList("PHP Version", "", opts, sg.phpCursor))

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -394,8 +394,41 @@ func stepBadge(stepNum, totalSteps int) string {
 	return tui.TextBadge(fmt.Sprintf("Step %d/%d", stepNum, totalSteps))
 }
 
+// totalSteps returns the number of numbered wizard steps. The profiler
+// credentials step is only counted when the chosen profiler needs them.
 func (sg setupGuide) totalSteps() int {
-	return 4 // admin, password, docker-php, review
+	// admin user, admin password, PHP version, profiler, review
+	total := 5
+	if profilerNeedsCreds(profilerChoices[sg.profilerCursor]) {
+		total++
+	}
+	return total
+}
+
+// stepNum returns the 1-based index of the given wizard step within the
+// currently active step sequence. Steps outside the numbered sequence
+// (welcome, done) return 0.
+func (sg setupGuide) stepNum(step setupStep) int {
+	switch step {
+	case setupStepAdminUser:
+		return 1
+	case setupStepAdminPassword:
+		return 2
+	case setupStepDockerPHP:
+		return 3
+	case setupStepDockerProfiler:
+		return 4
+	case setupStepProfilerCreds:
+		return 5
+	case setupStepReview:
+		if profilerNeedsCreds(profilerChoices[sg.profilerCursor]) {
+			return 6
+		}
+		return 5
+	case setupStepWelcome, setupStepDone:
+		return 0
+	}
+	return 0
 }
 
 func (sg setupGuide) viewWelcome() string {
@@ -426,12 +459,12 @@ func (sg setupGuide) viewWelcome() string {
 	b.WriteString("\n\n")
 	b.WriteString(renderConfirmButtons("Start setup", "Quit", sg.confirmYes))
 	b.WriteString("\n\n")
-	return tui.RenderPhaseCard(b.String())
+	return tui.RenderPhaseCardCowsay("Let me help you to set up Docker!", b.String())
 }
 
 func (sg setupGuide) viewAdminUser() string {
 	var b strings.Builder
-	b.WriteString(stepBadge(1, sg.totalSteps()))
+	b.WriteString(stepBadge(sg.stepNum(setupStepAdminUser), sg.totalSteps()))
 	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Admin Username"))
 	b.WriteString("\n")
@@ -444,7 +477,7 @@ func (sg setupGuide) viewAdminUser() string {
 
 func (sg setupGuide) viewAdminPassword() string {
 	var b strings.Builder
-	b.WriteString(stepBadge(1, sg.totalSteps()))
+	b.WriteString(stepBadge(sg.stepNum(setupStepAdminPassword), sg.totalSteps()))
 	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Admin Password"))
 	b.WriteString("\n")
@@ -459,7 +492,7 @@ func (sg setupGuide) viewAdminPassword() string {
 
 func (sg setupGuide) viewDockerPHP() string {
 	var b strings.Builder
-	b.WriteString(stepBadge(2, sg.totalSteps()))
+	b.WriteString(stepBadge(sg.stepNum(setupStepDockerPHP), sg.totalSteps()))
 	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Docker Configuration"))
 	b.WriteString("\n")
@@ -477,7 +510,7 @@ func (sg setupGuide) viewDockerPHP() string {
 
 func (sg setupGuide) viewDockerProfiler() string {
 	var b strings.Builder
-	b.WriteString(stepBadge(3, sg.totalSteps()))
+	b.WriteString(stepBadge(sg.stepNum(setupStepDockerProfiler), sg.totalSteps()))
 	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("PHP Profiler"))
 	b.WriteString("\n")
@@ -506,7 +539,7 @@ func (sg setupGuide) viewDockerProfiler() string {
 
 func (sg setupGuide) viewProfilerCreds() string {
 	var b strings.Builder
-	b.WriteString(stepBadge(4, sg.totalSteps()))
+	b.WriteString(stepBadge(sg.stepNum(setupStepProfilerCreds), sg.totalSteps()))
 	b.WriteString("\n\n")
 
 	switch {
@@ -537,7 +570,7 @@ func (sg setupGuide) viewProfilerCreds() string {
 func (sg setupGuide) viewReview() string {
 	c := sg.currentConfig()
 	var b strings.Builder
-	b.WriteString(stepBadge(4, sg.totalSteps()))
+	b.WriteString(stepBadge(sg.stepNum(setupStepReview), sg.totalSteps()))
 	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Review Configuration"))
 	b.WriteString("\n")

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -46,6 +46,67 @@ func TestResolvePHPVersions_NoMatchingVersionsFallsBackToAll(t *testing.T) {
 	assert.Equal(t, "^9.0", constraint)
 }
 
+func TestEnsureDeploymentHelper_AddsWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	composer := `{
+  "name": "shopware/production",
+  "require": {
+    "shopware/core": "^6.6"
+  }
+}`
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0o644))
+
+	changed, err := ensureDeploymentHelper(dir)
+	assert.NoError(t, err)
+	assert.True(t, changed)
+
+	// Verify it was actually written
+	out, err := os.ReadFile(filepath.Join(dir, "composer.json"))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), `"shopware/deployment-helper": "*"`)
+}
+
+func TestEnsureDeploymentHelper_NoOpWhenAlreadyInRequire(t *testing.T) {
+	dir := t.TempDir()
+	composer := `{
+  "name": "shopware/production",
+  "require": {
+    "shopware/core": "^6.6",
+    "shopware/deployment-helper": "^1.0"
+  }
+}`
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0o644))
+
+	changed, err := ensureDeploymentHelper(dir)
+	assert.NoError(t, err)
+	assert.False(t, changed)
+
+	// Existing pin must not be overwritten
+	out, err := os.ReadFile(filepath.Join(dir, "composer.json"))
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), `"shopware/deployment-helper": "^1.0"`)
+}
+
+func TestEnsureDeploymentHelper_NoOpWhenInRequireDev(t *testing.T) {
+	dir := t.TempDir()
+	composer := `{
+  "name": "shopware/production",
+  "require": {"shopware/core": "^6.6"},
+  "require-dev": {"shopware/deployment-helper": "^1.0"}
+}`
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0o644))
+
+	changed, err := ensureDeploymentHelper(dir)
+	assert.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestEnsureDeploymentHelper_MissingComposerJson(t *testing.T) {
+	changed, err := ensureDeploymentHelper(t.TempDir())
+	assert.NoError(t, err)
+	assert.False(t, changed)
+}
+
 func TestResolvePHPVersions_PlatformFallback(t *testing.T) {
 	dir := t.TempDir()
 	content := `{"packages":[{"name":"shopware/platform","version":"v6.5.0.0","require":{"php":">=8.2"}}]}`

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -1,0 +1,231 @@
+package devtui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+func TestNewSetupGuide(t *testing.T) {
+	sg := newSetupGuide()
+	assert.Equal(t, setupStepWelcome, sg.step)
+	assert.Equal(t, 1, sg.phpCursor)      // Default to 8.3
+	assert.Equal(t, 0, sg.profilerCursor) // Default to none
+	assert.True(t, sg.confirmYes)
+	assert.Equal(t, "http://127.0.0.1:8000", sg.url.Value())
+	assert.Equal(t, "admin", sg.username.Value())
+	assert.Equal(t, "shopware", sg.password.Value())
+}
+
+func TestSetupGuideCurrentConfig(t *testing.T) {
+	sg := newSetupGuide()
+	sg.phpCursor = 2      // 8.4
+	sg.profilerCursor = 0 // none
+
+	c := sg.currentConfig()
+	assert.Equal(t, "http://127.0.0.1:8000", c.url)
+	assert.Equal(t, "admin", c.username)
+	assert.Equal(t, "shopware", c.password)
+	assert.Equal(t, "8.4", c.phpVersion)
+	assert.Equal(t, "", c.profiler) // none -> ""
+}
+
+func TestSetupGuideCurrentConfig_Xdebug(t *testing.T) {
+	sg := newSetupGuide()
+	sg.profilerCursor = 1 // xdebug
+
+	c := sg.currentConfig()
+	assert.Equal(t, "xdebug", c.profiler)
+}
+
+func TestSetupGuideApplyToConfig(t *testing.T) {
+	cfg := &shop.Config{}
+	sg := newSetupGuide()
+	sg.phpCursor = 2 // 8.4
+
+	sg.applyToConfig(cfg)
+
+	assert.Equal(t, shop.CompatibilityDevMode, cfg.CompatibilityDate)
+	assert.Equal(t, "http://127.0.0.1:8000", cfg.URL)
+	assert.NotNil(t, cfg.Environments)
+	assert.NotNil(t, cfg.Environments["local"])
+	assert.Equal(t, "docker", cfg.Environments["local"].Type)
+	assert.Equal(t, "http://127.0.0.1:8000", cfg.Environments["local"].URL)
+	assert.NotNil(t, cfg.Environments["local"].AdminApi)
+	assert.Equal(t, "admin", cfg.Environments["local"].AdminApi.Username)
+	assert.Equal(t, "shopware", cfg.Environments["local"].AdminApi.Password)
+	assert.NotNil(t, cfg.Docker)
+	assert.NotNil(t, cfg.Docker.PHP)
+	assert.Equal(t, "8.4", cfg.Docker.PHP.Version)
+	assert.Equal(t, "", cfg.Docker.PHP.Profiler)
+}
+
+func TestSetupGuideApplyToConfig_PreservesExistingURL(t *testing.T) {
+	cfg := &shop.Config{URL: "https://myshop.example.com"}
+	sg := newSetupGuide()
+
+	sg.applyToConfig(cfg)
+
+	// Should preserve existing URL at top level
+	assert.Equal(t, "https://myshop.example.com", cfg.URL)
+	// But local env still uses the default
+	assert.Equal(t, "http://127.0.0.1:8000", cfg.Environments["local"].URL)
+}
+
+func TestSetupGuideLocalConfig_None(t *testing.T) {
+	sg := newSetupGuide()
+	sg.profilerCursor = 0 // none
+
+	assert.Nil(t, sg.localConfig())
+}
+
+func TestSetupGuideLocalConfig_Blackfire(t *testing.T) {
+	sg := newSetupGuide()
+	sg.profilerCursor = 2 // blackfire
+	sg.blackfireServerID.SetValue("my-id")
+	sg.blackfireServerToken.SetValue("my-token")
+
+	localCfg := sg.localConfig()
+	assert.NotNil(t, localCfg)
+	assert.Equal(t, "my-id", localCfg.Docker.PHP.BlackfireServerID)
+	assert.Equal(t, "my-token", localCfg.Docker.PHP.BlackfireServerToken)
+}
+
+func TestSetupGuideLocalConfig_Tideways(t *testing.T) {
+	sg := newSetupGuide()
+	sg.profilerCursor = 3 // tideways
+	sg.tidewaysAPIKey.SetValue("my-key")
+
+	localCfg := sg.localConfig()
+	assert.NotNil(t, localCfg)
+	assert.Equal(t, "my-key", localCfg.Docker.PHP.TidewaysAPIKey)
+}
+
+func TestSetupGuideViewSteps(t *testing.T) {
+	sg := newSetupGuide()
+
+	// Welcome should render without panic
+	view := sg.viewContent()
+	assert.Contains(t, view, "Docker")
+
+	sg.step = setupStepAdminUser
+	sg.username.Focus()
+	view = sg.viewContent()
+	assert.Contains(t, view, "Step")
+
+	sg.step = setupStepAdminPassword
+	sg.password.Focus()
+	view = sg.viewContent()
+	assert.Contains(t, view, "Password")
+
+	sg.step = setupStepDockerPHP
+	view = sg.viewContent()
+	assert.Contains(t, view, "PHP")
+
+	sg.step = setupStepDockerProfiler
+	view = sg.viewContent()
+	assert.Contains(t, view, "Profiler")
+
+	sg.step = setupStepReview
+	view = sg.viewContent()
+	assert.Contains(t, view, "Review")
+
+	sg.step = setupStepDone
+	view = sg.viewContent()
+	assert.Contains(t, view, "saved")
+}
+
+func TestSetupGuideWelcomeDefaultConfirmYes(t *testing.T) {
+	suggest := newSetupGuide()
+	assert.True(t, suggest.confirmYes)
+}
+
+func TestSetupGuideProfiler_NoneSkipsCredsStep(t *testing.T) {
+	sg := newSetupGuide()
+	sg.step = setupStepDockerProfiler
+	sg.profilerCursor = 0 // none
+
+	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, setupStepReview, next.step)
+	assert.False(t, next.blackfireServerID.Focused())
+	assert.False(t, next.tidewaysAPIKey.Focused())
+}
+
+func TestSetupGuideProfiler_BlackfireRoutesToCredsAndFocusesID(t *testing.T) {
+	sg := newSetupGuide()
+	sg.step = setupStepDockerProfiler
+	sg.profilerCursor = 2 // blackfire
+
+	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, setupStepProfilerCreds, next.step)
+	assert.True(t, next.blackfireServerID.Focused())
+	assert.False(t, next.blackfireServerToken.Focused())
+}
+
+func TestSetupGuideProfiler_TidewaysRoutesToCredsAndFocusesKey(t *testing.T) {
+	sg := newSetupGuide()
+	sg.step = setupStepDockerProfiler
+	sg.profilerCursor = 3 // tideways
+
+	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, setupStepProfilerCreds, next.step)
+	assert.True(t, next.tidewaysAPIKey.Focused())
+}
+
+func TestSetupGuideProfiler_BlackfireCredsAdvanceThroughInputs(t *testing.T) {
+	sg := newSetupGuide()
+	sg.step = setupStepDockerProfiler
+	sg.profilerCursor = 2 // blackfire
+
+	// Enter on profiler step → focuses Server ID
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.True(t, sg.blackfireServerID.Focused())
+
+	// Enter advances ID → Token
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.False(t, sg.blackfireServerID.Focused())
+	assert.True(t, sg.blackfireServerToken.Focused())
+	assert.Equal(t, setupStepProfilerCreds, sg.step)
+
+	// Enter on Token advances to Review
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.False(t, sg.blackfireServerToken.Focused())
+	assert.Equal(t, setupStepReview, sg.step)
+}
+
+func TestSetupGuideProfiler_TidewaysCredsAdvanceToReview(t *testing.T) {
+	sg := newSetupGuide()
+	sg.step = setupStepDockerProfiler
+	sg.profilerCursor = 3 // tideways
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.True(t, sg.tidewaysAPIKey.Focused())
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.False(t, sg.tidewaysAPIKey.Focused())
+	assert.Equal(t, setupStepReview, sg.step)
+}
+
+func TestSetupGuideViewProfilerCreds(t *testing.T) {
+	sg := newSetupGuide()
+	sg.step = setupStepProfilerCreds
+	sg.profilerCursor = 2 // blackfire
+	sg.blackfireServerID.Focus()
+
+	view := sg.viewContent()
+	assert.Contains(t, view, "Blackfire")
+	assert.Contains(t, view, "Server ID")
+}
+
+func TestProfilerNeedsCreds(t *testing.T) {
+	assert.False(t, profilerNeedsCreds("none"))
+	assert.False(t, profilerNeedsCreds(""))
+	assert.False(t, profilerNeedsCreds("xdebug"))
+	assert.False(t, profilerNeedsCreds("pcov"))
+	assert.False(t, profilerNeedsCreds("spx"))
+	assert.True(t, profilerNeedsCreds("blackfire"))
+	assert.True(t, profilerNeedsCreds("tideways"))
+}

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
 )
 
@@ -44,6 +45,92 @@ func TestResolvePHPVersions_NoMatchingVersionsFallsBackToAll(t *testing.T) {
 	assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, versions)
 	assert.Equal(t, len(versions)-1, idx)
 	assert.Equal(t, "^9.0", constraint)
+}
+
+func TestSetupGuideReview_QuitButtonQuits(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepReview
+	sg.confirmYes = false // user selected the "Quit" button
+
+	m := Model{
+		phase:      phaseSetupGuide,
+		setupGuide: sg,
+		config:     &shop.Config{},
+		watchers:   make(map[string]*executor.Process),
+	}
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.NotNil(t, cmd, "Enter on Quit button should yield a cmd")
+	_, isQuit := cmd().(tea.QuitMsg)
+	assert.True(t, isQuit, "Enter on Quit button should emit tea.QuitMsg")
+}
+
+func TestSetupGuideReview_SaveButtonDoesNotQuit(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepReview
+	sg.confirmYes = true // user selected "Save & start"
+
+	m := Model{
+		phase:       phaseSetupGuide,
+		setupGuide:  sg,
+		config:      &shop.Config{},
+		projectRoot: t.TempDir(),
+		watchers:    make(map[string]*executor.Process),
+	}
+
+	updated, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	// Should have transitioned to the done step, not quit.
+	if cmd != nil {
+		_, isQuit := cmd().(tea.QuitMsg)
+		assert.False(t, isQuit, "Save button must not quit")
+	}
+	assert.Equal(t, setupStepDone, updated.(Model).setupGuide.step)
+}
+
+func TestMergeLocalProfilerSecrets(t *testing.T) {
+	t.Run("copies blackfire and tideways onto runtime config", func(t *testing.T) {
+		dst := &shop.Config{
+			Docker: &shop.ConfigDocker{
+				PHP: &shop.ConfigDockerPHP{Version: "8.3", Profiler: "blackfire"},
+			},
+		}
+		src := &shop.Config{
+			Docker: &shop.ConfigDocker{
+				PHP: &shop.ConfigDockerPHP{
+					BlackfireServerID:    "id",
+					BlackfireServerToken: "token",
+					TidewaysAPIKey:       "key",
+				},
+			},
+		}
+		mergeLocalProfilerSecrets(dst, src)
+		assert.Equal(t, "id", dst.Docker.PHP.BlackfireServerID)
+		assert.Equal(t, "token", dst.Docker.PHP.BlackfireServerToken)
+		assert.Equal(t, "key", dst.Docker.PHP.TidewaysAPIKey)
+		// non-secret fields stay untouched
+		assert.Equal(t, "8.3", dst.Docker.PHP.Version)
+		assert.Equal(t, "blackfire", dst.Docker.PHP.Profiler)
+	})
+
+	t.Run("creates intermediate structs when missing on dst", func(t *testing.T) {
+		dst := &shop.Config{}
+		src := &shop.Config{
+			Docker: &shop.ConfigDocker{
+				PHP: &shop.ConfigDockerPHP{TidewaysAPIKey: "key"},
+			},
+		}
+		mergeLocalProfilerSecrets(dst, src)
+		assert.NotNil(t, dst.Docker)
+		assert.NotNil(t, dst.Docker.PHP)
+		assert.Equal(t, "key", dst.Docker.PHP.TidewaysAPIKey)
+	})
+
+	t.Run("nil src is a no-op", func(t *testing.T) {
+		dst := &shop.Config{Docker: &shop.ConfigDocker{PHP: &shop.ConfigDockerPHP{Version: "8.4"}}}
+		mergeLocalProfilerSecrets(dst, nil)
+		assert.Equal(t, "8.4", dst.Docker.PHP.Version)
+		assert.Empty(t, dst.Docker.PHP.BlackfireServerID)
+	})
 }
 
 func TestEnsureDeploymentHelper_AddsWhenMissing(t *testing.T) {

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -220,6 +220,27 @@ func TestSetupGuideViewProfilerCreds(t *testing.T) {
 	assert.Contains(t, view, "Server ID")
 }
 
+func TestSetupGuideStepNumbering_NoProfilerCreds(t *testing.T) {
+	sg := newSetupGuide()
+	sg.profilerCursor = 0 // none → no creds step
+	assert.Equal(t, 5, sg.totalSteps())
+	assert.Equal(t, 1, sg.stepNum(setupStepAdminUser))
+	assert.Equal(t, 2, sg.stepNum(setupStepAdminPassword))
+	assert.Equal(t, 3, sg.stepNum(setupStepDockerPHP))
+	assert.Equal(t, 4, sg.stepNum(setupStepDockerProfiler))
+	assert.Equal(t, 5, sg.stepNum(setupStepReview))
+	assert.Equal(t, 0, sg.stepNum(setupStepWelcome))
+	assert.Equal(t, 0, sg.stepNum(setupStepDone))
+}
+
+func TestSetupGuideStepNumbering_WithProfilerCreds(t *testing.T) {
+	sg := newSetupGuide()
+	sg.profilerCursor = 2 // blackfire → adds creds step
+	assert.Equal(t, 6, sg.totalSteps())
+	assert.Equal(t, 5, sg.stepNum(setupStepProfilerCreds))
+	assert.Equal(t, 6, sg.stepNum(setupStepReview))
+}
+
 func TestProfilerNeedsCreds(t *testing.T) {
 	assert.False(t, profilerNeedsCreds("none"))
 	assert.False(t, profilerNeedsCreds(""))

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -1,6 +1,8 @@
 package devtui
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -9,10 +11,57 @@ import (
 	"github.com/shopware/shopware-cli/internal/shop"
 )
 
+func writeLockWithCore(t *testing.T, dir, phpRequire string) {
+	t.Helper()
+	content := `{"packages":[{"name":"shopware/core","version":"v6.6.10.0","require":{"php":"` + phpRequire + `"}}]}`
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(content), 0o644))
+}
+
+func TestResolvePHPVersions_NoLockFile(t *testing.T) {
+	versions, idx, constraint := resolvePHPVersions(t.TempDir())
+	assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, versions)
+	assert.Equal(t, len(versions)-1, idx)
+	assert.Empty(t, constraint)
+}
+
+func TestResolvePHPVersions_FiltersByShopwareCore(t *testing.T) {
+	dir := t.TempDir()
+	writeLockWithCore(t, dir, "~8.2.0 || ~8.3.0")
+
+	versions, idx, constraint := resolvePHPVersions(dir)
+	assert.Equal(t, []string{"8.2", "8.3"}, versions)
+	assert.Equal(t, 1, idx) // highest compatible
+	assert.Equal(t, "~8.2.0 || ~8.3.0", constraint)
+}
+
+func TestResolvePHPVersions_NoMatchingVersionsFallsBackToAll(t *testing.T) {
+	dir := t.TempDir()
+	writeLockWithCore(t, dir, "^9.0")
+
+	versions, idx, constraint := resolvePHPVersions(dir)
+	// Constraint matches nothing → fall back to the full list so the user
+	// can still pick something.
+	assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, versions)
+	assert.Equal(t, len(versions)-1, idx)
+	assert.Equal(t, "^9.0", constraint)
+}
+
+func TestResolvePHPVersions_PlatformFallback(t *testing.T) {
+	dir := t.TempDir()
+	content := `{"packages":[{"name":"shopware/platform","version":"v6.5.0.0","require":{"php":">=8.2"}}]}`
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(content), 0o644))
+
+	versions, _, constraint := resolvePHPVersions(dir)
+	assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, versions)
+	assert.Equal(t, ">=8.2", constraint)
+}
+
 func TestNewSetupGuide(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	assert.Equal(t, setupStepWelcome, sg.step)
-	assert.Equal(t, 1, sg.phpCursor)      // Default to 8.3
+	// Without a composer.lock the wizard offers every supported PHP version
+	// and defaults the cursor to the highest.
+	assert.Equal(t, len(sg.phpVersions)-1, sg.phpCursor)
 	assert.Equal(t, 0, sg.profilerCursor) // Default to none
 	assert.True(t, sg.confirmYes)
 	assert.Equal(t, "http://127.0.0.1:8000", sg.url.Value())
@@ -21,7 +70,7 @@ func TestNewSetupGuide(t *testing.T) {
 }
 
 func TestSetupGuideCurrentConfig(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.phpCursor = 2      // 8.4
 	sg.profilerCursor = 0 // none
 
@@ -34,7 +83,7 @@ func TestSetupGuideCurrentConfig(t *testing.T) {
 }
 
 func TestSetupGuideCurrentConfig_Xdebug(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.profilerCursor = 1 // xdebug
 
 	c := sg.currentConfig()
@@ -43,7 +92,7 @@ func TestSetupGuideCurrentConfig_Xdebug(t *testing.T) {
 
 func TestSetupGuideApplyToConfig(t *testing.T) {
 	cfg := &shop.Config{}
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.phpCursor = 2 // 8.4
 
 	sg.applyToConfig(cfg)
@@ -65,7 +114,7 @@ func TestSetupGuideApplyToConfig(t *testing.T) {
 
 func TestSetupGuideApplyToConfig_PreservesExistingURL(t *testing.T) {
 	cfg := &shop.Config{URL: "https://myshop.example.com"}
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 
 	sg.applyToConfig(cfg)
 
@@ -76,14 +125,14 @@ func TestSetupGuideApplyToConfig_PreservesExistingURL(t *testing.T) {
 }
 
 func TestSetupGuideLocalConfig_None(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.profilerCursor = 0 // none
 
 	assert.Nil(t, sg.localConfig())
 }
 
 func TestSetupGuideLocalConfig_Blackfire(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.profilerCursor = 2 // blackfire
 	sg.blackfireServerID.SetValue("my-id")
 	sg.blackfireServerToken.SetValue("my-token")
@@ -95,7 +144,7 @@ func TestSetupGuideLocalConfig_Blackfire(t *testing.T) {
 }
 
 func TestSetupGuideLocalConfig_Tideways(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.profilerCursor = 3 // tideways
 	sg.tidewaysAPIKey.SetValue("my-key")
 
@@ -105,7 +154,7 @@ func TestSetupGuideLocalConfig_Tideways(t *testing.T) {
 }
 
 func TestSetupGuideViewSteps(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 
 	// Welcome should render without panic
 	view := sg.viewContent()
@@ -139,12 +188,12 @@ func TestSetupGuideViewSteps(t *testing.T) {
 }
 
 func TestSetupGuideWelcomeDefaultConfirmYes(t *testing.T) {
-	suggest := newSetupGuide()
+	suggest := newSetupGuide("")
 	assert.True(t, suggest.confirmYes)
 }
 
 func TestSetupGuideProfiler_NoneSkipsCredsStep(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.step = setupStepDockerProfiler
 	sg.profilerCursor = 0 // none
 
@@ -155,7 +204,7 @@ func TestSetupGuideProfiler_NoneSkipsCredsStep(t *testing.T) {
 }
 
 func TestSetupGuideProfiler_BlackfireRoutesToCredsAndFocusesID(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.step = setupStepDockerProfiler
 	sg.profilerCursor = 2 // blackfire
 
@@ -166,7 +215,7 @@ func TestSetupGuideProfiler_BlackfireRoutesToCredsAndFocusesID(t *testing.T) {
 }
 
 func TestSetupGuideProfiler_TidewaysRoutesToCredsAndFocusesKey(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.step = setupStepDockerProfiler
 	sg.profilerCursor = 3 // tideways
 
@@ -176,7 +225,7 @@ func TestSetupGuideProfiler_TidewaysRoutesToCredsAndFocusesKey(t *testing.T) {
 }
 
 func TestSetupGuideProfiler_BlackfireCredsAdvanceThroughInputs(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.step = setupStepDockerProfiler
 	sg.profilerCursor = 2 // blackfire
 
@@ -197,7 +246,7 @@ func TestSetupGuideProfiler_BlackfireCredsAdvanceThroughInputs(t *testing.T) {
 }
 
 func TestSetupGuideProfiler_TidewaysCredsAdvanceToReview(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.step = setupStepDockerProfiler
 	sg.profilerCursor = 3 // tideways
 
@@ -210,7 +259,7 @@ func TestSetupGuideProfiler_TidewaysCredsAdvanceToReview(t *testing.T) {
 }
 
 func TestSetupGuideViewProfilerCreds(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.step = setupStepProfilerCreds
 	sg.profilerCursor = 2 // blackfire
 	sg.blackfireServerID.Focus()
@@ -221,7 +270,7 @@ func TestSetupGuideViewProfilerCreds(t *testing.T) {
 }
 
 func TestSetupGuideStepNumbering_NoProfilerCreds(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.profilerCursor = 0 // none → no creds step
 	assert.Equal(t, 5, sg.totalSteps())
 	assert.Equal(t, 1, sg.stepNum(setupStepAdminUser))
@@ -234,7 +283,7 @@ func TestSetupGuideStepNumbering_NoProfilerCreds(t *testing.T) {
 }
 
 func TestSetupGuideStepNumbering_WithProfilerCreds(t *testing.T) {
-	sg := newSetupGuide()
+	sg := newSetupGuide("")
 	sg.profilerCursor = 2 // blackfire → adds creds step
 	assert.Equal(t, 6, sg.totalSteps())
 	assert.Equal(t, 5, sg.stepNum(setupStepProfilerCreds))

--- a/internal/packagist/lock.go
+++ b/internal/packagist/lock.go
@@ -7,8 +7,9 @@ import (
 )
 
 type ComposerLockPackage struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name    string            `json:"name"`
+	Version string            `json:"version"`
+	Require map[string]string `json:"require"`
 }
 
 type ComposerLock struct {
@@ -22,6 +23,23 @@ func (c *ComposerLock) GetPackage(name string) *ComposerLockPackage {
 		}
 	}
 
+	return nil
+}
+
+// ShopwarePHPConstraint returns the `require.php` constraint declared by the
+// project's installed Shopware package (shopware/core, falling back to
+// shopware/platform). Returns nil when no Shopware package is present or it
+// declares no PHP requirement.
+func (c *ComposerLock) ShopwarePHPConstraint() *PHPConstraint {
+	for _, name := range []string{"shopware/core", "shopware/platform"} {
+		pkg := c.GetPackage(name)
+		if pkg == nil {
+			continue
+		}
+		if php, ok := pkg.Require["php"]; ok && php != "" {
+			return NewPHPConstraint(php)
+		}
+	}
 	return nil
 }
 

--- a/internal/packagist/lock_test.go
+++ b/internal/packagist/lock_test.go
@@ -52,3 +52,50 @@ func TestReadComposerLock(t *testing.T) {
 		assert.Nil(t, lock)
 	})
 }
+
+func TestShopwarePHPConstraint(t *testing.T) {
+	t.Run("from shopware/core", func(t *testing.T) {
+		lock := &ComposerLock{
+			Packages: []ComposerLockPackage{
+				{Name: "symfony/console", Version: "v6.3.0"},
+				{Name: "shopware/core", Version: "v6.6.10.0", Require: map[string]string{"php": "~8.2.0 || ~8.3.0"}},
+			},
+		}
+		c := lock.ShopwarePHPConstraint()
+		assert.NotNil(t, c)
+		assert.Equal(t, "~8.2.0 || ~8.3.0", c.String())
+	})
+
+	t.Run("falls back to shopware/platform", func(t *testing.T) {
+		lock := &ComposerLock{
+			Packages: []ComposerLockPackage{
+				{Name: "shopware/platform", Version: "v6.5.0.0", Require: map[string]string{"php": ">=8.1"}},
+			},
+		}
+		c := lock.ShopwarePHPConstraint()
+		assert.NotNil(t, c)
+		assert.Equal(t, ">=8.1", c.String())
+	})
+
+	t.Run("prefers core over platform", func(t *testing.T) {
+		lock := &ComposerLock{
+			Packages: []ComposerLockPackage{
+				{Name: "shopware/platform", Version: "v6.5.0.0", Require: map[string]string{"php": ">=8.1"}},
+				{Name: "shopware/core", Version: "v6.6.10.0", Require: map[string]string{"php": ">=8.2"}},
+			},
+		}
+		assert.Equal(t, ">=8.2", lock.ShopwarePHPConstraint().String())
+	})
+
+	t.Run("returns nil when no shopware package present", func(t *testing.T) {
+		lock := &ComposerLock{Packages: []ComposerLockPackage{{Name: "symfony/console"}}}
+		assert.Nil(t, lock.ShopwarePHPConstraint())
+	})
+
+	t.Run("returns nil when shopware package has no php require", func(t *testing.T) {
+		lock := &ComposerLock{
+			Packages: []ComposerLockPackage{{Name: "shopware/core", Version: "v6.6.0.0"}},
+		}
+		assert.Nil(t, lock.ShopwarePHPConstraint())
+	})
+}

--- a/internal/packagist/php_constraint.go
+++ b/internal/packagist/php_constraint.go
@@ -23,6 +23,32 @@ func NewPHPConstraint(constraints ...string) *PHPConstraint {
 	return &PHPConstraint{raw: constraints}
 }
 
+// SupportedVersions returns the entries from SupportedPHPVersions that satisfy
+// every constraint. Invalid or empty constraints are ignored. A nil receiver
+// returns all supported versions. If no version satisfies the constraints, the
+// full list is returned as a best-effort default.
+func (c *PHPConstraint) SupportedVersions() []string {
+	parsed := c.parse()
+	if len(parsed) == 0 {
+		return append([]string(nil), SupportedPHPVersions...)
+	}
+
+	out := make([]string, 0, len(SupportedPHPVersions))
+	for _, candidate := range SupportedPHPVersions {
+		v, err := version.NewVersion(candidate + ".0")
+		if err != nil {
+			continue
+		}
+		if satisfiesAll(v, parsed) {
+			out = append(out, candidate)
+		}
+	}
+	if len(out) == 0 {
+		return append([]string(nil), SupportedPHPVersions...)
+	}
+	return out
+}
+
 // HighestSupported returns the highest entry from SupportedPHPVersions that satisfies
 // every constraint. Invalid or empty constraints are ignored. A nil receiver returns
 // the highest supported version. If no version satisfies all constraints, the highest

--- a/internal/packagist/php_constraint_test.go
+++ b/internal/packagist/php_constraint_test.go
@@ -25,6 +25,29 @@ func TestPHPConstraintHighestSupported(t *testing.T) {
 	})
 }
 
+func TestPHPConstraintSupportedVersions(t *testing.T) {
+	t.Run("nil receiver returns all", func(t *testing.T) {
+		var c *PHPConstraint
+		assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, c.SupportedVersions())
+	})
+
+	t.Run("filters by constraint", func(t *testing.T) {
+		assert.Equal(t, []string{"8.2", "8.3"}, NewPHPConstraint("~8.2.0 || ~8.3.0").SupportedVersions())
+	})
+
+	t.Run("multiple constraints take intersection", func(t *testing.T) {
+		assert.Equal(t, []string{"8.2", "8.3", "8.4"}, NewPHPConstraint("^8.2", "<8.5").SupportedVersions())
+	})
+
+	t.Run("no match falls back to full list", func(t *testing.T) {
+		assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, NewPHPConstraint("^9.0").SupportedVersions())
+	})
+
+	t.Run("invalid constraint is ignored", func(t *testing.T) {
+		assert.Equal(t, []string{"8.2", "8.3", "8.4", "8.5"}, NewPHPConstraint("not-a-constraint").SupportedVersions())
+	})
+}
+
 func TestPHPConstraintCheck(t *testing.T) {
 	t.Run("nil receiver always matches", func(t *testing.T) {
 		var c *PHPConstraint

--- a/internal/tui/mascot.go
+++ b/internal/tui/mascot.go
@@ -1,0 +1,303 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+const mascotArt = `____________________________
+____________________________
+____________▓▓▓▓██████______
+______████▓▓▓▓▓▓████████____
+____██████▓▓▓▓▓▓████████____
+__████████▓▓▓▓▓▓██▒█████____
+▓▓██████████▓▓▓▓████████____
+__██████████████████████____
+__████████████████__██████__
+__██████____██████______████
+__▓▓▓▓▓▓____▓▓▓▓▓▓__________
+____________________________
+____________________________`
+
+// mascotVisibleWidth is the rune-width of a single mascot art line.
+// All lines in mascotArt are normalized to this width.
+const mascotVisibleWidth = 28
+
+// mascotHeadCol is the column (0-indexed, within the 28-col art) where the
+// mascot's head is roughly centered. Used to align speech-bubble tails.
+const mascotHeadCol = 16
+
+// MascotStandard renders the Shopware mascot, horizontally centered within
+// targetWidth columns using dot padding.
+func MascotStandard(targetWidth int) string {
+	return renderMascot(targetWidth)
+}
+
+// MascotCowsay renders the Shopware mascot with a speech bubble above it
+// containing the given text. The bubble is centered above the mascot and
+// sized to fit text (wrapping long lines to targetWidth-4).
+func MascotCowsay(targetWidth int, text string) string {
+	mascot := trimLeadingBlankRows(renderMascot(targetWidth))
+	bubble := renderSpeechBubble(text, targetWidth)
+	return bubble + "\n" + mascot
+}
+
+// trimLeadingBlankRows removes leading rows from rendered art that contain
+// no body pixels (only dot-padding or whitespace). Used to tighten the gap
+// between a speech bubble and the mascot's head.
+func trimLeadingBlankRows(art string) string {
+	lines := strings.Split(art, "\n")
+	i := 0
+	for i < len(lines) && isBlankRow(lines[i]) {
+		i++
+	}
+	return strings.Join(lines[i:], "\n")
+}
+
+func isBlankRow(line string) bool {
+	for _, r := range stripANSI(line) {
+		if r != '·' && r != ' ' {
+			return false
+		}
+	}
+	return true
+}
+
+// stripANSI removes ANSI SGR escape sequences so we can inspect the raw
+// glyphs of a styled string.
+func stripANSI(s string) string {
+	var b strings.Builder
+	in := false
+	for _, r := range s {
+		if r == 0x1b {
+			in = true
+			continue
+		}
+		if in {
+			if r == 'm' {
+				in = false
+			}
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func renderMascot(targetWidth int) string {
+	const dashChar = '·'
+
+	dotStyle := lipgloss.NewStyle().Foreground(BorderColor)
+	bodyStyle := lipgloss.NewStyle().Foreground(BrandColor)
+	shadeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#0450A0"))
+	eyeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))
+
+	classOf := func(ch rune) int {
+		switch ch {
+		case dashChar:
+			return 0
+		case '▓':
+			return 1
+		case '▒':
+			return 2
+		default:
+			return 3
+		}
+	}
+
+	styleOf := func(ch rune) lipgloss.Style {
+		switch classOf(ch) {
+		case 0:
+			return dotStyle
+		case 1:
+			return shadeStyle
+		case 2:
+			return eyeStyle
+		default:
+			return bodyStyle
+		}
+	}
+
+	lines := strings.Split(mascotArt, "\n")
+
+	maxW := 0
+	for _, line := range lines {
+		if w := len([]rune(line)); w > maxW {
+			maxW = w
+		}
+	}
+
+	padTotal := targetWidth - maxW
+	leftPad, rightPad := 0, 0
+	if padTotal > 0 {
+		leftPad = padTotal / 2
+		rightPad = padTotal - leftPad
+	}
+
+	var result strings.Builder
+	for i, line := range lines {
+		runes := []rune(strings.ReplaceAll(line, "_", string(dashChar)))
+		for len(runes) < maxW {
+			runes = append(runes, dashChar)
+		}
+		if leftPad > 0 {
+			pad := make([]rune, 0, leftPad+len(runes))
+			for j := 0; j < leftPad; j++ {
+				pad = append(pad, dashChar)
+			}
+			runes = append(pad, runes...)
+		}
+		for j := 0; j < rightPad; j++ {
+			runes = append(runes, dashChar)
+		}
+
+		var batch []rune
+		curCls := classOf(runes[0])
+		for _, ch := range runes {
+			cls := classOf(ch)
+			if cls != curCls && len(batch) > 0 {
+				result.WriteString(styleOf(batch[0]).Render(string(batch)))
+				batch = batch[:0]
+			}
+			curCls = cls
+			batch = append(batch, ch)
+		}
+		if len(batch) > 0 {
+			result.WriteString(styleOf(batch[0]).Render(string(batch)))
+		}
+		if i < len(lines)-1 {
+			result.WriteByte('\n')
+		}
+	}
+	return result.String()
+}
+
+// renderSpeechBubble draws a rounded-border bubble with a downward tail
+// pointing at the mascot's head, centered horizontally within targetWidth.
+func renderSpeechBubble(text string, targetWidth int) string {
+	bubbleStyle := lipgloss.NewStyle().Foreground(BrandColor)
+	dotStyle := lipgloss.NewStyle().Foreground(BorderColor)
+
+	// Maximum text width inside the bubble: leave 4 cols for borders+padding,
+	// and clamp to a sensible reading width.
+	maxTextWidth := min(targetWidth-4, 60)
+	maxTextWidth = max(maxTextWidth, 8)
+
+	lines := wrapText(text, maxTextWidth)
+
+	contentW := 0
+	for _, line := range lines {
+		contentW = max(contentW, lipgloss.Width(line))
+	}
+	innerW := contentW + 2 // 1 col padding either side
+
+	// Mascot's head center sits at column leftPad + mascotVisibleWidth/2
+	// (relative to a targetWidth-wide canvas). Position the bubble so its
+	// tail lines up under that column.
+	mascotLeftPad := max((targetWidth-mascotVisibleWidth)/2, 0)
+	headCenter := mascotLeftPad + mascotHeadCol
+
+	// Bubble width is innerW + 2 (borders). Try to center the bubble's tail
+	// on headCenter, but clamp so the bubble stays within targetWidth.
+	bubbleW := innerW + 2
+	bubbleLeft := max(headCenter-bubbleW/2, 0)
+	if bubbleLeft+bubbleW > targetWidth {
+		bubbleLeft = targetWidth - bubbleW
+		if bubbleLeft < 0 {
+			bubbleLeft = 0
+			bubbleW = targetWidth
+			innerW = bubbleW - 2
+		}
+	}
+
+	tailCol := max(headCenter-bubbleLeft, 1) // column within the bubble where the tail lives
+	tailCol = min(tailCol, bubbleW-2)
+
+	leftDots := strings.Repeat("·", bubbleLeft)
+	rightDots := func(used int) string {
+		n := max(targetWidth-bubbleLeft-used, 0)
+		return strings.Repeat("·", n)
+	}
+
+	var b strings.Builder
+
+	// Top border: ╭─────╮
+	top := "╭" + strings.Repeat("─", innerW) + "╮"
+	b.WriteString(dotStyle.Render(leftDots))
+	b.WriteString(bubbleStyle.Render(top))
+	b.WriteString(dotStyle.Render(rightDots(lipgloss.Width(top))))
+	b.WriteByte('\n')
+
+	// Text rows: │ text │
+	for _, line := range lines {
+		pad := contentW - lipgloss.Width(line)
+		row := "│ " + line + strings.Repeat(" ", pad) + " │"
+		b.WriteString(dotStyle.Render(leftDots))
+		b.WriteString(bubbleStyle.Render(row))
+		b.WriteString(dotStyle.Render(rightDots(lipgloss.Width(row))))
+		b.WriteByte('\n')
+	}
+
+	// Bottom border: ╰─────╯ (clean, no tail notch)
+	bottom := "╰" + strings.Repeat("─", innerW) + "╯"
+	b.WriteString(dotStyle.Render(leftDots))
+	b.WriteString(bubbleStyle.Render(bottom))
+	b.WriteString(dotStyle.Render(rightDots(lipgloss.Width(bottom))))
+	b.WriteByte('\n')
+
+	// Tail: a "\/" shape below the bubble centered on tailCol
+	tailLeftWidth := max(bubbleLeft+tailCol-1, 0)
+	tailLeft := strings.Repeat("·", tailLeftWidth)
+	tailRight := strings.Repeat("·", targetWidth-tailLeftWidth-2)
+	b.WriteString(dotStyle.Render(tailLeft))
+	b.WriteString(bubbleStyle.Render(`\/`))
+	b.WriteString(dotStyle.Render(tailRight))
+
+	return b.String()
+}
+
+// wrapText breaks text into lines no wider than maxWidth, preserving
+// explicit newlines and breaking on word boundaries where possible.
+func wrapText(text string, maxWidth int) []string {
+	if maxWidth < 1 {
+		maxWidth = 1
+	}
+	var out []string
+	for paragraph := range strings.SplitSeq(text, "\n") {
+		if paragraph == "" {
+			out = append(out, "")
+			continue
+		}
+		words := strings.Fields(paragraph)
+		if len(words) == 0 {
+			out = append(out, "")
+			continue
+		}
+		line := ""
+		for _, w := range words {
+			switch {
+			case line == "":
+				line = w
+			case lipgloss.Width(line)+1+lipgloss.Width(w) <= maxWidth:
+				line += " " + w
+			default:
+				out = append(out, line)
+				line = w
+			}
+			// hard-break very long words
+			for lipgloss.Width(line) > maxWidth {
+				runes := []rune(line)
+				out = append(out, string(runes[:maxWidth]))
+				line = string(runes[maxWidth:])
+			}
+		}
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	if len(out) == 0 {
+		out = []string{""}
+	}
+	return out
+}

--- a/internal/tui/mascot_test.go
+++ b/internal/tui/mascot_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMascotStandardWidth(t *testing.T) {
+	out := MascotStandard(40)
+	for i, line := range strings.Split(out, "\n") {
+		assert.Equal(t, 40, lipgloss.Width(line), "line %d should be 40 cols", i)
+	}
+}
+
+func TestMascotCowsayContainsBubbleAndMascot(t *testing.T) {
+	out := MascotCowsay(60, "Hello there")
+	// Bubble border characters present
+	assert.Contains(t, out, "╭")
+	assert.Contains(t, out, "╮")
+	assert.Contains(t, out, "╰")
+	assert.Contains(t, out, "╯")
+	assert.Contains(t, out, "│")
+	assert.Contains(t, out, `\/`) // tail
+	// Speech text present
+	assert.Contains(t, out, "Hello there")
+	// Mascot art present
+	assert.Contains(t, out, "▓")
+}
+
+func TestMascotCowsayLineWidthsMatchTarget(t *testing.T) {
+	out := MascotCowsay(60, "Welcome to Shopware")
+	for i, line := range strings.Split(out, "\n") {
+		assert.Equal(t, 60, lipgloss.Width(line), "line %d should be 60 cols, got %q", i, line)
+	}
+}
+
+func TestMascotCowsayWrapsLongText(t *testing.T) {
+	short := MascotCowsay(60, "Hi")
+	long := "This is a really long message that should definitely wrap onto multiple lines inside the speech bubble."
+	longOut := MascotCowsay(60, long)
+	// Wrapping must add at least one extra content row to the bubble.
+	assert.Greater(t, strings.Count(longOut, "\n"), strings.Count(short, "\n"))
+	// Original message words still present somewhere
+	assert.Contains(t, longOut, "really long message")
+}
+
+func TestWrapText(t *testing.T) {
+	got := wrapText("hello world this is a test", 11)
+	assert.Equal(t, []string{"hello world", "this is a", "test"}, got)
+}
+
+func TestWrapTextHardBreaksLongWord(t *testing.T) {
+	got := wrapText("supercalifragilistic", 6)
+	assert.Equal(t, []string{"superc", "alifra", "gilist", "ic"}, got)
+}
+
+func TestWrapTextPreservesExplicitNewlines(t *testing.T) {
+	got := wrapText("first\nsecond line here", 100)
+	assert.Equal(t, []string{"first", "second line here"}, got)
+}

--- a/internal/tui/phasecard.go
+++ b/internal/tui/phasecard.go
@@ -6,118 +6,26 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-const mascotArt = `____________________________
-____________________________
-____________▓▓▓▓██████______
-______████▓▓▓▓▓▓████████____
-____██████▓▓▓▓▓▓████████____
-__████████▓▓▓▓▓▓██▒█████____
-▓▓██████████▓▓▓▓████████____
-__██████████████████████____
-__████████████████__██████__
-__██████____██████______████
-__▓▓▓▓▓▓____▓▓▓▓▓▓__________
-____________________________
-____________________________`
-
 const PhaseCardWidth = 79
-
-func renderMascotArt(targetWidth int) string {
-	const dashChar = '·'
-
-	dotStyle := lipgloss.NewStyle().Foreground(BorderColor)
-	bodyStyle := lipgloss.NewStyle().Foreground(BrandColor)
-	shadeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#0450A0"))
-	eyeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))
-
-	classOf := func(ch rune) int {
-		switch ch {
-		case dashChar:
-			return 0
-		case '▓':
-			return 1
-		case '▒':
-			return 2
-		default:
-			return 3
-		}
-	}
-
-	styleOf := func(ch rune) lipgloss.Style {
-		switch classOf(ch) {
-		case 0:
-			return dotStyle
-		case 1:
-			return shadeStyle
-		case 2:
-			return eyeStyle
-		default:
-			return bodyStyle
-		}
-	}
-
-	lines := strings.Split(mascotArt, "\n")
-
-	maxW := 0
-	for _, line := range lines {
-		if w := len([]rune(line)); w > maxW {
-			maxW = w
-		}
-	}
-
-	padTotal := targetWidth - maxW
-	leftPad, rightPad := 0, 0
-	if padTotal > 0 {
-		leftPad = padTotal / 2
-		rightPad = padTotal - leftPad
-	}
-
-	var result strings.Builder
-	for i, line := range lines {
-		runes := []rune(strings.ReplaceAll(line, "_", string(dashChar)))
-		for len(runes) < maxW {
-			runes = append(runes, dashChar)
-		}
-		if leftPad > 0 {
-			pad := make([]rune, 0, leftPad+len(runes))
-			for j := 0; j < leftPad; j++ {
-				pad = append(pad, dashChar)
-			}
-			runes = append(pad, runes...)
-		}
-		for j := 0; j < rightPad; j++ {
-			runes = append(runes, dashChar)
-		}
-
-		var batch []rune
-		curCls := classOf(runes[0])
-		for _, ch := range runes {
-			cls := classOf(ch)
-			if cls != curCls && len(batch) > 0 {
-				result.WriteString(styleOf(batch[0]).Render(string(batch)))
-				batch = batch[:0]
-			}
-			curCls = cls
-			batch = append(batch, ch)
-		}
-		if len(batch) > 0 {
-			result.WriteString(styleOf(batch[0]).Render(string(batch)))
-		}
-		if i < len(lines)-1 {
-			result.WriteByte('\n')
-		}
-	}
-	return result.String()
-}
 
 // RenderPhaseCard renders content inside a fixed-width card with the Shopware
 // mascot art at the top, a divider, and the content below.
 func RenderPhaseCard(content string) string {
+	return renderPhaseCard(MascotStandard(PhaseCardWidth-2), content)
+}
+
+// RenderPhaseCardCowsay renders content inside a fixed-width card with the
+// Shopware mascot saying the given text via a speech bubble.
+func RenderPhaseCardCowsay(speech, content string) string {
+	return renderPhaseCard(MascotCowsay(PhaseCardWidth-2, speech), content)
+}
+
+func renderPhaseCard(logo, content string) string {
 	innerW := PhaseCardWidth - 2
 
 	logoSection := lipgloss.NewStyle().
 		Width(innerW).
-		Render(renderMascotArt(innerW))
+		Render(logo)
 
 	divider := lipgloss.NewStyle().Foreground(BorderColor).Render(strings.Repeat("─", innerW))
 


### PR DESCRIPTION
## Summary

When `shopware-cli project dev` is run against a project whose `compatibility_date` predates dev-mode support (older than `2026-03-01`), the CLI previously returned a hard error telling the user to upgrade. This PR replaces that dead-end with an interactive wizard that bootstraps everything dev mode needs and then drops into the regular devtui dashboard.

## What the wizard does

1. **Welcome screen** — Cowsay-styled mascot says "Let me help you to set up Docker!"
2. **Admin credentials** — username + password (with tab-to-show toggle).
3. **PHP version** — list filtered against `shopware/core`'s `require.php` read from `composer.lock`. Default cursor points at the highest compatible version. If no lock or no constraint, all supported versions (8.2 → 8.5) are shown.
4. **PHP profiler** — none / xdebug / blackfire / tideways / pcov / spx. The numbered total adapts: profilers that need credentials add an extra step.
5. **Profiler credentials** (Blackfire / Tideways only) — server ID + token / API key. These go to `.shopware-project.local.yml` so they don't get committed.
6. **Review & save** — writes `.shopware-project.yml`, bumps `compatibility_date` to `CompatibilityDevMode`, and ensures `shopware/deployment-helper` is in the project's `composer.json` (new projects already pin it; older projects need it added so `vendor/bin/shopware-deployment-helper` works during install).
7. **Transition** — re-resolves the env config, regenerates `compose.yaml`, and hands off to the normal Docker startup phase.

## Key behaviors

- **PHP filtering:** `composer.lock` → `shopware/core` (fallback `shopware/platform`) → `require.php` → intersected against `SupportedPHPVersions`. The constraint is shown to the user in the description line so the filtering isn't a black box.
- **`shopware/deployment-helper` migration:** Read `composer.json`, check both `require` and `require-dev`, add `"shopware/deployment-helper": "*"` to `require` only when missing in both. Tells the user on the done screen to run `composer update shopware/deployment-helper` before installing.
- **Error handling:** Failures during save (config write, composer.json write, env re-resolution, executor creation, compose write) surface as styled errors on the done screen instead of being silently swallowed.
- **Non-TTY fallback:** Still returns `shop.ErrDevModeNotSupported` when stdin isn't a terminal — the wizard is interactive only.

## Mascot / cowsay refactor

The mascot art was previously bound to `phasecard.go`. This PR:
- Moves it to its own `internal/tui/mascot.go` with `MascotStandard(width)` and `MascotCowsay(width, text)` entry points.
- Adds `RenderPhaseCardCowsay(speech, content)` alongside the existing `RenderPhaseCard`. Only the wizard's welcome screen uses cowsay; everywhere else still renders the plain mascot.
- The speech bubble uses a rounded border with a `\/` tail centered above the mascot's head; long messages wrap on word boundaries.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 17 new tests across devtui (wizard flow, PHP resolution, deployment-helper insertion, step numbering), packagist (composer.lock helpers, constraint filtering), and tui (mascot widths, cowsay structure, text wrapping)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual: run `shopware-cli project dev` on a project with an old `compatibility_date`, walk through every step including Blackfire/Tideways credential flows, verify written files (`.shopware-project.yml`, `.shopware-project.local.yml`, `composer.json`) match the choices, confirm transition into the normal devtui dashboard.