### PR TITLE
[codex] Replace permissive file modes

### DIFF
--- a/cmd/account/account_producer_extension_info_pull.go
+++ b/cmd/account/account_producer_extension_info_pull.go
@@ -64,7 +64,7 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 		faqEN := make([]extension.ConfigStoreFaq, 0)
 
 		if _, err := os.Stat(resourcesFolder); os.IsNotExist(err) {
-			err = os.MkdirAll(resourcesFolder, os.ModePerm)
+			err = os.MkdirAll(resourcesFolder, 0o755)
 			if err != nil {
 				return fmt.Errorf("cannot create file: %w", err)
 			}
@@ -139,11 +139,11 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 				germanMetaTitle = info.MetaTitle
 				germanMetaDescription = info.MetaDescription
 
-				if err := os.WriteFile(path.Join(zipExt.GetPath(), germanDescription[5:]), []byte(info.Description), os.ModePerm); err != nil {
+				if err := os.WriteFile(path.Join(zipExt.GetPath(), germanDescription[5:]), []byte(info.Description), 0o644); err != nil {
 					return fmt.Errorf("cannot write file: %w", err)
 				}
 
-				if err := os.WriteFile(path.Join(zipExt.GetPath(), germanInstallationManual[5:]), []byte(info.InstallationManual), os.ModePerm); err != nil {
+				if err := os.WriteFile(path.Join(zipExt.GetPath(), germanInstallationManual[5:]), []byte(info.InstallationManual), 0o644); err != nil {
 					return fmt.Errorf("cannot write file: %w", err)
 				}
 
@@ -173,11 +173,11 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 				englishMetaTitle = info.MetaTitle
 				englishMetaDescription = info.MetaDescription
 
-				if err := os.WriteFile(path.Join(zipExt.GetPath(), englishDescription[5:]), []byte(info.Description), os.ModePerm); err != nil {
+				if err := os.WriteFile(path.Join(zipExt.GetPath(), englishDescription[5:]), []byte(info.Description), 0o644); err != nil {
 					return fmt.Errorf("cannot write file: %w", err)
 				}
 
-				if err := os.WriteFile(path.Join(zipExt.GetPath(), englishInstallationManual[5:]), []byte(info.InstallationManual), os.ModePerm); err != nil {
+				if err := os.WriteFile(path.Join(zipExt.GetPath(), englishInstallationManual[5:]), []byte(info.InstallationManual), 0o644); err != nil {
 					return fmt.Errorf("cannot write file: %w", err)
 				}
 
@@ -256,7 +256,7 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 		}
 
 		extCfgFile := fmt.Sprintf("%s/%s", zipExt.GetPath(), newCfg.FileName)
-		err = os.WriteFile(extCfgFile, content, os.ModePerm)
+		err = os.WriteFile(extCfgFile, content, 0o644)
 		if err != nil {
 			return fmt.Errorf("cannot save file: %w", err)
 		}
@@ -293,7 +293,7 @@ func downloadFileTo(ctx context.Context, url string, target string) error {
 		return fmt.Errorf("read file body: %w", err)
 	}
 
-	err = os.WriteFile(target, content, os.ModePerm)
+	err = os.WriteFile(target, content, 0o644)
 	if err != nil {
 		return fmt.Errorf("write to file: %w", err)
 	}
@@ -329,7 +329,7 @@ func writeImages(ctx context.Context, imagePath string, index int, storeImages [
 	}
 
 	if _, err := os.Stat(imagePath); os.IsNotExist(err) {
-		if err := os.MkdirAll(imagePath, os.ModePerm); err != nil {
+		if err := os.MkdirAll(imagePath, 0o755); err != nil {
 			return err
 		}
 	}

--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -76,7 +76,7 @@ var extensionZipCmd = &cobra.Command{
 
 		extDir := fmt.Sprintf("%s/%s/", tempDir, extName)
 
-		err = os.Mkdir(extDir, os.ModePerm)
+		err = os.Mkdir(extDir, 0o755)
 		if err != nil {
 			return fmt.Errorf("create temp directory: %w", err)
 		}
@@ -202,7 +202,7 @@ var extensionZipCmd = &cobra.Command{
 
 		if len(outputDir) > 0 {
 			if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-				if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+				if err := os.MkdirAll(outputDir, 0o755); err != nil {
 					return fmt.Errorf("create output directory: %w", err)
 				}
 			}

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -259,13 +259,13 @@ var projectCI = &cobra.Command{
 
 			for _, source := range sources {
 				if _, err := os.Stat(path.Join(source.Path, "Resources", "public", "administration", "css")); err == nil {
-					if err := os.WriteFile(path.Join(source.Path, "Resources", ".administration-css"), []byte{}, os.ModePerm); err != nil {
+					if err := os.WriteFile(path.Join(source.Path, "Resources", ".administration-css"), []byte{}, 0o644); err != nil {
 						return err
 					}
 				}
 
 				if _, err := os.Stat(path.Join(source.Path, "Resources", "public", "administration", "js")); err == nil {
-					if err := os.WriteFile(path.Join(source.Path, "Resources", ".administration-js"), []byte{}, os.ModePerm); err != nil {
+					if err := os.WriteFile(path.Join(source.Path, "Resources", ".administration-js"), []byte{}, 0o644); err != nil {
 						return err
 					}
 				}
@@ -279,11 +279,11 @@ var projectCI = &cobra.Command{
 				return err
 			}
 
-			if err := os.WriteFile(path.Join(args[0], "vendor", "shopware", "administration", "Resources", ".administration-js"), []byte{}, os.ModePerm); err != nil {
+			if err := os.WriteFile(path.Join(args[0], "vendor", "shopware", "administration", "Resources", ".administration-js"), []byte{}, 0o644); err != nil {
 				return err
 			}
 
-			if err := os.WriteFile(path.Join(args[0], "vendor", "shopware", "administration", "Resources", ".administration-css"), []byte{}, os.ModePerm); err != nil {
+			if err := os.WriteFile(path.Join(args[0], "vendor", "shopware", "administration", "Resources", ".administration-css"), []byte{}, 0o644); err != nil {
 				return err
 			}
 
@@ -310,7 +310,7 @@ func createEmptySnippetFolder(root string) error {
 	for _, dir := range dirs {
 		fullPath := path.Join(root, dir)
 
-		if err := os.MkdirAll(fullPath, os.ModePerm); err != nil {
+		if err := os.MkdirAll(fullPath, 0o755); err != nil {
 			return err
 		}
 
@@ -442,7 +442,7 @@ func cleanupAdministrationFiles(ctx context.Context, folder string) error {
 					return err
 				}
 
-				if err := os.WriteFile(path.Join(folder, language), data, os.ModePerm); err != nil {
+				if err := os.WriteFile(path.Join(folder, language), data, 0o644); err != nil {
 					return err
 				}
 
@@ -473,7 +473,7 @@ func cleanupAdministrationFiles(ctx context.Context, folder string) error {
 				return err
 			}
 
-			if err := os.WriteFile(path.Join(folder, language), mergedData, os.ModePerm); err != nil {
+			if err := os.WriteFile(path.Join(folder, language), mergedData, 0o644); err != nil {
 				return err
 			}
 		}
@@ -487,7 +487,7 @@ func cleanupAdministrationFiles(ctx context.Context, folder string) error {
 		logging.FromContext(ctx).Infof("Migrating generated snippet file for %s", folder)
 
 		snippetFolder := path.Join(adminFolder, "src", "app", "snippet")
-		if err := os.MkdirAll(snippetFolder, os.ModePerm); err != nil {
+		if err := os.MkdirAll(snippetFolder, 0o755); err != nil {
 			return err
 		}
 
@@ -498,7 +498,7 @@ func cleanupAdministrationFiles(ctx context.Context, folder string) error {
 		}
 
 		logging.FromContext(ctx).Infof("Creating empty main.js for %s", folder)
-		return os.WriteFile(path.Join(adminFolder, "src", "main.js"), []byte(""), os.ModePerm)
+		return os.WriteFile(path.Join(adminFolder, "src", "main.js"), []byte(""), 0o644)
 	}
 
 	return nil
@@ -545,7 +545,7 @@ func cleanupJavaScriptSourceMaps(folder string) error {
 
 		overwrittenContent := strings.ReplaceAll(string(content), expectedSourceMapComment, "")
 
-		return os.WriteFile(expectedJsFile, []byte(overwrittenContent), os.ModePerm)
+		return os.WriteFile(expectedJsFile, []byte(overwrittenContent), 0o644)
 	})
 }
 

--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -81,7 +81,7 @@ func filterAndWritePluginJson(cmd *cobra.Command, projectRoot string, shopCfg *s
 		return err
 	}
 
-	if err := os.WriteFile(path.Join(projectRoot, "var", "plugins.json"), pluginJson, os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(projectRoot, "var", "plugins.json"), pluginJson, 0o644); err != nil {
 		return err
 	}
 

--- a/cmd/project/project_admin_watch.go
+++ b/cmd/project/project_admin_watch.go
@@ -64,7 +64,7 @@ var projectAdminWatchCmd = &cobra.Command{
 		if _, err := os.Stat(extension.PlatformPath(projectRoot, "Administration", "Resources/app/administration/scripts/entitySchemaConverter/entity-schema-converter.ts")); err == nil {
 			mockDirectory := extension.PlatformPath(projectRoot, "Administration", "Resources/app/administration/test/_mocks_")
 			if _, err := os.Stat(mockDirectory); os.IsNotExist(err) {
-				if err := os.MkdirAll(mockDirectory, os.ModePerm); err != nil {
+				if err := os.MkdirAll(mockDirectory, 0o755); err != nil {
 					return err
 				}
 			}

--- a/cmd/project/project_config_init.go
+++ b/cmd/project/project_config_init.go
@@ -35,7 +35,7 @@ var projectConfigInitCmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.WriteFile(".shopware-project.yml", content, os.ModePerm); err != nil {
+		if err := os.WriteFile(".shopware-project.yml", content, 0o600); err != nil {
 			return err
 		}
 

--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -481,7 +481,7 @@ var projectCreateCmd = &cobra.Command{
 			return fmt.Errorf("cannot find version %s", selectedVersion)
 		}
 
-		if err := os.MkdirAll(projectFolder, os.ModePerm); err != nil {
+		if err := os.MkdirAll(projectFolder, 0o755); err != nil {
 			return err
 		}
 
@@ -500,11 +500,11 @@ var projectCreateCmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.WriteFile(filepath.Join(projectFolder, "composer.json"), []byte(composerJson), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, "composer.json"), []byte(composerJson), 0o644); err != nil {
 			return err
 		}
 
-		if err := os.WriteFile(filepath.Join(projectFolder, ".env"), []byte(""), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, ".env"), []byte(""), 0o600); err != nil {
 			return err
 		}
 
@@ -514,24 +514,24 @@ var projectCreateCmd = &cobra.Command{
 			envLocalContent += "APP_ENV=dev\n"
 		}
 
-		if err := os.WriteFile(filepath.Join(projectFolder, ".env.local"), []byte(envLocalContent), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, ".env.local"), []byte(envLocalContent), 0o600); err != nil {
 			return err
 		}
 
-		if err := os.WriteFile(filepath.Join(projectFolder, ".gitignore"), []byte("/.idea\n/vendor"), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, ".gitignore"), []byte("/.idea\n/vendor"), 0o644); err != nil {
 			return err
 		}
 
-		if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "plugins"), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "plugins"), 0o755); err != nil {
 			return err
 		}
 
-		if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "static-plugins"), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "static-plugins"), 0o755); err != nil {
 			return err
 		}
 
 		if !useDocker && system.IsSymfonyCliInstalled() {
-			if err := os.WriteFile(filepath.Join(projectFolder, "php.ini"), []byte("memory_limit=512M"), os.ModePerm); err != nil {
+			if err := os.WriteFile(filepath.Join(projectFolder, "php.ini"), []byte("memory_limit=512M"), 0o644); err != nil {
 				return err
 			}
 		}
@@ -623,7 +623,7 @@ func resolveVersion(selectedVersion string, filteredVersions []*version.Version)
 func setupDeployment(projectFolder, deploymentMethod string) error {
 	switch deploymentMethod {
 	case packagist.DeploymentDeployer:
-		if err := os.WriteFile(filepath.Join(projectFolder, "deploy.php"), []byte(deployerTemplate), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, "deploy.php"), []byte(deployerTemplate), 0o644); err != nil {
 			return err
 		}
 
@@ -636,7 +636,7 @@ services:
     version: "8.0"
 `
 
-		if err := os.WriteFile(filepath.Join(projectFolder, "application.yaml"), []byte(shopwarePaasApp), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, "application.yaml"), []byte(shopwarePaasApp), 0o644); err != nil {
 			return err
 		}
 	}
@@ -647,17 +647,17 @@ services:
 func setupCI(ctx context.Context, projectFolder, ciSystem, deploymentMethod string) error {
 	switch ciSystem {
 	case "github":
-		if err := os.MkdirAll(filepath.Join(projectFolder, ".github", "workflows"), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Join(projectFolder, ".github", "workflows"), 0o755); err != nil {
 			return err
 		}
 		ciPath := filepath.Join(".github", "workflows", "ci.yml")
-		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), []byte(githubCITemplate), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), []byte(githubCITemplate), 0o644); err != nil {
 			return err
 		}
 		logging.FromContext(ctx).Infof("Created CI template %s", ciPath)
 		if deploymentMethod == packagist.DeploymentDeployer {
 			deployPath := filepath.Join(".github", "workflows", "deploy.yml")
-			if err := os.WriteFile(filepath.Join(projectFolder, deployPath), []byte(githubDeployTemplate), os.ModePerm); err != nil {
+			if err := os.WriteFile(filepath.Join(projectFolder, deployPath), []byte(githubDeployTemplate), 0o644); err != nil {
 				return err
 			}
 			logging.FromContext(ctx).Infof("Created CI template %s", deployPath)
@@ -675,7 +675,7 @@ func setupCI(ctx context.Context, projectFolder, ciSystem, deploymentMethod stri
 		}
 
 		ciPath := ".gitlab-ci.yml"
-		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), buf.Bytes(), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), buf.Bytes(), 0o644); err != nil {
 			return err
 		}
 		logging.FromContext(ctx).Infof("Created CI template %s", ciPath)

--- a/cmd/project/project_extension_upload.go
+++ b/cmd/project/project_extension_upload.go
@@ -91,7 +91,7 @@ var projectExtensionUploadCmd = &cobra.Command{
 
 			extDir := fmt.Sprintf("%s/%s/", tempDir, extName)
 
-			err = os.Mkdir(extDir, os.ModePerm)
+			err = os.Mkdir(extDir, 0o755)
 			if err != nil {
 				return fmt.Errorf("create temp directory: %w", err)
 			}
@@ -297,7 +297,7 @@ func increaseExtensionVersion(ctx context.Context, ext extension.Extension) erro
 		newManifest = strings.ReplaceAll(newManifest, "xmlns:_xmlns=\"xmlns\" _xmlns:xsi=", "xmlns:xsi=")
 		newManifest = strings.ReplaceAll(newManifest, "xmlns:_XMLSchema-instance=\"http://www.w3.org/2001/XMLSchema-instance\" _XMLSchema-instance:noNamespaceSchemaLocation=", "xsi:noNamespaceSchemaLocation=")
 
-		if err := os.WriteFile(manifestPath, []byte(newManifest), os.ModePerm); err != nil {
+		if err := os.WriteFile(manifestPath, []byte(newManifest), 0o644); err != nil {
 			return err
 		}
 
@@ -337,7 +337,7 @@ func increaseExtensionVersion(ctx context.Context, ext extension.Extension) erro
 		return err
 	}
 
-	if err := os.WriteFile(composerJsonPath, composerJsonContent, os.ModePerm); err != nil {
+	if err := os.WriteFile(composerJsonPath, composerJsonContent, 0o644); err != nil {
 		return err
 	}
 

--- a/cmd/project/project_generate_jwt.go
+++ b/cmd/project/project_generate_jwt.go
@@ -43,7 +43,7 @@ var projectNewJWTCmd = &cobra.Command{
 		jwtFolder := path.Join(projectRoot, "config", "jwt")
 
 		if _, err := os.Stat(jwtFolder); os.IsNotExist(err) {
-			if err := os.MkdirAll(jwtFolder, os.ModePerm); err != nil {
+			if err := os.MkdirAll(jwtFolder, 0o700); err != nil {
 				return err
 			}
 		}

--- a/internal/account-api/client.go
+++ b/internal/account-api/client.go
@@ -150,7 +150,7 @@ func saveApiTokenToTokenCache(client *Client) error {
 		}
 	}
 
-	err = os.WriteFile(tokenFilePath, content, os.ModePerm)
+	err = os.WriteFile(tokenFilePath, content, 0o600)
 	if err != nil {
 		return err
 	}

--- a/internal/archiver/zip.go
+++ b/internal/archiver/zip.go
@@ -24,12 +24,12 @@ func Unzip(r *zip.Reader, dest string) error {
 
 		if f.FileInfo().IsDir() {
 			// Make Folder
-			_ = os.MkdirAll(fpath, os.ModePerm)
+			_ = os.MkdirAll(fpath, 0o755)
 			continue
 		}
 
 		// Make File
-		if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fpath), 0o755); err != nil {
 			return err
 		}
 

--- a/internal/esbuild/download_unix.go
+++ b/internal/esbuild/download_unix.go
@@ -77,7 +77,7 @@ func downloadDartSass(ctx context.Context, cacheDir string) error {
 
 		if !strings.HasSuffix(folder, ".") {
 			if _, err := os.Stat(folder); os.IsNotExist(err) {
-				if err := os.MkdirAll(folder, os.ModePerm); err != nil {
+				if err := os.MkdirAll(folder, 0o755); err != nil {
 					return err
 				}
 			}

--- a/internal/esbuild/download_windows.go
+++ b/internal/esbuild/download_windows.go
@@ -57,7 +57,7 @@ func downloadDartSass(ctx context.Context, cacheDir string) error {
 		extractedFolder := filepath.Dir(extractedPath)
 
 		if _, err := os.Stat(extractedFolder); os.IsNotExist(err) {
-			if err := os.MkdirAll(extractedFolder, os.ModePerm); err != nil {
+			if err := os.MkdirAll(extractedFolder, 0o755); err != nil {
 				return fmt.Errorf("cannot create dart-sass in temp: %w", err)
 			}
 		}

--- a/internal/esbuild/esbuild.go
+++ b/internal/esbuild/esbuild.go
@@ -192,12 +192,12 @@ func writeBundlerResultToDisk(result api.BuildResult, jsFile, cssFile string) er
 		outFolder := filepath.Dir(outFile)
 
 		if _, err := os.Stat(outFolder); os.IsNotExist(err) {
-			if err := os.MkdirAll(outFolder, os.ModePerm); err != nil {
+			if err := os.MkdirAll(outFolder, 0o755); err != nil {
 				return err
 			}
 		}
 
-		if err := os.WriteFile(outFile, file.Contents, os.ModePerm); err != nil {
+		if err := os.WriteFile(outFile, file.Contents, 0o644); err != nil {
 			return err
 		}
 	}

--- a/internal/esbuild/esbuild_test.go
+++ b/internal/esbuild/esbuild_test.go
@@ -30,9 +30,9 @@ func TestESBuildAdmin(t *testing.T) {
 	dir := t.TempDir()
 
 	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
-	_ = os.MkdirAll(adminDir, os.ModePerm)
+	_ = os.MkdirAll(adminDir, 0o755)
 
-	_ = os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("console.log('bla')"), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("console.log('bla')"), 0o644)
 
 	options := NewAssetCompileOptionsAdmin("Bla", dir)
 	options.DisableSass = true
@@ -53,10 +53,10 @@ func TestESBuildAdminWithSCSS(t *testing.T) {
 	dir := t.TempDir()
 
 	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
-	_ = os.MkdirAll(adminDir, os.ModePerm)
+	_ = os.MkdirAll(adminDir, 0o755)
 
-	_ = os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import './a.scss'"), os.ModePerm)
-	_ = os.WriteFile(filepath.Join(adminDir, "a.scss"), []byte(".a { .b { color: red } }"), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import './a.scss'"), 0o644)
+	_ = os.WriteFile(filepath.Join(adminDir, "a.scss"), []byte(".a { .b { color: red } }"), 0o644)
 
 	options := NewAssetCompileOptionsAdmin("Bla", dir)
 	_, err := CompileExtensionAsset(getTestContext(), options)
@@ -81,9 +81,9 @@ func TestESBuildAdminTypeScript(t *testing.T) {
 	dir := t.TempDir()
 
 	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
-	_ = os.MkdirAll(adminDir, os.ModePerm)
+	_ = os.MkdirAll(adminDir, 0o755)
 
-	_ = os.WriteFile(filepath.Join(adminDir, "main.ts"), []byte("console.log('bla')"), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(adminDir, "main.ts"), []byte("console.log('bla')"), 0o644)
 
 	options := NewAssetCompileOptionsAdmin("Bla", dir)
 	options.DisableSass = true
@@ -101,9 +101,9 @@ func TestESBuildStorefront(t *testing.T) {
 	dir := t.TempDir()
 
 	storefrontDir := filepath.Join(dir, "Resources", "app", "storefront", "src")
-	_ = os.MkdirAll(storefrontDir, os.ModePerm)
+	_ = os.MkdirAll(storefrontDir, 0o755)
 
-	_ = os.WriteFile(filepath.Join(storefrontDir, "main.js"), []byte("console.log('bla')"), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(storefrontDir, "main.js"), []byte("console.log('bla')"), 0o644)
 
 	options := NewAssetCompileOptionsStorefront("Bla", dir, false)
 	_, err := CompileExtensionAsset(getTestContext(), options)
@@ -119,9 +119,9 @@ func TestESBuildStorefrontNewLayout(t *testing.T) {
 	dir := t.TempDir()
 
 	storefrontDir := filepath.Join(dir, "Resources", "app", "storefront", "src")
-	_ = os.MkdirAll(storefrontDir, os.ModePerm)
+	_ = os.MkdirAll(storefrontDir, 0o755)
 
-	_ = os.WriteFile(filepath.Join(storefrontDir, "main.js"), []byte("console.log('bla')"), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(storefrontDir, "main.js"), []byte("console.log('bla')"), 0o644)
 
 	options := NewAssetCompileOptionsStorefront("Bla", dir, true)
 	_, err := CompileExtensionAsset(getTestContext(), options)

--- a/internal/esbuild/fs.go
+++ b/internal/esbuild/fs.go
@@ -16,7 +16,7 @@ func copyStaticFiles(currentPath string, targetPath string) error {
 	}
 
 	// Create target directory if it doesn't exist
-	if err := os.MkdirAll(targetPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(targetPath, 0o755); err != nil {
 		return fmt.Errorf("failed to create target directory: %w", err)
 	}
 
@@ -37,7 +37,7 @@ func copyStaticFiles(currentPath string, targetPath string) error {
 
 		// If it's a directory, create it in target
 		if info.IsDir() {
-			return os.MkdirAll(targetFilePath, os.ModePerm)
+			return os.MkdirAll(targetFilePath, 0o755)
 		}
 
 		// Copy the file

--- a/internal/esbuild/vite_config.go
+++ b/internal/esbuild/vite_config.go
@@ -36,7 +36,7 @@ func dumpViteManifest(options AssetCompileOptions, viteDir string) error {
 		return err
 	}
 
-	return os.WriteFile(path.Join(viteDir, "manifest.json"), j, os.ModePerm)
+	return os.WriteFile(path.Join(viteDir, "manifest.json"), j, 0o644)
 }
 
 type ViteEntrypoint struct {
@@ -100,7 +100,7 @@ func dumpViteEntrypoint(options AssetCompileOptions, viteDir string) error {
 		return err
 	}
 
-	return os.WriteFile(path.Join(viteDir, "entrypoints.json"), j, os.ModePerm)
+	return os.WriteFile(path.Join(viteDir, "entrypoints.json"), j, 0o644)
 }
 
 func DumpViteConfig(options AssetCompileOptions) error {

--- a/internal/extension/app.go
+++ b/internal/extension/app.go
@@ -181,7 +181,7 @@ func (a App) UpdateMetaData(metadata *ExtensionMetadata) error {
 
 	newXml = append([]byte(xml.Header), newXml...)
 
-	if err := os.WriteFile(manifestFile, newXml, os.ModePerm); err != nil {
+	if err := os.WriteFile(manifestFile, newXml, 0o644); err != nil {
 		return fmt.Errorf("could not write manifest.xml: %w", err)
 	}
 

--- a/internal/extension/app_test.go
+++ b/internal/extension/app_test.go
@@ -120,7 +120,7 @@ const testAppManifestSetup = `<?xml version="1.0" encoding="UTF-8"?>
 func TestIconNotExists(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -139,8 +139,8 @@ func TestIconNotExists(t *testing.T) {
 func TestAppNoLicense(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingLicense), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingLicense), 0o644))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
 	app, err := newApp(t.Context(), appPath)
@@ -157,8 +157,8 @@ func TestAppNoLicense(t *testing.T) {
 func TestAppNoCopyright(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingCopyright), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingCopyright), 0o644))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
 	app, err := newApp(t.Context(), appPath)
@@ -175,8 +175,8 @@ func TestAppNoCopyright(t *testing.T) {
 func TestAppNoAuthor(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingAuthor), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestMissingAuthor), 0o644))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
 	app, err := newApp(t.Context(), appPath)
@@ -193,8 +193,8 @@ func TestAppNoAuthor(t *testing.T) {
 func TestAppHasSecret(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestSetup), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestSetup), 0o644))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
 	app, err := newApp(t.Context(), appPath)
@@ -211,10 +211,10 @@ func TestAppHasSecret(t *testing.T) {
 func TestIconExistsDefaultsPath(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -232,7 +232,7 @@ func TestIconExistsDefaultsPath(t *testing.T) {
 func TestIconExistsDifferentPath(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestIcon), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestIcon), 0o644))
 	assert.NoError(t, createTestImageWithSize(filepath.Join(appPath, "app.png"), 120, 120))
 
 	app, err := newApp(t.Context(), appPath)
@@ -251,7 +251,7 @@ func TestIconExistsDifferentPath(t *testing.T) {
 func TestNoCompatibilityGiven(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -266,7 +266,7 @@ func TestNoCompatibilityGiven(t *testing.T) {
 func TestCompatibilityGiven(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestCompatibility), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifestCompatibility), 0o644))
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -281,11 +281,11 @@ func TestCompatibilityGiven(t *testing.T) {
 func TestAppWithPHPFiles(t *testing.T) {
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "test.php"), []byte("<?php echo 'Hello World';"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "test.php"), []byte("<?php echo 'Hello World';"), 0o644))
 
 	app, err := newApp(t.Context(), appPath)
 
@@ -305,13 +305,13 @@ func TestAppWithTwigFiles(t *testing.T) {
 
 	appPath := t.TempDir()
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/views/"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/config"), 0o755))
+	assert.NoError(t, os.MkdirAll(filepath.Join(appPath, "Resources/views/"), 0o755))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "manifest.xml"), []byte(testAppManifest), 0o644))
 	assert.NoError(t, createTestImage(filepath.Join(appPath, "Resources/config/plugin.png")))
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "test.twig"), []byte("<?php echo 'Hello World';"), os.ModePerm))
-	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "Resources/views/test.twig"), []byte("<?php echo 'Hello World';"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "test.twig"), []byte("<?php echo 'Hello World';"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(appPath, "Resources/views/test.twig"), []byte("<?php echo 'Hello World';"), 0o644))
 
 	app, err := newApp(t.Context(), appPath)
 

--- a/internal/extension/asset_platform.go
+++ b/internal/extension/asset_platform.go
@@ -325,7 +325,7 @@ func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, asset
 func prepareShopwareForAsset(shopwareRoot string, cfgs ExtensionAssetConfig) error {
 	varFolder := fmt.Sprintf("%s/var", shopwareRoot)
 	if _, err := os.Stat(varFolder); os.IsNotExist(err) {
-		err := os.Mkdir(varFolder, os.ModePerm)
+		err := os.Mkdir(varFolder, 0o755)
 		if err != nil {
 			return fmt.Errorf("prepareShopwareForAsset: %w", err)
 		}
@@ -336,12 +336,12 @@ func prepareShopwareForAsset(shopwareRoot string, cfgs ExtensionAssetConfig) err
 		return fmt.Errorf("prepareShopwareForAsset: %w", err)
 	}
 
-	err = os.WriteFile(fmt.Sprintf("%s/var/plugins.json", shopwareRoot), pluginJson, os.ModePerm)
+	err = os.WriteFile(fmt.Sprintf("%s/var/plugins.json", shopwareRoot), pluginJson, 0o644)
 	if err != nil {
 		return fmt.Errorf("prepareShopwareForAsset: %w", err)
 	}
 
-	err = os.WriteFile(fmt.Sprintf("%s/var/features.json", shopwareRoot), []byte("{}"), os.ModePerm)
+	err = os.WriteFile(fmt.Sprintf("%s/var/features.json", shopwareRoot), []byte("{}"), 0o644)
 	if err != nil {
 		return fmt.Errorf("prepareShopwareForAsset: %w", err)
 	}

--- a/internal/extension/asset_platform_test.go
+++ b/internal/extension/asset_platform_test.go
@@ -21,10 +21,10 @@ func getTestContext() context.Context {
 func TestGenerateConfigWithAdminAndStorefrontFiles(t *testing.T) {
 	dir := t.TempDir()
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), os.ModePerm))
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.js"), []byte("test"), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "src"), os.ModePerm))
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "src", "main.js"), []byte("test"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.js"), []byte("test"), 0o644))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "src"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "src", "main.js"), []byte("test"), 0o644))
 
 	config := BuildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "FroshTools", Path: dir}}, AssetBuildConfig{})
 
@@ -43,18 +43,18 @@ func TestGenerateConfigWithAdminAndStorefrontFiles(t *testing.T) {
 func TestGenerateConfigWithTypeScript(t *testing.T) {
 	dir := t.TempDir()
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "build"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), 0o755))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "build"), 0o755))
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "src"), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "build"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "src"), 0o755))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "build"), 0o755))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.ts"), []byte("test"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.ts"), []byte("test"), 0o644))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "build", "webpack.config.js"), []byte("test"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "build", "webpack.config.js"), []byte("test"), 0o644))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "src", "main.ts"), []byte("test"), os.ModePerm))
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "build", "webpack.config.js"), []byte("test"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "src", "main.ts"), []byte("test"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "build", "webpack.config.js"), []byte("test"), 0o644))
 
 	config := BuildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "FroshTools", Path: dir}}, AssetBuildConfig{})
 
@@ -73,18 +73,18 @@ func TestGenerateConfigWithTypeScript(t *testing.T) {
 func TestGenerateWebpackCJS(t *testing.T) {
 	dir := t.TempDir()
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "build"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), 0o755))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "build"), 0o755))
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "src"), os.ModePerm))
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "build"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "src"), 0o755))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "storefront", "build"), 0o755))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.ts"), []byte("test"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.ts"), []byte("test"), 0o644))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "build", "webpack.config.cjs"), []byte("test"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "build", "webpack.config.cjs"), []byte("test"), 0o644))
 
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "src", "main.ts"), []byte("test"), os.ModePerm))
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "build", "webpack.config.cjs"), []byte("test"), os.ModePerm))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "src", "main.ts"), []byte("test"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "storefront", "build", "webpack.config.cjs"), []byte("test"), 0o644))
 
 	config := BuildAssetConfigFromExtensions(getTestContext(), []asset.Source{{Name: "FroshTools", Path: dir}}, AssetBuildConfig{})
 

--- a/internal/extension/build_modifier.go
+++ b/internal/extension/build_modifier.go
@@ -48,7 +48,7 @@ func BuildModifier(ext Extension, extensionRoot string, config BuildModifierConf
 			return fmt.Errorf("could not marshal manifest.xml: %w", err)
 		}
 
-		if err := os.WriteFile(path.Join(extensionRoot, "manifest.xml"), newXml, os.ModePerm); err != nil {
+		if err := os.WriteFile(path.Join(extensionRoot, "manifest.xml"), newXml, 0o644); err != nil {
 			return fmt.Errorf("could not write manifest.xml: %w", err)
 		}
 	}
@@ -74,7 +74,7 @@ func BuildModifier(ext Extension, extensionRoot string, config BuildModifierConf
 			return fmt.Errorf("could not marshal composer.json: %w", err)
 		}
 
-		if err := os.WriteFile(path.Join(extensionRoot, "composer.json"), newComposerJson, os.ModePerm); err != nil {
+		if err := os.WriteFile(path.Join(extensionRoot, "composer.json"), newComposerJson, 0o644); err != nil {
 			return fmt.Errorf("could not write composer.json: %w", err)
 		}
 	}

--- a/internal/extension/platform.go
+++ b/internal/extension/platform.go
@@ -236,7 +236,7 @@ func (p PlatformPlugin) UpdateMetaData(metadata *ExtensionMetadata) error {
 
 	newComposerJson = append(newComposerJson, '\n')
 
-	if err := os.WriteFile(composerJsonFile, newComposerJson, os.ModePerm); err != nil {
+	if err := os.WriteFile(composerJsonFile, newComposerJson, 0o644); err != nil {
 		return fmt.Errorf("could not write composer.json: %w", err)
 	}
 

--- a/internal/extension/platform_test.go
+++ b/internal/extension/platform_test.go
@@ -102,7 +102,7 @@ func TestPluginIconExists(t *testing.T) {
 
 	plugin := getTestPlugin(dir)
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(dir, "src", "Resources", "config", "plugin.png")))
 
 	check := &testCheck{}
@@ -134,7 +134,7 @@ func TestPluginIconIsTooBig(t *testing.T) {
 
 	plugin := getTestPlugin(dir)
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), 0o755))
 	assert.NoError(t, createTestImageWithSize(filepath.Join(dir, "src", "Resources", "config", "plugin.png"), 1000, 1000))
 
 	check := &testCheck{}
@@ -155,7 +155,7 @@ func TestPluginGermanDescriptionMissing(t *testing.T) {
 	}
 
 	check := &testCheck{}
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(dir, "src", "Resources", "config", "plugin.png")))
 
 	plugin.Validate(getTestContext(), check)
@@ -173,7 +173,7 @@ func TestPluginGermanDescriptionMissingOnlyEnglishMarket(t *testing.T) {
 		"en-GB": "Frosh Tools",
 	}
 	plugin.config.Store.Availabilities = &[]string{"International"}
-	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "Resources", "config"), 0o755))
 	assert.NoError(t, createTestImage(filepath.Join(dir, "src", "Resources", "config", "plugin.png")))
 
 	check := &testCheck{}

--- a/internal/extension/project_test.go
+++ b/internal/extension/project_test.go
@@ -134,7 +134,7 @@ final public const SHOPWARE_FALLBACK_VERSION = '6.6.9999999.9999999-dev';
 				parentDir := filepath.Dir(tmpFile)
 
 				if _, err := os.Stat(parentDir); os.IsNotExist(err) {
-					assert.NoError(t, os.MkdirAll(parentDir, os.ModePerm))
+					assert.NoError(t, os.MkdirAll(parentDir, 0o755))
 				}
 
 				assert.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
@@ -162,7 +162,7 @@ func TestFindAssetSourcesOfProjectYAMLBundles(t *testing.T) {
 	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{"require": {"shopware/core": "~6.6.0"}}`), 0o644))
 
 	// Create the bundle directory
-	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
 
 	shopCfg := &shop.Config{
 		Build: &shop.ConfigBuild{
@@ -192,7 +192,7 @@ func TestFindAssetSourcesOfProjectYAMLBundleNameOverride(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{"require": {"shopware/core": "~6.6.0"}}`), 0o644))
-	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
 
 	shopCfg := &shop.Config{
 		Build: &shop.ConfigBuild{
@@ -221,7 +221,7 @@ func TestFindAssetSourcesOfProjectYAMLBundleDeduplication(t *testing.T) {
 		"require": {"shopware/core": "~6.6.0"},
 		"extra": {"shopware-bundles": {"src/MyBundle": {"name": "MyBundle"}}}
 	}`), 0o644))
-	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
 
 	shopCfg := &shop.Config{
 		Build: &shop.ConfigBuild{

--- a/internal/extension/snippet_validator_test.go
+++ b/internal/extension/snippet_validator_test.go
@@ -32,8 +32,8 @@ func TestSnippetValidateStorefrontByPathOneFileIsIgnored(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	check := &testCheck{}
-	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{}`), os.ModePerm)
+	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), 0o755)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{}`), 0o644)
 
 	assert.NoError(t, validateSnippetsByPath(tmpDir, tmpDir, check, storefrontSnippetFilter))
 	assert.Len(t, check.Results, 0)
@@ -45,9 +45,9 @@ func TestSnippetValidateStorefrontByPathSameFile(t *testing.T) {
 
 	check := &testCheck{}
 
-	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"test": "1"}`), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"test": "2"}`), os.ModePerm)
+	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), 0o755)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"test": "1"}`), 0o644)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"test": "2"}`), 0o644)
 
 	assert.NoError(t, validateSnippetsByPath(tmpDir, tmpDir, check, storefrontSnippetFilter))
 	assert.Len(t, check.Results, 0)
@@ -59,9 +59,9 @@ func TestSnippetValidateStorefrontByPathTestDifferent(t *testing.T) {
 
 	check := &testCheck{}
 
-	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1"}`), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"b": "2"}`), os.ModePerm)
+	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), 0o755)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1"}`), 0o644)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"b": "2"}`), 0o644)
 
 	assert.NoError(t, validateSnippetsByPath(tmpDir, tmpDir, check, storefrontSnippetFilter))
 	assert.Len(t, check.Results, 2)
@@ -74,9 +74,9 @@ func TestSnippetValidateFindsInvalidJsonInMainFile(t *testing.T) {
 
 	check := &testCheck{}
 
-	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1",}`), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "2"}`), os.ModePerm)
+	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), 0o755)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1",}`), 0o644)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "2"}`), 0o644)
 
 	assert.NoError(t, validateSnippetsByPath(tmpDir, tmpDir, check, storefrontSnippetFilter))
 	assert.Len(t, check.Results, 1)
@@ -88,9 +88,9 @@ func TestSnippetValidateFindsInvalidJsonInGermanFile(t *testing.T) {
 
 	check := &testCheck{}
 
-	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1"}`), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "2",}`), os.ModePerm)
+	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), 0o755)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1"}`), 0o644)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "2",}`), 0o644)
 
 	assert.NoError(t, validateSnippetsByPath(tmpDir, tmpDir, check, storefrontSnippetFilter))
 	assert.Len(t, check.Results, 1)
@@ -101,10 +101,10 @@ func TestSnippetValidatePrioritizesCountryAgnosticEnglish(t *testing.T) {
 	tmpDir := t.TempDir()
 	check := &testCheck{}
 
-	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en.json"), []byte(`{"a": "1"}`), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1", "b": "2"}`), os.ModePerm)
-	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "3"}`), os.ModePerm)
+	_ = os.MkdirAll(path.Join(tmpDir, "Resources", "snippet"), 0o755)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en.json"), []byte(`{"a": "1"}`), 0o644)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.en-GB.json"), []byte(`{"a": "1", "b": "2"}`), 0o644)
+	_ = os.WriteFile(path.Join(tmpDir, "Resources", "snippet", "storefront.de-DE.json"), []byte(`{"a": "3"}`), 0o644)
 
 	assert.NoError(t, validateSnippetsByPath(tmpDir, tmpDir, check, storefrontSnippetFilter))
 	assert.Len(t, check.Results, 1)

--- a/internal/extension/zip.go
+++ b/internal/extension/zip.go
@@ -205,7 +205,7 @@ func PrepareExtensionForRelease(ctx context.Context, sourceRoot, extensionRoot s
 
 		logging.FromContext(ctx).Debugf("Changelog:\n%s", changelogFile)
 
-		if err := os.WriteFile(path.Join(extensionRoot, "CHANGELOG_en-GB.md"), []byte(changelogFile), os.ModePerm); err != nil {
+		if err := os.WriteFile(path.Join(extensionRoot, "CHANGELOG_en-GB.md"), []byte(changelogFile), 0o644); err != nil {
 			return err
 		}
 	}
@@ -233,7 +233,7 @@ func PrepareExtensionForRelease(ctx context.Context, sourceRoot, extensionRoot s
 		return fmt.Errorf("cannot marshal manifest failed: %w", err)
 	}
 
-	if err := os.WriteFile(manifestPath, newManifest, os.ModePerm); err != nil {
+	if err := os.WriteFile(manifestPath, newManifest, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/flexmigrator/env.go
+++ b/internal/flexmigrator/env.go
@@ -14,7 +14,7 @@ func MigrateEnv(project string) error {
 			return err
 		}
 
-		return os.WriteFile(path.Join(project, ".env"), []byte(""), os.ModePerm)
+		return os.WriteFile(path.Join(project, ".env"), []byte(""), 0o644)
 	}
 
 	return nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -23,7 +23,7 @@ func TestNoTags(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	prepareRepository(t, tmpDir)
-	_ = os.WriteFile(filepath.Join(tmpDir, "a"), []byte(""), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(tmpDir, "a"), []byte(""), 0o644)
 	runCommand(t, tmpDir, "add", "a")
 	runCommand(t, tmpDir, "commit", "-m", "initial commit", "--no-verify", "--no-gpg-sign")
 
@@ -44,11 +44,11 @@ func TestWithOneTagAndCommit(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	prepareRepository(t, tmpDir)
-	_ = os.WriteFile(filepath.Join(tmpDir, "a"), []byte(""), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(tmpDir, "a"), []byte(""), 0o644)
 	runCommand(t, tmpDir, "add", "a")
 	runCommand(t, tmpDir, "commit", "-m", "initial commit", "--no-verify", "--no-gpg-sign")
 	runCommand(t, tmpDir, "tag", "v1.0.0", "-m", "initial release")
-	_ = os.WriteFile(filepath.Join(tmpDir, "b"), []byte(""), os.ModePerm)
+	_ = os.WriteFile(filepath.Join(tmpDir, "b"), []byte(""), 0o644)
 	runCommand(t, tmpDir, "add", "b")
 	runCommand(t, tmpDir, "commit", "-m", "second commit", "--no-verify", "--no-gpg-sign")
 

--- a/internal/npm/caniuse.go
+++ b/internal/npm/caniuse.go
@@ -33,7 +33,7 @@ func PatchPackageLockToRemoveCanIUse(packageLockPath string) error {
 		return err
 	}
 
-	return os.WriteFile(packageLockPath, updatedBody, os.ModePerm)
+	return os.WriteFile(packageLockPath, updatedBody, 0o644)
 }
 
 func removeCanIUsePackage(pkg map[string]any) {

--- a/internal/packagist/auth.go
+++ b/internal/packagist/auth.go
@@ -116,7 +116,7 @@ func (a *ComposerAuth) Save() error {
 		return err
 	}
 
-	return os.WriteFile(a.path, content, os.ModePerm)
+	return os.WriteFile(a.path, content, 0o600)
 }
 
 func (a *ComposerAuth) Json(formatted bool) ([]byte, error) {

--- a/internal/packagist/composer.go
+++ b/internal/packagist/composer.go
@@ -161,7 +161,7 @@ func (c *ComposerJson) Save() error {
 		return err
 	}
 
-	return os.WriteFile(c.path, content, os.ModePerm)
+	return os.WriteFile(c.path, content, 0o644)
 }
 
 func ReadComposerJson(composerPath string) (*ComposerJson, error) {

--- a/internal/phplint/wasm.go
+++ b/internal/phplint/wasm.go
@@ -15,7 +15,7 @@ func getWazeroRuntime(ctx context.Context) (wazero.Runtime, error) {
 	wazeroCacheDir := path.Join(system.GetShopwareCliCacheDir(), "wasm", "cache")
 
 	if _, err := os.Stat(wazeroCacheDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(wazeroCacheDir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(wazeroCacheDir, 0o755); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/shop/console.go
+++ b/internal/shop/console.go
@@ -69,7 +69,7 @@ func GetConsoleCompletion(ctx context.Context, projectRoot string) (*ConsoleResp
 		return nil, err
 	}
 
-	if err := os.WriteFile(cachePath, commandJson, os.ModePerm); err != nil {
+	if err := os.WriteFile(cachePath, commandJson, 0o644); err != nil {
 		return nil, err
 	}
 

--- a/internal/shop/version_check_test.go
+++ b/internal/shop/version_check_test.go
@@ -26,7 +26,7 @@ func TestDetectPlatformTrunk(t *testing.T) {
 
 	bytes, _ := json.Marshal(jsonStruct)
 
-	_ = os.WriteFile(composerJson, bytes, os.ModePerm)
+	_ = os.WriteFile(composerJson, bytes, 0o644)
 
 	val, err := IsShopwareVersion(tmpDir, ">=6.3")
 
@@ -45,7 +45,7 @@ func TestDetectComposerJsonNotPlatform(t *testing.T) {
 
 	bytes, _ := json.Marshal(jsonStruct)
 
-	_ = os.WriteFile(composerJson, bytes, os.ModePerm)
+	_ = os.WriteFile(composerJson, bytes, 0o644)
 
 	val, err := IsShopwareVersion(tmpDir, ">=6.3")
 
@@ -72,7 +72,7 @@ func TestComposerLockMatching(t *testing.T) {
 
 	bytes, _ := json.Marshal(jsonStruct)
 
-	_ = os.WriteFile(composerLock, bytes, os.ModePerm)
+	_ = os.WriteFile(composerLock, bytes, 0o644)
 
 	val, err := IsShopwareVersion(tmpDir, ">=6.3")
 
@@ -99,7 +99,7 @@ func TestComposerLockNotMatching(t *testing.T) {
 
 	bytes, _ := json.Marshal(jsonStruct)
 
-	_ = os.WriteFile(composerLock, bytes, os.ModePerm)
+	_ = os.WriteFile(composerLock, bytes, 0o644)
 
 	val, err := IsShopwareVersion(tmpDir, "<=6.3")
 
@@ -121,7 +121,7 @@ func TestComposerLockNoDependency(t *testing.T) {
 
 	bytes, _ := json.Marshal(jsonStruct)
 
-	_ = os.WriteFile(composerLock, bytes, os.ModePerm)
+	_ = os.WriteFile(composerLock, bytes, 0o644)
 
 	val, err := IsShopwareVersion(tmpDir, "<=6.3")
 

--- a/internal/verifier/admin_twig.go
+++ b/internal/verifier/admin_twig.go
@@ -114,7 +114,7 @@ func (a AdminTwigLinter) Fix(ctx context.Context, config ToolConfig) error {
 				}
 			}
 
-			return os.WriteFile(path, []byte(parsed.Dump(0)), os.ModePerm)
+			return os.WriteFile(path, []byte(parsed.Dump(0)), 0o644)
 		})
 		if err != nil {
 			return err
@@ -156,7 +156,7 @@ func (a AdminTwigLinter) Format(ctx context.Context, config ToolConfig, dryRun b
 
 				return nil
 			} else {
-				return os.WriteFile(path, []byte(parsed.Dump(0)), os.ModePerm)
+				return os.WriteFile(path, []byte(parsed.Dump(0)), 0o644)
 			}
 		})
 		if err != nil {

--- a/internal/verifier/embed.go
+++ b/internal/verifier/embed.go
@@ -46,7 +46,7 @@ func SetupTools(ctx context.Context, currentVersion string) error {
 	}
 
 	logging.FromContext(ctx).Debugf("Using tool directory: %s", toolsDir)
-	if err := os.MkdirAll(toolsDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(toolsDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", toolsDir, err)
 	}
 
@@ -91,7 +91,7 @@ func unpackFile(fs embed.FS, filePath, unpackDir string) error {
 
 	for _, file := range f {
 		if file.IsDir() {
-			if err := os.MkdirAll(path.Join(unpackDir, file.Name()), os.ModePerm); err != nil {
+			if err := os.MkdirAll(path.Join(unpackDir, file.Name()), 0o755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", path.Join(unpackDir, file.Name()), err)
 			}
 
@@ -104,7 +104,7 @@ func unpackFile(fs embed.FS, filePath, unpackDir string) error {
 				return fmt.Errorf("failed to read file %s: %w", path.Join(filePath, file.Name()), err)
 			}
 
-			if err := os.WriteFile(path.Join(unpackDir, file.Name()), content, os.ModePerm); err != nil {
+			if err := os.WriteFile(path.Join(unpackDir, file.Name()), content, 0o644); err != nil {
 				return fmt.Errorf("failed to write file %s: %w", path.Join(unpackDir, file.Name()), err)
 			}
 		}

--- a/internal/verifier/project_test.go
+++ b/internal/verifier/project_test.go
@@ -58,7 +58,7 @@ func TestGetConfigFromProjectYAMLBundles(t *testing.T) {
 
 	// Create bundle directory with an admin subfolder
 	adminPath := filepath.Join(tmpDir, "src", "MyBundle", "Resources", "app", "administration")
-	assert.NoError(t, os.MkdirAll(adminPath, os.ModePerm))
+	assert.NoError(t, os.MkdirAll(adminPath, 0o755))
 
 	// Write .shopware-project.yml with the bundle declared
 	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".shopware-project.yml"), []byte(testProjectYAMLSingleBundle), 0o644))
@@ -81,7 +81,7 @@ func TestGetConfigFromProjectYAMLBundleStorefront(t *testing.T) {
 
 	// Create bundle directory with a storefront subfolder only
 	storefrontPath := filepath.Join(tmpDir, "src", "MyBundle", "Resources", "app", "storefront")
-	assert.NoError(t, os.MkdirAll(storefrontPath, os.ModePerm))
+	assert.NoError(t, os.MkdirAll(storefrontPath, 0o755))
 
 	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".shopware-project.yml"), []byte(testProjectYAMLSingleBundle), 0o644))
 
@@ -103,7 +103,7 @@ func TestGetConfigFromProjectYAMLBundleDeduplication(t *testing.T) {
 		"extra": {"shopware-bundles": {"src/MyBundle": {"name": "MyBundle"}}}
 	}`), 0o644))
 
-	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), os.ModePerm))
+	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "src", "MyBundle"), 0o755))
 
 	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".shopware-project.yml"), []byte(testProjectYAMLSingleBundle), 0o644))
 


### PR DESCRIPTION
## What changed

- Replaced remaining `os.ModePerm` usages for file and directory creation with explicit modes.
- Uses `0o600` for sensitive token/credential files, `0o700` for the JWT key directory, `0o644` for regular generated files, and `0o755` for directories.
- Cleaned up the same pattern in tests so `os.ModePerm` no longer appears in the repository.

## Why

`os.ModePerm` maps to `0777`, which can create world-writable and executable files when the process umask is permissive. This avoids over-broad permissions for generated project, cache, package, and credential files.

Closes #1020.

## Validation

- `rg -n "os\\.ModePerm|\\b0777\\b|0o777"`
- `go test ./...`
- `git diff --check`