### PR TITLE
fix(validation): include summary output in github reporter

### DIFF
--- a/internal/validation/reporter.go
+++ b/internal/validation/reporter.go
@@ -129,6 +129,12 @@ func doJSONReport(result Check) error {
 }
 
 func doGitHubReport(result Check) error {
+	// Print the human-readable summary first so the GitHub Actions log
+	// shows file/line context, then emit annotations for PR inline display.
+	if err := doSummaryReport(result); err != nil {
+		return err
+	}
+
 	// Sort results for deterministic output
 	results := result.GetResults()
 	sort.Slice(results, func(i, j int) bool {

--- a/internal/validation/reporter.go
+++ b/internal/validation/reporter.go
@@ -2,6 +2,8 @@ package validation
 
 import (
 	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -131,9 +133,21 @@ func doJSONReport(result Check) error {
 func doGitHubReport(result Check) error {
 	// Print the human-readable summary first so the GitHub Actions log
 	// shows file/line context, then emit annotations for PR inline display.
-	if err := doSummaryReport(result); err != nil {
+	// File paths and messages can contain `::` which the runner would parse
+	// as a workflow command, so wrap the summary in stop-commands/resume
+	// using a random token to neutralize any embedded commands.
+	var tokenBytes [16]byte
+	if _, err := rand.Read(tokenBytes[:]); err != nil {
 		return err
 	}
+	token := hex.EncodeToString(tokenBytes[:])
+
+	fmt.Printf("::stop-commands::%s\n", token)
+	if err := doSummaryReport(result); err != nil {
+		fmt.Printf("::%s::\n", token)
+		return err
+	}
+	fmt.Printf("::%s::\n", token)
 
 	// Sort results for deterministic output
 	results := result.GetResults()

--- a/internal/validation/reporter_test.go
+++ b/internal/validation/reporter_test.go
@@ -75,18 +75,28 @@ func TestReportingOutputIsDeterministic(t *testing.T) {
 			_ = doGitHubReport(check)
 		})
 
-		lines := strings.Split(strings.TrimSpace(output), "\n")
-		assert.Len(t, lines, 4) // 4 results
+		// The GitHub reporter now prefixes the summary output before the
+		// annotations. Extract only the annotation lines for ordering checks.
+		var annotationLines []string
+		for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+			if strings.HasPrefix(line, "::") {
+				annotationLines = append(annotationLines, line)
+			}
+		}
+		assert.Len(t, annotationLines, 4) // 4 results
 
 		// Check that results are sorted by path first, then by line
-		assert.Contains(t, lines[0], "a_file.go")
-		assert.Contains(t, lines[0], "line=5")
-		assert.Contains(t, lines[1], "a_file.go")
-		assert.Contains(t, lines[1], "line=10")
-		assert.Contains(t, lines[2], "b_file.go")
-		assert.Contains(t, lines[2], "line=1")
-		assert.Contains(t, lines[3], "z_file.go")
-		assert.Contains(t, lines[3], "line=5")
+		assert.Contains(t, annotationLines[0], "a_file.go")
+		assert.Contains(t, annotationLines[0], "line=5")
+		assert.Contains(t, annotationLines[1], "a_file.go")
+		assert.Contains(t, annotationLines[1], "line=10")
+		assert.Contains(t, annotationLines[2], "b_file.go")
+		assert.Contains(t, annotationLines[2], "line=1")
+		assert.Contains(t, annotationLines[3], "z_file.go")
+		assert.Contains(t, annotationLines[3], "line=5")
+
+		// And the summary header should be present
+		assert.Contains(t, output, "problems")
 	}
 }
 

--- a/internal/validation/reporter_test.go
+++ b/internal/validation/reporter_test.go
@@ -79,7 +79,7 @@ func TestReportingOutputIsDeterministic(t *testing.T) {
 		// annotations. Extract only the annotation lines for ordering checks.
 		var annotationLines []string
 		for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
-			if strings.HasPrefix(line, "::") {
+			if strings.HasPrefix(line, "::error") || strings.HasPrefix(line, "::warning") {
 				annotationLines = append(annotationLines, line)
 			}
 		}
@@ -318,6 +318,50 @@ func TestSummaryReportWithTip(t *testing.T) {
 	assert.Contains(t, output, "Method has no return type")
 	assert.Contains(t, output, "Tip: Add a return type declaration")
 	assert.Contains(t, output, "Some other error")
+}
+
+func TestGitHubReportNeutralizesSummaryCommands(t *testing.T) {
+	// A malicious path containing a workflow command must not be executed
+	// by the runner when emitted via the summary section.
+	testResults := []CheckResult{
+		{
+			Path:       "::add-mask::secret",
+			Line:       1,
+			Identifier: "test.rule",
+			Message:    "boom",
+			Severity:   SeverityError,
+		},
+	}
+
+	check := &testCheck{Results: testResults}
+
+	output := captureOutput(func() {
+		_ = doGitHubReport(check)
+	})
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	assert.True(t, strings.HasPrefix(lines[0], "::stop-commands::"), "summary must be wrapped in ::stop-commands::")
+
+	token := strings.TrimPrefix(lines[0], "::stop-commands::")
+	assert.NotEmpty(t, token)
+
+	// The matching resume marker must appear before any annotation lines.
+	resume := "::" + token + "::"
+	resumeIdx := -1
+	for i, line := range lines {
+		if line == resume {
+			resumeIdx = i
+			break
+		}
+	}
+	assert.GreaterOrEqual(t, resumeIdx, 1, "resume marker must follow the stop marker")
+
+	// Annotations should appear only after the resume marker.
+	for i, line := range lines {
+		if strings.HasPrefix(line, "::error") || strings.HasPrefix(line, "::warning") {
+			assert.Greater(t, i, resumeIdx, "annotations must come after resume marker")
+		}
+	}
 }
 
 func TestGitHubReportWithTip(t *testing.T) {


### PR DESCRIPTION
## Summary
- GitHub workflow annotations (`::error file=...::`) only render inline on PRs; on push events the log just shows the raw annotation lines, making it hard to see which file/line each problem belongs to.
- The `github` reporter now prints the same file-grouped summary as the `summary` reporter before emitting annotations, so the log stays readable regardless of event type while PR inline annotations still work.

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`