### PR TITLE
fix(validation): surface rule identifier before the message in summary

### DIFF
--- a/internal/validation/reporter.go
+++ b/internal/validation/reporter.go
@@ -104,7 +104,7 @@ func doSummaryReport(result Check) error {
 				warningCount++
 			}
 			//nolint:forbidigo
-			fmt.Printf("  %d  %-7s  %s  %s\n", r.Line, r.Severity, r.Message, r.Identifier)
+			fmt.Printf("  %d  %-7s  [%s]  %s\n", r.Line, r.Severity, r.Identifier, r.Message)
 			if r.Tip != "" {
 				//nolint:forbidigo
 				fmt.Printf("             Tip: %s\n", r.Tip)


### PR DESCRIPTION
## Summary
- The summary reporter printed the rule identifier *after* the message, so when a PHPStan deprecation message contained an embedded newline the identifier wrapped onto its own line and looked like part of the message text.
- Move the identifier into bracketed form right after the severity column (`  47  error    [phpstan/method.deprecatedClass]  Call to method ...`) so it stays aligned and visible regardless of message content.
- Makes it obvious which value to paste into the `identifier:` field of `validation.ignore` in `.shopware-extension.yml`.

## Test plan
- [x] `go test ./internal/validation/...`
- [x] `go run . extension validate --full <plugin>` against a plugin with PHPStan deprecation errors — identifier is now clearly shown next to each result.