### PR TITLE
fix: replace http.DefaultClient with package-level client with 30s timeout

### DIFF
--- a/internal/packagist/advisories.go
+++ b/internal/packagist/advisories.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/shyim/go-version"
-
-	"github.com/shopware/shopware-cli/logging"
 )
 
 // SecurityAdvisory describes a single packagist security advisory for a package.
@@ -64,15 +62,11 @@ func GetShopwareSecurityAdvisories(ctx context.Context) ([]SecurityAdvisory, err
 	}
 	req.Header.Set("User-Agent", "Shopware CLI")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch advisories: %w", err)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logging.FromContext(ctx).Errorf("Cannot close response body: %v", err)
-		}
-	}()
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetch advisories: %s", resp.Status)

--- a/internal/packagist/packagist.go
+++ b/internal/packagist/packagist.go
@@ -7,9 +7,15 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/shopware/shopware-cli/logging"
 )
+
+// httpClient is the default HTTP client used for all packagist API requests.
+// It has a 30-second timeout to prevent indefinite hangs and avoids the
+// shared http.DefaultClient which is not safe to override in tests.
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 type PackageResponse struct {
 	Packages map[string]map[string]PackageVersion `json:"packages"`
@@ -53,16 +59,11 @@ func GetAvailablePackagesFromShopwareStore(ctx context.Context, token string) (*
 	req.Header.Set("User-Agent", "Shopware CLI")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logging.FromContext(ctx).Errorf("Cannot close response body: %v", err)
-		}
-	}()
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get packages: %s", resp.Status)
@@ -115,16 +116,11 @@ func GetShopwarePackageVersions(ctx context.Context) ([]ComposerPackageVersion, 
 
 	req.Header.Set("User-Agent", "Shopware CLI")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch package versions: %w", err)
 	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logging.FromContext(ctx).Errorf("Cannot close response body: %v", err)
-		}
-	}()
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetch package versions: %s", resp.Status)
@@ -203,4 +199,11 @@ func cloneRawMessageMap(in map[string]json.RawMessage) map[string]json.RawMessag
 	}
 
 	return out
+}
+
+// closeResponseBody safely closes an HTTP response body, logging any error.
+func closeResponseBody(ctx context.Context, resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		logging.FromContext(ctx).Errorf("Cannot close response body: %v", err)
+	}
 }

--- a/internal/packagist/packagist_test.go
+++ b/internal/packagist/packagist_test.go
@@ -74,9 +74,9 @@ func TestPackageResponseHasPackage(t *testing.T) {
 }
 
 func TestGetPackages(t *testing.T) {
-	originalClient := http.DefaultClient
+	originalClient := httpClient
 	defer func() {
-		http.DefaultClient = originalClient
+		httpClient = originalClient
 	}()
 
 	t.Run("successful request", func(t *testing.T) {
@@ -102,7 +102,7 @@ func TestGetPackages(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},
@@ -122,7 +122,7 @@ func TestGetPackages(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},
@@ -143,7 +143,7 @@ func TestGetPackages(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},
@@ -161,7 +161,7 @@ func TestGetPackages(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},
@@ -186,9 +186,9 @@ func TestGetPackages(t *testing.T) {
 }
 
 func TestGetPackageVersions(t *testing.T) {
-	originalClient := http.DefaultClient
+	originalClient := httpClient
 	defer func() {
-		http.DefaultClient = originalClient
+		httpClient = originalClient
 	}()
 
 	t.Run("successful request with composer unminify", func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestGetPackageVersions(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},
@@ -266,7 +266,7 @@ func TestGetPackageVersions(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},
@@ -293,7 +293,7 @@ func TestGetPackageVersions(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},
@@ -312,7 +312,7 @@ func TestGetPackageVersions(t *testing.T) {
 		}))
 		defer server.Close()
 
-		http.DefaultClient = &http.Client{
+		httpClient = &http.Client{
 			Transport: &mockTransport{
 				server: server,
 			},

--- a/internal/packagist/project_composer_json.go
+++ b/internal/packagist/project_composer_json.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-
-	"github.com/shopware/shopware-cli/logging"
 )
 
 const (
@@ -212,20 +210,15 @@ func getLatestFallbackVersion(ctx context.Context, branch string) (string, error
 
 	r.Header.Set("User-Agent", "shopware-cli")
 
-	resp, err := http.DefaultClient.Do(r)
+	resp, err := httpClient.Do(r)
 	if err != nil {
 		return "", err
 	}
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("could not fetch kernel.php from branch %s", branch)
 	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logging.FromContext(context.Background()).Errorf("getLatestFallbackVersion: %v", err)
-		}
-	}()
 
 	content, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
## Problem

All packagist API calls used `http.DefaultClient` which has:
- **No request timeout** — can hang indefinitely
- **Race condition in tests** — tests monkey-patch `http.DefaultClient` which is a shared global
- **No ability to configure transport/proxy**

## Changes

- Added package-level `httpClient` var in `packagist.go` with a 30s timeout
- Replaced all `http.DefaultClient.Do()` calls with `httpClient.Do()` in:
  - `advisories.go`
  - `packagist.go` (2 call sites)
  - `project_composer_json.go`
- Extracted `closeResponseBody()` helper to deduplicate the 3 identical `defer resp.Body.Close()` patterns
- Updated all tests to swap `httpClient` instead of `http.DefaultClient`
- Removed now-unused `logging` imports from `advisories.go` and `project_composer_json.go`

## Testing

All existing tests pass with the new client. Tests now swap the package-level `httpClient` var instead of the shared `http.DefaultClient`, eliminating race conditions.

```
go test ./internal/packagist/... -v  # PASS
go vet ./internal/packagist/...      # OK
go build ./...                        # OK
```

Related: Issue #2 in CODE_IMPROVEMENTS.md