### PR TITLE
[codex] fix goreleaser package skip config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -178,7 +178,7 @@ aurs:
 
 nix:
   - name: shopware-cli
-    disable: '{{ .Prerelease }}'
+    skip_upload: '{{ .Prerelease }}'
     repository:
       owner: FriendsOfShopware
       name: nur-packages
@@ -218,7 +218,7 @@ nfpms:
 
 homebrew_casks:
   - name: shopware-cli
-    disable: '{{ .Prerelease }}'
+    skip_upload: '{{ .Prerelease }}'
     repository:
       owner: shopware
       name: homebrew-tap


### PR DESCRIPTION
## Summary

Updates the GoReleaser configuration for the `nix` and `homebrew_casks` sections to use `skip_upload` instead of the unsupported `disable` field.

## Why

GoReleaser Pro 2.15.4 rejects the current config with YAML unmarshal errors because `config.Nix` and `config.HomebrewCask` no longer define `disable`. The generated schema still supports `skip_upload`, which preserves the existing prerelease behavior by skipping package manager uploads for prereleases.

## Validation

- `goreleaser check`
- `git diff --check`