### PR TITLE
fix: tighten file permissions for config writes

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -72,7 +72,7 @@ func WriteComposeFile(projectFolder string, opts *ComposeOptions) error {
 		return fmt.Errorf("failed to generate compose.yaml: %w", err)
 	}
 
-	return os.WriteFile(filepath.Join(projectFolder, "compose.yaml"), composeBytes, os.ModePerm)
+	return os.WriteFile(filepath.Join(projectFolder, "compose.yaml"), composeBytes, 0o644)
 }
 
 func buildCompose(hasAMQP, hasElasticsearch bool, opts *ComposeOptions) yaml.Node {

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -534,7 +534,7 @@ func WriteConfig(cfg *Config, dir string) error {
 
 	filePath := filepath.Join(dir, ".shopware-project.yml")
 
-	if err := os.WriteFile(filePath, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write shop configuration to %s: %w", filePath, err)
 	}
 
@@ -552,7 +552,7 @@ func WriteLocalConfig(cfg *Config, dir string) error {
 
 	filePath := filepath.Join(dir, ".shopware-project.local.yml")
 
-	if err := os.WriteFile(filePath, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write local shop configuration to %s: %w", filePath, err)
 	}
 


### PR DESCRIPTION
## Summary

- `.shopware-project.local.yml` contains secrets (Blackfire/Tideways API keys) — write with `0o600` so it isn't world-readable.
- `.shopware-project.yml` and `compose.yaml` now use `0o644` instead of `os.ModePerm` (`0o777`).

`os.ModePerm` is `0o777` (world-writable, executable bits set), which is the wrong default for config files. Linters like gosec flag it as G306.

This addresses item #1 in the post-merge review of `next`. Remaining `os.ModePerm` call sites across the codebase are tracked in #1020.

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./internal/shop/... ./internal/docker/...`
- [ ] Verify generated `.shopware-project.local.yml` has mode `-rw-------` after `shopware-cli project create` with a profiler enabled