### PR TITLE
Add `project config-schema` command to output project YAML JSON schema

### DIFF
--- a/cmd/project/project_config_schema.go
+++ b/cmd/project/project_config_schema.go
@@ -1,0 +1,39 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/invopop/jsonschema"
+	"github.com/spf13/cobra"
+
+	"github.com/shopware/shopware-cli/internal/shop"
+)
+
+var projectConfigSchemaCmd = &cobra.Command{
+	Use:   "config-schema",
+	Short: "Print the JSON schema of .shopware-project.yaml",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		r := new(jsonschema.Reflector)
+		r.FieldNameTag = "yaml"
+		r.RequiredFromJSONSchemaTags = true
+
+		if err := r.AddGoComments("github.com/shopware/shopware-cli", "./internal/shop"); err != nil {
+			return fmt.Errorf("cannot generate project schema comments: %w", err)
+		}
+
+		schema := r.Reflect(&shop.Config{})
+
+		bytes, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			return fmt.Errorf("cannot marshal project schema: %w", err)
+		}
+
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), string(bytes))
+		return err
+	},
+}
+
+func init() {
+	projectRootCmd.AddCommand(projectConfigSchemaCmd)
+}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable JSON schema for `.shopware-project.yaml` so AI agents and external tooling can validate and understand project configuration.

### Description
- Add new `project config-schema` subcommand in `cmd/project` as `projectConfigSchemaCmd` which generates a JSON schema at runtime from `internal/shop.Config` using `invopop/jsonschema` with `FieldNameTag = "yaml"` and `RequiredFromJSONSchemaTags = true`, marshals it with `json.MarshalIndent`, and prints it to stdout; the command is registered on `projectRootCmd`.

### Testing
- Ran `go test ./cmd/project` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06aae28c588336a128a9d221bc97fc)