### PR TITLE
refactor(project create): split RunE into phase-specific files

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -1,50 +1,38 @@
 package project
 
 import (
-	"bytes"
-	"context"
-	_ "embed"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"slices"
-	"sort"
-	"strings"
-	"text/template"
 
-	"charm.land/huh/v2"
-	"charm.land/huh/v2/spinner"
-	"charm.land/lipgloss/v2"
-	"github.com/shyim/go-version"
 	"github.com/spf13/cobra"
 
-	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
-	"github.com/shopware/shopware-cli/internal/git"
 	"github.com/shopware/shopware-cli/internal/packagist"
-	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/system"
-	"github.com/shopware/shopware-cli/internal/tracking"
 	"github.com/shopware/shopware-cli/internal/tui"
-	"github.com/shopware/shopware-cli/logging"
 )
 
-//go:embed static/deploy.php
-var deployerTemplate string
+const (
+	versionLatest = "latest"
 
-//go:embed static/github-ci.yml
-var githubCITemplate string
+	ciNone   = "none"
+	ciGitHub = "github"
+	ciGitLab = "gitlab"
+)
 
-//go:embed static/github-deploy.yml
-var githubDeployTemplate string
+type createOptions struct {
+	projectFolder      string
+	selectedVersion    string
+	selectedDeployment string
+	selectedCI         string
+	useDocker          bool
+	initGit            bool
+	withElasticsearch  bool
+	withAMQP           bool
+	noAudit            bool
 
-//go:embed static/gitlab-ci.yml.tmpl
-var gitlabCITemplate string
-
-//go:embed static/shopware-paas-application.yaml
-var shopwarePaasAppTemplate string
-
-const versionLatest = "latest"
+	interactive           bool
+	elasticsearchExplicit bool
+	isVerbose             bool
+}
 
 var projectCreateCmd = &cobra.Command{
 	Use:   "create [name] [version]",
@@ -72,33 +60,11 @@ var projectCreateCmd = &cobra.Command{
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		interactive := system.IsInteractionEnabled(cmd.Context())
+		opts := parseCreateFlags(cmd, args)
 
-		if interactive {
+		if opts.interactive {
 			tui.PrintBanner()
 		}
-
-		useDocker, _ := cmd.PersistentFlags().GetBool("docker")
-		withElasticsearch, _ := cmd.PersistentFlags().GetBool("with-elasticsearch")
-		withAMQP, _ := cmd.PersistentFlags().GetBool("with-amqp")
-		noAudit, _ := cmd.PersistentFlags().GetBool("no-audit")
-		initGit, _ := cmd.PersistentFlags().GetBool("git")
-		versionFlag, _ := cmd.PersistentFlags().GetString("version")
-		deploymentMethod, _ := cmd.PersistentFlags().GetString("deployment")
-		ciSystem, _ := cmd.PersistentFlags().GetString("ci")
-
-		if cmd.PersistentFlags().Changed("without-elasticsearch") {
-			withoutElasticsearch, _ := cmd.PersistentFlags().GetBool("without-elasticsearch")
-			withElasticsearch = !withoutElasticsearch
-		}
-
-		elasticsearchExplicit := cmd.PersistentFlags().Changed("with-elasticsearch") || cmd.PersistentFlags().Changed("without-elasticsearch")
-
-		const (
-			ciNone   = "none"
-			ciGitHub = "github"
-			ciGitLab = "gitlab"
-		)
 
 		releases, err := packagist.GetShopwarePackageVersions(cmd.Context())
 		if err != nil {
@@ -106,771 +72,88 @@ var projectCreateCmd = &cobra.Command{
 		}
 		filteredVersions := filterInstallVersions(releases)
 
-		type minorGroup struct {
-			label    string
-			versions []string
-		}
-		var minorGroups []minorGroup
-		minorIndex := map[string]int{}
-		for _, v := range filteredVersions {
-			segments := v.Segments()
-			key := fmt.Sprintf("%d.%d", segments[0], segments[1])
-			if idx, ok := minorIndex[key]; ok {
-				minorGroups[idx].versions = append(minorGroups[idx].versions, v.String())
-			} else {
-				minorIndex[key] = len(minorGroups)
-				minorGroups = append(minorGroups, minorGroup{label: key, versions: []string{v.String()}})
-			}
-		}
-
-		minorOptions := make([]huh.Option[string], 0, len(minorGroups)+1)
-		minorOptions = append(minorOptions, huh.NewOption(versionLatest, versionLatest))
-		for _, g := range minorGroups {
-			minorOptions = append(minorOptions, huh.NewOption(g.label, g.label))
-		}
-
-		deploymentOptions := []huh.Option[string]{
-			huh.NewOption("None", packagist.DeploymentNone),
-			huh.NewOption("PaaS powered by Shopware", packagist.DeploymentShopwarePaaS),
-			huh.NewOption("PaaS powered by Platform.sh", packagist.DeploymentPlatformSH),
-			huh.NewOption("Deployer (SSH-based)", packagist.DeploymentDeployer),
-		}
-
-		ciOptions := []huh.Option[string]{
-			huh.NewOption("None", ciNone),
-			huh.NewOption("GitHub Actions", ciGitHub),
-			huh.NewOption("GitLab CI", ciGitLab),
-		}
-
-		var projectFolder string
-		selectedVersion := versionFlag
-		selectedDeployment := deploymentMethod
-		selectedCI := ciSystem
-
-		if len(args) > 0 {
-			projectFolder = args[0]
-		}
-
-		if len(args) > 1 && selectedVersion == "" {
-			selectedVersion = args[1]
-		}
-
-		if !interactive {
-			if projectFolder == "" {
-				return fmt.Errorf("project name is required in non-interactive mode")
-			}
-			if selectedVersion == "" {
-				selectedVersion = versionLatest
-			}
-			if selectedDeployment == "" {
-				selectedDeployment = packagist.DeploymentNone
-			}
-			if selectedCI == "" {
-				selectedCI = ciNone
-			}
-			if !elasticsearchExplicit {
-				withElasticsearch = true
-			}
-		} else {
-			needsAdvanced := selectedDeployment == "" || selectedCI == "" ||
-				!cmd.PersistentFlags().Changed("git") ||
-				!cmd.PersistentFlags().Changed("with-amqp") ||
-				!elasticsearchExplicit
-
-			needsProjectFolder := projectFolder == ""
-			needsVersion := selectedVersion == ""
-			needsDeployment := selectedDeployment == ""
-			needsCI := selectedCI == ""
-
-			selectDocker := tui.Yes
-			selectGit := tui.Yes
-			selectElasticsearch := tui.No
-			selectAMQP := tui.Yes
-
-			if !system.IsGitInstalled() {
-				selectGit = tui.No
-			}
-
-			if !useDocker {
-				extensions, err := system.GetAvailablePHPExtensions(cmd.Context())
-				if err == nil && !slices.Contains(extensions, "amqp") {
-					selectAMQP = tui.No
-				}
-			}
-			selectedMinor := versionLatest
-
-			theme := huh.ThemeFunc(func(isDark bool) *huh.Styles {
-				s := huh.ThemeCharm(isDark)
-				s.Focused.Title = s.Focused.Title.Foreground(tui.BlueColor)
-				s.Blurred.Title = s.Blurred.Title.Foreground(tui.BlueColor)
-				return s
-			})
-
-			onOff := func(v bool) string {
-				if v {
-					return tui.GreenText.Render("Yes")
-				}
-				return tui.RedText.Render("No")
-			}
-
-			sectionStyle := lipgloss.NewStyle().Bold(true).Underline(true)
-			labelStyle := lipgloss.NewStyle().Width(20)
-
-			for {
-				var formGroups []*huh.Group
-
-				if needsProjectFolder {
-					formGroups = append(formGroups, huh.NewGroup(
-						huh.NewInput().
-							Title("Project Name").
-							Description("The name of the project directory to create").
-							Placeholder("my-shopware-project").
-							Value(&projectFolder).
-							Validate(func(s string) error {
-								if s == "" {
-									return fmt.Errorf("project name is required")
-								}
-								if info, err := os.Stat(s); err == nil && info.IsDir() {
-									empty, err := system.IsDirEmpty(s)
-									if err != nil {
-										return err
-									}
-									if !empty {
-										return fmt.Errorf("folder already exists and is not empty")
-									}
-								}
-								return nil
-							}),
-					))
-				}
-
-				if needsVersion {
-					formGroups = append(formGroups, huh.NewGroup(
-						huh.NewSelect[string]().
-							Title("Shopware Version").
-							Description("Select the major version to install").
-							Options(minorOptions...).
-							Value(&selectedMinor),
-					))
-
-					formGroups = append(formGroups, huh.NewGroup(
-						huh.NewSelect[string]().
-							Title("Patch Version").
-							Description("Select the specific patch version").
-							Height(10).
-							OptionsFunc(func() []huh.Option[string] {
-								if idx, ok := minorIndex[selectedMinor]; ok {
-									opts := make([]huh.Option[string], 0, len(minorGroups[idx].versions))
-									for _, v := range minorGroups[idx].versions {
-										opts = append(opts, huh.NewOption(v, v))
-									}
-									return opts
-								}
-								return []huh.Option[string]{huh.NewOption(versionLatest, versionLatest)}
-							}, &selectedMinor).
-							Value(&selectedVersion),
-					).WithHideFunc(func() bool {
-						return selectedMinor == versionLatest
-					}))
-				}
-
-				if !cmd.PersistentFlags().Changed("docker") {
-					formGroups = append(formGroups, huh.NewGroup(
-						tui.NewYesNo().
-							Title("Docker").
-							Description("Use Docker to run Shopware locally").
-							Value(&selectDocker),
-					))
-				}
-
-				selectAdvanced := tui.No
-				if needsAdvanced {
-					formGroups = append(formGroups, huh.NewGroup(
-						tui.NewYesNo().
-							Title("Do you want to further customize the project creation?").
-							Description("Configure deployment, CI/CD, and optional features").
-							Value(&selectAdvanced),
-					))
-				}
-
-				if needsDeployment {
-					selectedDeployment = packagist.DeploymentNone
-					formGroups = append(formGroups, huh.NewGroup(
-						huh.NewSelect[string]().
-							Title("Deployment Method").
-							Description("Select how you want to deploy your project").
-							Options(deploymentOptions...).
-							Value(&selectedDeployment),
-					).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
-				}
-
-				if needsCI {
-					selectedCI = ciNone
-					formGroups = append(formGroups, huh.NewGroup(
-						huh.NewSelect[string]().
-							Title("CI/CD System").
-							Description("Select your CI/CD platform for automated testing and deployment").
-							Options(ciOptions...).
-							Value(&selectedCI),
-					).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
-				}
-
-				if !cmd.PersistentFlags().Changed("git") {
-					formGroups = append(formGroups, huh.NewGroup(
-						tui.NewYesNo().
-							Title("Git Repository").
-							Description("Initialize a Git repository for version control").
-							Value(&selectGit),
-					).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
-				}
-
-				if !elasticsearchExplicit {
-					formGroups = append(formGroups, huh.NewGroup(
-						tui.NewYesNo().
-							Title("OpenSearch").
-							Description("Set up OpenSearch for large catalogs and advanced search").
-							Value(&selectElasticsearch),
-					).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
-				}
-
-				if !cmd.PersistentFlags().Changed("with-amqp") {
-					formGroups = append(formGroups, huh.NewGroup(
-						tui.NewYesNo().
-							Title("AMQP").
-							Description("Enable AMQP queue support for background jobs and messaging").
-							Value(&selectAMQP),
-					).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
-				}
-
-				if len(formGroups) > 0 {
-					form := huh.NewForm(formGroups...).WithTheme(theme)
-					if err := form.Run(); err != nil {
-						return err
-					}
-				}
-
-				if selectedVersion == "" {
-					selectedVersion = versionLatest
-				}
-
-				if !cmd.PersistentFlags().Changed("docker") {
-					useDocker = selectDocker == tui.Yes
-				}
-				if !cmd.PersistentFlags().Changed("git") {
-					initGit = selectGit == tui.Yes
-				}
-				if !elasticsearchExplicit {
-					withElasticsearch = selectElasticsearch == tui.Yes
-				}
-				if !cmd.PersistentFlags().Changed("with-amqp") {
-					withAMQP = selectAMQP == tui.Yes
-				}
-
-				fmt.Println()
-				fmt.Println(sectionStyle.Render("Summary"))
-				fmt.Println()
-				fmt.Printf("  %s %s\n", labelStyle.Render("Project name:"), projectFolder)
-				fmt.Printf("  %s %s\n", labelStyle.Render("Version:"), selectedVersion)
-				fmt.Printf("  %s %s\n", labelStyle.Render("Deployment:"), selectedDeployment)
-				fmt.Printf("  %s %s\n", labelStyle.Render("CI/CD:"), selectedCI)
-				fmt.Printf("  %s %s\n", labelStyle.Render("Docker:"), onOff(useDocker))
-				fmt.Printf("  %s %s\n", labelStyle.Render("Git:"), onOff(initGit))
-				fmt.Printf("  %s %s\n", labelStyle.Render("OpenSearch:"), onOff(withElasticsearch))
-				fmt.Printf("  %s %s\n", labelStyle.Render("AMQP:"), onOff(withAMQP))
-				fmt.Println()
-
-				selectConfirm := "proceed"
-				confirmForm := huh.NewForm(huh.NewGroup(
-					huh.NewSelect[string]().
-						Title("What would you like to do?").
-						Options(
-							huh.NewOption("Proceed", "proceed"),
-							huh.NewOption("Restart form", "restart"),
-							huh.NewOption("Cancel", "cancel"),
-						).
-						Value(&selectConfirm),
-				)).WithTheme(theme)
-
-				if err := confirmForm.Run(); err != nil {
-					return err
-				}
-
-				if selectConfirm == "proceed" {
-					break
-				}
-
-				if selectConfirm == "cancel" {
-					return fmt.Errorf("project creation cancelled")
-				}
-			}
-		}
-
-		chooseVersion := resolveVersion(selectedVersion, filteredVersions)
-		if chooseVersion == "" {
-			return fmt.Errorf("cannot find version %s", selectedVersion)
-		}
-
-		phpConstraint := packagist.PHPConstraintForShopwareVersion(releases, chooseVersion)
-
-		missingDeps := system.CheckProjectDependencies(cmd.Context(), useDocker, phpConstraint)
-
-		validDeployments := map[string]bool{
-			packagist.DeploymentNone:         true,
-			packagist.DeploymentDeployer:     true,
-			packagist.DeploymentPlatformSH:   true,
-			packagist.DeploymentShopwarePaaS: true,
-		}
-		if !validDeployments[selectedDeployment] {
-			return fmt.Errorf("invalid deployment method: %s. Valid options: none, deployer, platformsh, shopware-paas", selectedDeployment)
-		}
-
-		validCISystems := map[string]bool{
-			ciNone:   true,
-			ciGitHub: true,
-			ciGitLab: true,
-		}
-		if !validCISystems[selectedCI] {
-			return fmt.Errorf("invalid CI system: %s. Valid options: none, github, gitlab", selectedCI)
-		}
-
-		if len(missingDeps) > 0 {
-			fmt.Fprintln(os.Stderr, system.RenderMissingDependencies(useDocker, missingDeps))
-			return fmt.Errorf("missing required dependencies")
-		}
-
-		advisories, err := packagist.GetShopwareSecurityAdvisories(cmd.Context())
-		if err != nil {
-			logging.FromContext(cmd.Context()).Warnf("Could not fetch security advisories: %v", err)
-		}
-		matchingAdvisories := packagist.FilterAdvisoriesForVersion(advisories, chooseVersion)
-		if len(matchingAdvisories) > 0 {
-			fmt.Fprintln(os.Stderr, renderSecurityAdvisories(chooseVersion, matchingAdvisories))
-
-			if interactive {
-				var continueAnyway string
-				if err := huh.NewForm(huh.NewGroup(
-					tui.NewYesNo().
-						Title(fmt.Sprintf("Shopware %s is affected by %d known security advisor%s", chooseVersion, len(matchingAdvisories), pluralize(len(matchingAdvisories), "y", "ies"))).
-						Description("Continuing will disable composer's audit blocking (--no-audit) so installation can proceed. If you continue, we strongly recommend installing the Shopware Security plugin (https://store.shopware.com/en/swag136939272659f/shopware-6-security-plugin.html) which backports security fixes to older versions. Do you want to continue anyway?").
-						Value(&continueAnyway),
-				)).Run(); err != nil {
-					return err
-				}
-
-				if continueAnyway == tui.No {
-					return fmt.Errorf("project creation cancelled")
-				}
-
-				noAudit = true
-			} else if !noAudit {
-				return fmt.Errorf("shopware %s is affected by known security advisories; re-run with --no-audit to proceed. We strongly recommend installing the Shopware Security plugin (https://store.shopware.com/en/swag136939272659f/shopware-6-security-plugin.html) which backports security fixes to older versions", chooseVersion)
-			}
-		}
-
-		incompatibilities := system.CheckIncompatibilities(useDocker, projectFolder)
-
-		for _, incompatibility := range incompatibilities {
-			if interactive {
-				var continueAnyway string
-				if err := huh.NewForm(huh.NewGroup(
-					tui.NewYesNo().
-						Title(incompatibility.Title).
-						Description(fmt.Sprintf("%s. Do you want to continue anyway?", incompatibility.Description)).
-						Value(&continueAnyway),
-				)).Run(); err != nil {
-					return err
-				}
-
-				if continueAnyway == tui.No {
-					return fmt.Errorf("project creation cancelled")
-				}
-			} else {
-				logging.FromContext(cmd.Context()).Warnf("%s. %s", incompatibility.Title, incompatibility.Description)
-			}
-		}
-
-		if _, err := os.Stat(projectFolder); err == nil {
-			empty, err := system.IsDirEmpty(projectFolder)
-			if err != nil {
+		if opts.interactive {
+			if err := runCreateForm(cmd, &opts, filteredVersions); err != nil {
 				return err
 			}
-
-			if !empty {
-				return fmt.Errorf("the folder %s exists already and is not empty", projectFolder)
+		} else {
+			if err := applyNonInteractiveDefaults(&opts); err != nil {
+				return err
 			}
 		}
 
-		// @todo: it's broken in paas deployments, the paas recipe configures Elasticsearch and it's difficult to do it only when elasticsearch is available.
-		if selectedDeployment == packagist.DeploymentShopwarePaaS {
-			withElasticsearch = true
-		}
-
-		go tracking.Track(cmd.Context(), "project.create", map[string]string{
-			"version":            selectedVersion,
-			"deployment":         selectedDeployment,
-			"ci":                 selectedCI,
-			"docker":             fmt.Sprintf("%v", useDocker),
-			"with_elasticsearch": fmt.Sprintf("%v", withElasticsearch),
-			"with_amqp":          fmt.Sprintf("%v", withAMQP),
-			"interactive":        fmt.Sprintf("%v", interactive),
-		})
-
-		if err := os.MkdirAll(projectFolder, os.ModePerm); err != nil {
-			return err
-		}
-
-		logging.FromContext(cmd.Context()).Infof("Setting up Shopware %s", chooseVersion)
-
-		composerJson, err := packagist.GenerateComposerJson(cmd.Context(), packagist.ComposerJsonOptions{
-			Version:          chooseVersion,
-			RC:               strings.Contains(chooseVersion, "rc"),
-			UseElasticsearch: withElasticsearch,
-			UseAMQP:          withAMQP,
-			NoAudit:          noAudit,
-			DeploymentMethod: selectedDeployment,
-		})
+		chosenVersion, phpConstraint, err := validateAndPreflight(cmd.Context(), &opts, releases, filteredVersions)
 		if err != nil {
 			return err
 		}
 
-		if err := os.WriteFile(filepath.Join(projectFolder, "composer.json"), []byte(composerJson), os.ModePerm); err != nil {
+		if err := scaffoldProject(cmd.Context(), &opts, chosenVersion); err != nil {
 			return err
 		}
 
-		if err := os.WriteFile(filepath.Join(projectFolder, ".env"), []byte(""), os.ModePerm); err != nil {
-			return err
-		}
-
-		envLocalContent := ""
-
-		if useDocker {
-			envLocalContent += "APP_ENV=dev\n"
-		}
-
-		if err := os.WriteFile(filepath.Join(projectFolder, ".env.local"), []byte(envLocalContent), os.ModePerm); err != nil {
-			return err
-		}
-
-		if err := os.WriteFile(filepath.Join(projectFolder, ".gitignore"), []byte("/.idea\n/vendor"), os.ModePerm); err != nil {
-			return err
-		}
-
-		if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "plugins"), os.ModePerm); err != nil {
-			return err
-		}
-
-		if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "static-plugins"), os.ModePerm); err != nil {
-			return err
-		}
-
-		if !useDocker && system.IsSymfonyCliInstalled() {
-			if err := os.WriteFile(filepath.Join(projectFolder, "php.ini"), []byte("memory_limit=512M"), os.ModePerm); err != nil {
-				return err
-			}
-		}
-
-		if err := setupDeployment(projectFolder, selectedDeployment); err != nil {
-			return err
-		}
-
-		if err := setupCI(cmd.Context(), projectFolder, selectedCI, selectedDeployment); err != nil {
-			return err
-		}
-
-		logging.FromContext(cmd.Context()).Infof("Installing dependencies")
-
-		isVerbose, _ := cmd.Flags().GetBool("verbose")
-		showSpinner := system.IsInteractionEnabled(cmd.Context()) && !isVerbose
-
-		composerInstallPHP := ""
-		if useDocker {
-			composerInstallPHP = phpConstraint.HighestSupported()
-			logging.FromContext(cmd.Context()).Infof("Using PHP %s for composer install", composerInstallPHP)
-		}
-
-		if err := runComposerInstall(cmd.Context(), projectFolder, useDocker, showSpinner, composerInstallPHP); err != nil {
-			return err
-		}
-
-		if useDocker {
-			if err := dockerpkg.WriteComposeFile(projectFolder, &dockerpkg.ComposeOptions{PHPVersion: composerInstallPHP}); err != nil {
-				return err
-			}
-		}
-
-		if initGit {
-			logging.FromContext(cmd.Context()).Infof("Initializing Git repository")
-			if err := git.Init(cmd.Context(), projectFolder); err != nil {
-				return fmt.Errorf("failed to initialize git repository: %w", err)
-			}
-		}
-
-		shopCfg := shop.NewConfig()
-		if useDocker {
-			shopCfg.Environments["local"].Type = "docker"
-			shopCfg.Docker = &shop.ConfigDocker{
-				PHP: &shop.ConfigDockerPHP{Version: composerInstallPHP},
-			}
-		}
-
-		if err := shop.WriteConfig(shopCfg, projectFolder); err != nil {
-			return err
-		}
-
-		if interactive {
-			cmdStyle := lipgloss.NewStyle().Bold(true)
-			sectionStyle := lipgloss.NewStyle().Bold(true).Underline(true)
-
-			fmt.Println()
-			fmt.Println(tui.GreenText.Render("✔ Setup complete in " + projectFolder))
-
-			if useDocker {
-				fmt.Println()
-				fmt.Println(sectionStyle.Render("Next steps"))
-				fmt.Println()
-				fmt.Printf("  %s  %s\n", tui.GreenText.Render("Start developing:"), cmdStyle.Render(fmt.Sprintf("cd %s && shopware-cli project dev", projectFolder)))
-				fmt.Println()
-				fmt.Println(sectionStyle.Render("Access your shop (after make setup)"))
-				fmt.Println()
-				fmt.Printf("  %s  %s\n", tui.GreenText.Render("Storefront:"), cmdStyle.Render("http://127.0.0.1:8000"))
-				fmt.Printf("  %s  %s\n", tui.GreenText.Render("Admin:"), cmdStyle.Render("http://127.0.0.1:8000/admin"))
-				fmt.Printf("  %s  %s\n", tui.GreenText.Render("Credentials:"), cmdStyle.Render("admin")+" / "+cmdStyle.Render("shopware"))
-			}
-
-			fmt.Println()
-		} else {
-			logging.FromContext(cmd.Context()).Infof("Project created successfully in %s", projectFolder)
-		}
-
-		return nil
+		return installAndFinalize(cmd, &opts, phpConstraint)
 	},
 }
 
-func renderSecurityAdvisories(chosenVersion string, advisories []packagist.SecurityAdvisory) string {
-	var b strings.Builder
+func parseCreateFlags(cmd *cobra.Command, args []string) createOptions {
+	useDocker, _ := cmd.PersistentFlags().GetBool("docker")
+	withElasticsearch, _ := cmd.PersistentFlags().GetBool("with-elasticsearch")
+	withAMQP, _ := cmd.PersistentFlags().GetBool("with-amqp")
+	noAudit, _ := cmd.PersistentFlags().GetBool("no-audit")
+	initGit, _ := cmd.PersistentFlags().GetBool("git")
+	versionFlag, _ := cmd.PersistentFlags().GetString("version")
+	deploymentMethod, _ := cmd.PersistentFlags().GetString("deployment")
+	ciSystem, _ := cmd.PersistentFlags().GetString("ci")
 
-	b.WriteString(tui.RedText.Bold(true).Render(fmt.Sprintf("Security Advisories for Shopware %s", chosenVersion)))
-	b.WriteString("\n\n")
+	if cmd.PersistentFlags().Changed("without-elasticsearch") {
+		withoutElasticsearch, _ := cmd.PersistentFlags().GetBool("without-elasticsearch")
+		withElasticsearch = !withoutElasticsearch
+	}
+	elasticsearchExplicit := cmd.PersistentFlags().Changed("with-elasticsearch") || cmd.PersistentFlags().Changed("without-elasticsearch")
 
-	warn := tui.YellowText.Render("⚠")
-	for _, a := range advisories {
-		severity := strings.ToUpper(a.Severity)
-		if severity == "" {
-			severity = "UNKNOWN"
-		}
-		fmt.Fprintf(&b, "  %s [%s] %s\n", warn, tui.BoldText.Render(severity), a.Title)
-		if a.CVE != "" {
-			fmt.Fprintf(&b, "    %s: %s\n", tui.DimText.Render("CVE"), a.CVE)
-		}
-		if a.Link != "" {
-			fmt.Fprintf(&b, "    %s\n", tui.BlueText.Render(a.Link))
-		}
+	isVerbose, _ := cmd.Flags().GetBool("verbose")
+
+	opts := createOptions{
+		useDocker:             useDocker,
+		withElasticsearch:     withElasticsearch,
+		withAMQP:              withAMQP,
+		noAudit:               noAudit,
+		initGit:               initGit,
+		selectedVersion:       versionFlag,
+		selectedDeployment:    deploymentMethod,
+		selectedCI:            ciSystem,
+		interactive:           system.IsInteractionEnabled(cmd.Context()),
+		elasticsearchExplicit: elasticsearchExplicit,
+		isVerbose:             isVerbose,
 	}
 
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(tui.BlueColor).
-		Padding(1, 2).
-		Render(strings.TrimRight(b.String(), "\n"))
+	if len(args) > 0 {
+		opts.projectFolder = args[0]
+	}
+	if len(args) > 1 && opts.selectedVersion == "" {
+		opts.selectedVersion = args[1]
+	}
+
+	return opts
 }
 
-func pluralize(n int, singular, plural string) string {
-	if n == 1 {
-		return singular
+func applyNonInteractiveDefaults(opts *createOptions) error {
+	if opts.projectFolder == "" {
+		return fmt.Errorf("project name is required in non-interactive mode")
 	}
-	return plural
-}
-
-func resolveVersion(selectedVersion string, filteredVersions []*version.Version) string {
-	if selectedVersion == versionLatest {
-		// pick the most recent stable (non-RC) version
-		for _, v := range filteredVersions {
-			vs := v.String()
-			if !strings.Contains(strings.ToLower(vs), "rc") {
-				return vs
-			}
-		}
-		// if no stable found, fall back to top entry
-		if len(filteredVersions) > 0 {
-			return filteredVersions[0].String()
-		}
-		return ""
+	if opts.selectedVersion == "" {
+		opts.selectedVersion = versionLatest
 	}
-
-	if strings.HasPrefix(selectedVersion, "dev-") {
-		return selectedVersion
+	if opts.selectedDeployment == "" {
+		opts.selectedDeployment = packagist.DeploymentNone
 	}
-
-	for _, release := range filteredVersions {
-		if release.String() == selectedVersion {
-			return release.String()
-		}
+	if opts.selectedCI == "" {
+		opts.selectedCI = ciNone
 	}
-
-	return ""
-}
-
-func setupDeployment(projectFolder, deploymentMethod string) error {
-	switch deploymentMethod {
-	case packagist.DeploymentDeployer:
-		if err := os.WriteFile(filepath.Join(projectFolder, "deploy.php"), []byte(deployerTemplate), os.ModePerm); err != nil {
-			return err
-		}
-
-	case packagist.DeploymentShopwarePaaS:
-		if err := os.WriteFile(filepath.Join(projectFolder, "application.yaml"), []byte(shopwarePaasAppTemplate), os.ModePerm); err != nil {
-			return err
-		}
+	if !opts.elasticsearchExplicit {
+		opts.withElasticsearch = true
 	}
-
 	return nil
-}
-
-func setupCI(ctx context.Context, projectFolder, ciSystem, deploymentMethod string) error {
-	switch ciSystem {
-	case "github":
-		if err := os.MkdirAll(filepath.Join(projectFolder, ".github", "workflows"), os.ModePerm); err != nil {
-			return err
-		}
-		ciPath := filepath.Join(".github", "workflows", "ci.yml")
-		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), []byte(githubCITemplate), os.ModePerm); err != nil {
-			return err
-		}
-		logging.FromContext(ctx).Infof("Created CI template %s", ciPath)
-		if deploymentMethod == packagist.DeploymentDeployer {
-			deployPath := filepath.Join(".github", "workflows", "deploy.yml")
-			if err := os.WriteFile(filepath.Join(projectFolder, deployPath), []byte(githubDeployTemplate), os.ModePerm); err != nil {
-				return err
-			}
-			logging.FromContext(ctx).Infof("Created CI template %s", deployPath)
-		}
-
-	case "gitlab":
-		tmpl, err := template.New("gitlab-ci").Parse(gitlabCITemplate)
-		if err != nil {
-			return err
-		}
-
-		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, struct{ Deployer bool }{Deployer: deploymentMethod == packagist.DeploymentDeployer}); err != nil {
-			return err
-		}
-
-		ciPath := ".gitlab-ci.yml"
-		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), buf.Bytes(), os.ModePerm); err != nil {
-			return err
-		}
-		logging.FromContext(ctx).Infof("Created CI template %s", ciPath)
-	}
-
-	return nil
-}
-
-func runComposerInstall(ctx context.Context, projectFolder string, useDocker bool, showSpinner bool, phpVersion string) error {
-	var cmdInstall *exec.Cmd
-
-	if useDocker && !system.IsInsideContainer() {
-		absProjectFolder, err := filepath.Abs(projectFolder)
-		if err != nil {
-			return err
-		}
-
-		dockerArgs := []string{"run",
-			"--rm",
-			"--pull=always",
-			"-v", fmt.Sprintf("%s:/app", absProjectFolder),
-			"-w", "/app"}
-
-		if system.IsDockerMountable() {
-			homeDir, err := os.UserHomeDir()
-			if err == nil {
-				composerDir := filepath.Join(homeDir, ".composer")
-				_ = os.MkdirAll(composerDir, 0o755)
-				dockerArgs = append(dockerArgs, "-v", fmt.Sprintf("%s:/tmp/composer/", composerDir))
-			}
-		}
-
-		if phpVersion == "" {
-			phpVersion = packagist.SupportedPHPVersions[len(packagist.SupportedPHPVersions)-1]
-		}
-		dockerArgs = append(dockerArgs,
-			fmt.Sprintf("ghcr.io/shopware/docker-dev:php%s-node24-caddy", phpVersion),
-			"composer", "install", "--no-interaction")
-
-		cmdInstall = exec.CommandContext(ctx, "docker", dockerArgs...)
-	} else {
-		composerBinary, err := exec.LookPath("composer")
-		if err != nil {
-			return err
-		}
-
-		phpBinary := os.Getenv("PHP_BINARY")
-
-		if phpBinary != "" {
-			cmdInstall = exec.CommandContext(ctx, phpBinary, composerBinary, "install", "--no-interaction")
-		} else {
-			cmdInstall = exec.CommandContext(ctx, "composer", "install", "--no-interaction")
-		}
-
-		cmdInstall.Dir = projectFolder
-	}
-
-	if !showSpinner {
-		cmdInstall.Stdin = os.Stdin
-		cmdInstall.Stdout = os.Stdout
-		cmdInstall.Stderr = os.Stderr
-
-		return cmdInstall.Run()
-	}
-
-	var stdErr bytes.Buffer
-	cmdInstall.Stderr = &stdErr
-
-	var runErr error
-
-	if err := spinner.New().Context(ctx).Title("Installing dependencies").Action(func() {
-		runErr = cmdInstall.Run()
-	}).Run(); err != nil {
-		return err
-	}
-
-	if runErr != nil {
-		if stdErr.Len() > 0 {
-			fmt.Fprint(os.Stderr, stdErr.String())
-		}
-
-		return runErr
-	}
-
-	return nil
-}
-
-func filterInstallVersions(releases []packagist.ComposerPackageVersion) []*version.Version {
-	filteredVersions := make([]*version.Version, 0)
-	constraint, _ := version.NewConstraint(">=6.4.18.0")
-
-	for _, release := range releases {
-		if strings.HasPrefix(release.Version, "dev-") {
-			continue
-		}
-
-		parsed, err := version.NewVersion(release.Version)
-		if err != nil {
-			continue
-		}
-
-		if constraint.Check(parsed) {
-			filteredVersions = append(filteredVersions, parsed)
-		}
-	}
-
-	sort.Sort(sort.Reverse(version.Collection(filteredVersions)))
-
-	for i, v := range filteredVersions {
-		filteredVersions[i], _ = version.NewVersion(strings.TrimPrefix(v.String(), "v"))
-	}
-
-	return filteredVersions
 }
 
 func init() {

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -15,7 +15,7 @@ import (
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
-func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*version.Version) error {
+func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*version.Version) error { //nolint:gocyclo
 	type minorGroup struct {
 		label    string
 		versions []string

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -1,0 +1,286 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"charm.land/huh/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/shyim/go-version"
+	"github.com/spf13/cobra"
+
+	"github.com/shopware/shopware-cli/internal/packagist"
+	"github.com/shopware/shopware-cli/internal/system"
+	"github.com/shopware/shopware-cli/internal/tui"
+)
+
+func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*version.Version) error {
+	type minorGroup struct {
+		label    string
+		versions []string
+	}
+	var minorGroups []minorGroup
+	minorIndex := map[string]int{}
+	for _, v := range filteredVersions {
+		segments := v.Segments()
+		key := fmt.Sprintf("%d.%d", segments[0], segments[1])
+		if idx, ok := minorIndex[key]; ok {
+			minorGroups[idx].versions = append(minorGroups[idx].versions, v.String())
+		} else {
+			minorIndex[key] = len(minorGroups)
+			minorGroups = append(minorGroups, minorGroup{label: key, versions: []string{v.String()}})
+		}
+	}
+
+	minorOptions := make([]huh.Option[string], 0, len(minorGroups)+1)
+	minorOptions = append(minorOptions, huh.NewOption(versionLatest, versionLatest))
+	for _, g := range minorGroups {
+		minorOptions = append(minorOptions, huh.NewOption(g.label, g.label))
+	}
+
+	deploymentOptions := []huh.Option[string]{
+		huh.NewOption("None", packagist.DeploymentNone),
+		huh.NewOption("PaaS powered by Shopware", packagist.DeploymentShopwarePaaS),
+		huh.NewOption("PaaS powered by Platform.sh", packagist.DeploymentPlatformSH),
+		huh.NewOption("Deployer (SSH-based)", packagist.DeploymentDeployer),
+	}
+
+	ciOptions := []huh.Option[string]{
+		huh.NewOption("None", ciNone),
+		huh.NewOption("GitHub Actions", ciGitHub),
+		huh.NewOption("GitLab CI", ciGitLab),
+	}
+
+	needsAdvanced := opts.selectedDeployment == "" || opts.selectedCI == "" ||
+		!cmd.PersistentFlags().Changed("git") ||
+		!cmd.PersistentFlags().Changed("with-amqp") ||
+		!opts.elasticsearchExplicit
+
+	needsProjectFolder := opts.projectFolder == ""
+	needsVersion := opts.selectedVersion == ""
+	needsDeployment := opts.selectedDeployment == ""
+	needsCI := opts.selectedCI == ""
+
+	selectDocker := tui.Yes
+	selectGit := tui.Yes
+	selectElasticsearch := tui.No
+	selectAMQP := tui.Yes
+
+	if !system.IsGitInstalled() {
+		selectGit = tui.No
+	}
+
+	if !opts.useDocker {
+		extensions, err := system.GetAvailablePHPExtensions(cmd.Context())
+		if err == nil && !slices.Contains(extensions, "amqp") {
+			selectAMQP = tui.No
+		}
+	}
+	selectedMinor := versionLatest
+
+	theme := huh.ThemeFunc(func(isDark bool) *huh.Styles {
+		s := huh.ThemeCharm(isDark)
+		s.Focused.Title = s.Focused.Title.Foreground(tui.BlueColor)
+		s.Blurred.Title = s.Blurred.Title.Foreground(tui.BlueColor)
+		return s
+	})
+
+	onOff := func(v bool) string {
+		if v {
+			return tui.GreenText.Render("Yes")
+		}
+		return tui.RedText.Render("No")
+	}
+
+	sectionStyle := lipgloss.NewStyle().Bold(true).Underline(true)
+	labelStyle := lipgloss.NewStyle().Width(20)
+
+	for {
+		var formGroups []*huh.Group
+
+		if needsProjectFolder {
+			formGroups = append(formGroups, huh.NewGroup(
+				huh.NewInput().
+					Title("Project Name").
+					Description("The name of the project directory to create").
+					Placeholder("my-shopware-project").
+					Value(&opts.projectFolder).
+					Validate(func(s string) error {
+						if s == "" {
+							return fmt.Errorf("project name is required")
+						}
+						if info, err := os.Stat(s); err == nil && info.IsDir() {
+							empty, err := system.IsDirEmpty(s)
+							if err != nil {
+								return err
+							}
+							if !empty {
+								return fmt.Errorf("folder already exists and is not empty")
+							}
+						}
+						return nil
+					}),
+			))
+		}
+
+		if needsVersion {
+			formGroups = append(formGroups, huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Shopware Version").
+					Description("Select the major version to install").
+					Options(minorOptions...).
+					Value(&selectedMinor),
+			))
+
+			formGroups = append(formGroups, huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Patch Version").
+					Description("Select the specific patch version").
+					Height(10).
+					OptionsFunc(func() []huh.Option[string] {
+						if idx, ok := minorIndex[selectedMinor]; ok {
+							out := make([]huh.Option[string], 0, len(minorGroups[idx].versions))
+							for _, v := range minorGroups[idx].versions {
+								out = append(out, huh.NewOption(v, v))
+							}
+							return out
+						}
+						return []huh.Option[string]{huh.NewOption(versionLatest, versionLatest)}
+					}, &selectedMinor).
+					Value(&opts.selectedVersion),
+			).WithHideFunc(func() bool {
+				return selectedMinor == versionLatest
+			}))
+		}
+
+		if !cmd.PersistentFlags().Changed("docker") {
+			formGroups = append(formGroups, huh.NewGroup(
+				tui.NewYesNo().
+					Title("Docker").
+					Description("Use Docker to run Shopware locally").
+					Value(&selectDocker),
+			))
+		}
+
+		selectAdvanced := tui.No
+		if needsAdvanced {
+			formGroups = append(formGroups, huh.NewGroup(
+				tui.NewYesNo().
+					Title("Do you want to further customize the project creation?").
+					Description("Configure deployment, CI/CD, and optional features").
+					Value(&selectAdvanced),
+			))
+		}
+
+		if needsDeployment {
+			opts.selectedDeployment = packagist.DeploymentNone
+			formGroups = append(formGroups, huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Deployment Method").
+					Description("Select how you want to deploy your project").
+					Options(deploymentOptions...).
+					Value(&opts.selectedDeployment),
+			).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
+		}
+
+		if needsCI {
+			opts.selectedCI = ciNone
+			formGroups = append(formGroups, huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("CI/CD System").
+					Description("Select your CI/CD platform for automated testing and deployment").
+					Options(ciOptions...).
+					Value(&opts.selectedCI),
+			).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
+		}
+
+		if !cmd.PersistentFlags().Changed("git") {
+			formGroups = append(formGroups, huh.NewGroup(
+				tui.NewYesNo().
+					Title("Git Repository").
+					Description("Initialize a Git repository for version control").
+					Value(&selectGit),
+			).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
+		}
+
+		if !opts.elasticsearchExplicit {
+			formGroups = append(formGroups, huh.NewGroup(
+				tui.NewYesNo().
+					Title("OpenSearch").
+					Description("Set up OpenSearch for large catalogs and advanced search").
+					Value(&selectElasticsearch),
+			).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
+		}
+
+		if !cmd.PersistentFlags().Changed("with-amqp") {
+			formGroups = append(formGroups, huh.NewGroup(
+				tui.NewYesNo().
+					Title("AMQP").
+					Description("Enable AMQP queue support for background jobs and messaging").
+					Value(&selectAMQP),
+			).WithHideFunc(func() bool { return selectAdvanced != tui.Yes }))
+		}
+
+		if len(formGroups) > 0 {
+			form := huh.NewForm(formGroups...).WithTheme(theme)
+			if err := form.Run(); err != nil {
+				return err
+			}
+		}
+
+		if opts.selectedVersion == "" {
+			opts.selectedVersion = versionLatest
+		}
+
+		if !cmd.PersistentFlags().Changed("docker") {
+			opts.useDocker = selectDocker == tui.Yes
+		}
+		if !cmd.PersistentFlags().Changed("git") {
+			opts.initGit = selectGit == tui.Yes
+		}
+		if !opts.elasticsearchExplicit {
+			opts.withElasticsearch = selectElasticsearch == tui.Yes
+		}
+		if !cmd.PersistentFlags().Changed("with-amqp") {
+			opts.withAMQP = selectAMQP == tui.Yes
+		}
+
+		fmt.Println()
+		fmt.Println(sectionStyle.Render("Summary"))
+		fmt.Println()
+		fmt.Printf("  %s %s\n", labelStyle.Render("Project name:"), opts.projectFolder)
+		fmt.Printf("  %s %s\n", labelStyle.Render("Version:"), opts.selectedVersion)
+		fmt.Printf("  %s %s\n", labelStyle.Render("Deployment:"), opts.selectedDeployment)
+		fmt.Printf("  %s %s\n", labelStyle.Render("CI/CD:"), opts.selectedCI)
+		fmt.Printf("  %s %s\n", labelStyle.Render("Docker:"), onOff(opts.useDocker))
+		fmt.Printf("  %s %s\n", labelStyle.Render("Git:"), onOff(opts.initGit))
+		fmt.Printf("  %s %s\n", labelStyle.Render("OpenSearch:"), onOff(opts.withElasticsearch))
+		fmt.Printf("  %s %s\n", labelStyle.Render("AMQP:"), onOff(opts.withAMQP))
+		fmt.Println()
+
+		selectConfirm := "proceed"
+		confirmForm := huh.NewForm(huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("What would you like to do?").
+				Options(
+					huh.NewOption("Proceed", "proceed"),
+					huh.NewOption("Restart form", "restart"),
+					huh.NewOption("Cancel", "cancel"),
+				).
+				Value(&selectConfirm),
+		)).WithTheme(theme)
+
+		if err := confirmForm.Run(); err != nil {
+			return err
+		}
+
+		if selectConfirm == "proceed" {
+			return nil
+		}
+
+		if selectConfirm == "cancel" {
+			return fmt.Errorf("project creation cancelled")
+		}
+	}
+}

--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -1,0 +1,175 @@
+package project
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"charm.land/huh/v2/spinner"
+	"charm.land/lipgloss/v2"
+	"github.com/spf13/cobra"
+
+	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
+	"github.com/shopware/shopware-cli/internal/git"
+	"github.com/shopware/shopware-cli/internal/packagist"
+	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/system"
+	"github.com/shopware/shopware-cli/internal/tui"
+	"github.com/shopware/shopware-cli/logging"
+)
+
+func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *packagist.PHPConstraint) error {
+	ctx := cmd.Context()
+
+	logging.FromContext(ctx).Infof("Installing dependencies")
+
+	showSpinner := system.IsInteractionEnabled(ctx) && !opts.isVerbose
+
+	composerInstallPHP := ""
+	if opts.useDocker {
+		composerInstallPHP = phpConstraint.HighestSupported()
+		logging.FromContext(ctx).Infof("Using PHP %s for composer install", composerInstallPHP)
+	}
+
+	if err := runComposerInstall(ctx, opts.projectFolder, opts.useDocker, showSpinner, composerInstallPHP); err != nil {
+		return err
+	}
+
+	if opts.useDocker {
+		if err := dockerpkg.WriteComposeFile(opts.projectFolder, &dockerpkg.ComposeOptions{PHPVersion: composerInstallPHP}); err != nil {
+			return err
+		}
+	}
+
+	if opts.initGit {
+		logging.FromContext(ctx).Infof("Initializing Git repository")
+		if err := git.Init(ctx, opts.projectFolder); err != nil {
+			return fmt.Errorf("failed to initialize git repository: %w", err)
+		}
+	}
+
+	shopCfg := shop.NewConfig()
+	if opts.useDocker {
+		shopCfg.Environments["local"].Type = "docker"
+		shopCfg.Docker = &shop.ConfigDocker{
+			PHP: &shop.ConfigDockerPHP{Version: composerInstallPHP},
+		}
+	}
+
+	if err := shop.WriteConfig(shopCfg, opts.projectFolder); err != nil {
+		return err
+	}
+
+	printCreateSummary(ctx, opts)
+	return nil
+}
+
+func printCreateSummary(ctx context.Context, opts *createOptions) {
+	if !opts.interactive {
+		logging.FromContext(ctx).Infof("Project created successfully in %s", opts.projectFolder)
+		return
+	}
+
+	cmdStyle := lipgloss.NewStyle().Bold(true)
+	sectionStyle := lipgloss.NewStyle().Bold(true).Underline(true)
+
+	fmt.Println()
+	fmt.Println(tui.GreenText.Render("✔ Setup complete in " + opts.projectFolder))
+
+	if opts.useDocker {
+		fmt.Println()
+		fmt.Println(sectionStyle.Render("Next steps"))
+		fmt.Println()
+		fmt.Printf("  %s  %s\n", tui.GreenText.Render("Start developing:"), cmdStyle.Render(fmt.Sprintf("cd %s && shopware-cli project dev", opts.projectFolder)))
+		fmt.Println()
+		fmt.Println(sectionStyle.Render("Access your shop (after make setup)"))
+		fmt.Println()
+		fmt.Printf("  %s  %s\n", tui.GreenText.Render("Storefront:"), cmdStyle.Render("http://127.0.0.1:8000"))
+		fmt.Printf("  %s  %s\n", tui.GreenText.Render("Admin:"), cmdStyle.Render("http://127.0.0.1:8000/admin"))
+		fmt.Printf("  %s  %s\n", tui.GreenText.Render("Credentials:"), cmdStyle.Render("admin")+" / "+cmdStyle.Render("shopware"))
+	}
+
+	fmt.Println()
+}
+
+func runComposerInstall(ctx context.Context, projectFolder string, useDocker bool, showSpinner bool, phpVersion string) error {
+	var cmdInstall *exec.Cmd
+
+	if useDocker && !system.IsInsideContainer() {
+		absProjectFolder, err := filepath.Abs(projectFolder)
+		if err != nil {
+			return err
+		}
+
+		dockerArgs := []string{"run",
+			"--rm",
+			"--pull=always",
+			"-v", fmt.Sprintf("%s:/app", absProjectFolder),
+			"-w", "/app"}
+
+		if system.IsDockerMountable() {
+			homeDir, err := os.UserHomeDir()
+			if err == nil {
+				composerDir := filepath.Join(homeDir, ".composer")
+				_ = os.MkdirAll(composerDir, 0o755)
+				dockerArgs = append(dockerArgs, "-v", fmt.Sprintf("%s:/tmp/composer/", composerDir))
+			}
+		}
+
+		if phpVersion == "" {
+			phpVersion = packagist.SupportedPHPVersions[len(packagist.SupportedPHPVersions)-1]
+		}
+		dockerArgs = append(dockerArgs,
+			fmt.Sprintf("ghcr.io/shopware/docker-dev:php%s-node24-caddy", phpVersion),
+			"composer", "install", "--no-interaction")
+
+		cmdInstall = exec.CommandContext(ctx, "docker", dockerArgs...)
+	} else {
+		composerBinary, err := exec.LookPath("composer")
+		if err != nil {
+			return err
+		}
+
+		phpBinary := os.Getenv("PHP_BINARY")
+
+		if phpBinary != "" {
+			cmdInstall = exec.CommandContext(ctx, phpBinary, composerBinary, "install", "--no-interaction")
+		} else {
+			cmdInstall = exec.CommandContext(ctx, "composer", "install", "--no-interaction")
+		}
+
+		cmdInstall.Dir = projectFolder
+	}
+
+	if !showSpinner {
+		cmdInstall.Stdin = os.Stdin
+		cmdInstall.Stdout = os.Stdout
+		cmdInstall.Stderr = os.Stderr
+
+		return cmdInstall.Run()
+	}
+
+	var stdErr bytes.Buffer
+	cmdInstall.Stderr = &stdErr
+
+	var runErr error
+
+	if err := spinner.New().Context(ctx).Title("Installing dependencies").Action(func() {
+		runErr = cmdInstall.Run()
+	}).Run(); err != nil {
+		return err
+	}
+
+	if runErr != nil {
+		if stdErr.Len() > 0 {
+			fmt.Fprint(os.Stderr, stdErr.String())
+		}
+
+		return runErr
+	}
+
+	return nil
+}

--- a/cmd/project/project_create_scaffold.go
+++ b/cmd/project/project_create_scaffold.go
@@ -1,0 +1,159 @@
+package project
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/shopware/shopware-cli/internal/packagist"
+	"github.com/shopware/shopware-cli/internal/system"
+	"github.com/shopware/shopware-cli/internal/tracking"
+	"github.com/shopware/shopware-cli/logging"
+)
+
+//go:embed static/deploy.php
+var deployerTemplate string
+
+//go:embed static/github-ci.yml
+var githubCITemplate string
+
+//go:embed static/github-deploy.yml
+var githubDeployTemplate string
+
+//go:embed static/gitlab-ci.yml.tmpl
+var gitlabCITemplate string
+
+//go:embed static/shopware-paas-application.yaml
+var shopwarePaasAppTemplate string
+
+func scaffoldProject(ctx context.Context, opts *createOptions, chosenVersion string) error {
+	go tracking.Track(ctx, "project.create", map[string]string{
+		"version":            opts.selectedVersion,
+		"deployment":         opts.selectedDeployment,
+		"ci":                 opts.selectedCI,
+		"docker":             fmt.Sprintf("%v", opts.useDocker),
+		"with_elasticsearch": fmt.Sprintf("%v", opts.withElasticsearch),
+		"with_amqp":          fmt.Sprintf("%v", opts.withAMQP),
+		"interactive":        fmt.Sprintf("%v", opts.interactive),
+	})
+
+	if err := os.MkdirAll(opts.projectFolder, os.ModePerm); err != nil {
+		return err
+	}
+
+	logging.FromContext(ctx).Infof("Setting up Shopware %s", chosenVersion)
+
+	composerJson, err := packagist.GenerateComposerJson(ctx, packagist.ComposerJsonOptions{
+		Version:          chosenVersion,
+		RC:               strings.Contains(chosenVersion, "rc"),
+		UseElasticsearch: opts.withElasticsearch,
+		UseAMQP:          opts.withAMQP,
+		NoAudit:          opts.noAudit,
+		DeploymentMethod: opts.selectedDeployment,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(opts.projectFolder, "composer.json"), []byte(composerJson), os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".env"), []byte(""), os.ModePerm); err != nil {
+		return err
+	}
+
+	envLocalContent := ""
+	if opts.useDocker {
+		envLocalContent += "APP_ENV=dev\n"
+	}
+
+	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".env.local"), []byte(envLocalContent), os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".gitignore"), []byte("/.idea\n/vendor"), os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Join(opts.projectFolder, "custom", "plugins"), os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Join(opts.projectFolder, "custom", "static-plugins"), os.ModePerm); err != nil {
+		return err
+	}
+
+	if !opts.useDocker && system.IsSymfonyCliInstalled() {
+		if err := os.WriteFile(filepath.Join(opts.projectFolder, "php.ini"), []byte("memory_limit=512M"), os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	if err := setupDeployment(opts.projectFolder, opts.selectedDeployment); err != nil {
+		return err
+	}
+
+	return setupCI(ctx, opts.projectFolder, opts.selectedCI, opts.selectedDeployment)
+}
+
+func setupDeployment(projectFolder, deploymentMethod string) error {
+	switch deploymentMethod {
+	case packagist.DeploymentDeployer:
+		if err := os.WriteFile(filepath.Join(projectFolder, "deploy.php"), []byte(deployerTemplate), os.ModePerm); err != nil {
+			return err
+		}
+
+	case packagist.DeploymentShopwarePaaS:
+		if err := os.WriteFile(filepath.Join(projectFolder, "application.yaml"), []byte(shopwarePaasAppTemplate), os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setupCI(ctx context.Context, projectFolder, ciSystem, deploymentMethod string) error {
+	switch ciSystem {
+	case ciGitHub:
+		if err := os.MkdirAll(filepath.Join(projectFolder, ".github", "workflows"), os.ModePerm); err != nil {
+			return err
+		}
+		ciPath := filepath.Join(".github", "workflows", "ci.yml")
+		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), []byte(githubCITemplate), os.ModePerm); err != nil {
+			return err
+		}
+		logging.FromContext(ctx).Infof("Created CI template %s", ciPath)
+		if deploymentMethod == packagist.DeploymentDeployer {
+			deployPath := filepath.Join(".github", "workflows", "deploy.yml")
+			if err := os.WriteFile(filepath.Join(projectFolder, deployPath), []byte(githubDeployTemplate), os.ModePerm); err != nil {
+				return err
+			}
+			logging.FromContext(ctx).Infof("Created CI template %s", deployPath)
+		}
+
+	case ciGitLab:
+		tmpl, err := template.New("gitlab-ci").Parse(gitlabCITemplate)
+		if err != nil {
+			return err
+		}
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, struct{ Deployer bool }{Deployer: deploymentMethod == packagist.DeploymentDeployer}); err != nil {
+			return err
+		}
+
+		ciPath := ".gitlab-ci.yml"
+		if err := os.WriteFile(filepath.Join(projectFolder, ciPath), buf.Bytes(), os.ModePerm); err != nil {
+			return err
+		}
+		logging.FromContext(ctx).Infof("Created CI template %s", ciPath)
+	}
+
+	return nil
+}

--- a/cmd/project/project_create_validate.go
+++ b/cmd/project/project_create_validate.go
@@ -1,0 +1,236 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"charm.land/huh/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/shyim/go-version"
+
+	"github.com/shopware/shopware-cli/internal/packagist"
+	"github.com/shopware/shopware-cli/internal/system"
+	"github.com/shopware/shopware-cli/internal/tui"
+	"github.com/shopware/shopware-cli/logging"
+)
+
+func validateAndPreflight(ctx context.Context, opts *createOptions, releases []packagist.ComposerPackageVersion, filteredVersions []*version.Version) (string, *packagist.PHPConstraint, error) {
+	chosenVersion := resolveVersion(opts.selectedVersion, filteredVersions)
+	if chosenVersion == "" {
+		return "", nil, fmt.Errorf("cannot find version %s", opts.selectedVersion)
+	}
+
+	phpConstraint := packagist.PHPConstraintForShopwareVersion(releases, chosenVersion)
+
+	missingDeps := system.CheckProjectDependencies(ctx, opts.useDocker, phpConstraint)
+
+	validDeployments := map[string]bool{
+		packagist.DeploymentNone:         true,
+		packagist.DeploymentDeployer:     true,
+		packagist.DeploymentPlatformSH:   true,
+		packagist.DeploymentShopwarePaaS: true,
+	}
+	if !validDeployments[opts.selectedDeployment] {
+		return "", nil, fmt.Errorf("invalid deployment method: %s. Valid options: none, deployer, platformsh, shopware-paas", opts.selectedDeployment)
+	}
+
+	validCISystems := map[string]bool{
+		ciNone:   true,
+		ciGitHub: true,
+		ciGitLab: true,
+	}
+	if !validCISystems[opts.selectedCI] {
+		return "", nil, fmt.Errorf("invalid CI system: %s. Valid options: none, github, gitlab", opts.selectedCI)
+	}
+
+	if len(missingDeps) > 0 {
+		fmt.Fprintln(os.Stderr, system.RenderMissingDependencies(opts.useDocker, missingDeps))
+		return "", nil, fmt.Errorf("missing required dependencies")
+	}
+
+	if err := checkSecurityAdvisories(ctx, opts, chosenVersion); err != nil {
+		return "", nil, err
+	}
+
+	if err := checkIncompatibilities(ctx, opts); err != nil {
+		return "", nil, err
+	}
+
+	if _, err := os.Stat(opts.projectFolder); err == nil {
+		empty, err := system.IsDirEmpty(opts.projectFolder)
+		if err != nil {
+			return "", nil, err
+		}
+
+		if !empty {
+			return "", nil, fmt.Errorf("the folder %s exists already and is not empty", opts.projectFolder)
+		}
+	}
+
+	// @todo: it's broken in paas deployments, the paas recipe configures Elasticsearch and it's difficult to do it only when elasticsearch is available.
+	if opts.selectedDeployment == packagist.DeploymentShopwarePaaS {
+		opts.withElasticsearch = true
+	}
+
+	return chosenVersion, phpConstraint, nil
+}
+
+func checkSecurityAdvisories(ctx context.Context, opts *createOptions, chosenVersion string) error {
+	advisories, err := packagist.GetShopwareSecurityAdvisories(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warnf("Could not fetch security advisories: %v", err)
+	}
+
+	matchingAdvisories := packagist.FilterAdvisoriesForVersion(advisories, chosenVersion)
+	if len(matchingAdvisories) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(os.Stderr, renderSecurityAdvisories(chosenVersion, matchingAdvisories))
+
+	if opts.interactive {
+		var continueAnyway string
+		if err := huh.NewForm(huh.NewGroup(
+			tui.NewYesNo().
+				Title(fmt.Sprintf("Shopware %s is affected by %d known security advisor%s", chosenVersion, len(matchingAdvisories), pluralize(len(matchingAdvisories), "y", "ies"))).
+				Description("Continuing will disable composer's audit blocking (--no-audit) so installation can proceed. If you continue, we strongly recommend installing the Shopware Security plugin (https://store.shopware.com/en/swag136939272659f/shopware-6-security-plugin.html) which backports security fixes to older versions. Do you want to continue anyway?").
+				Value(&continueAnyway),
+		)).Run(); err != nil {
+			return err
+		}
+
+		if continueAnyway == tui.No {
+			return fmt.Errorf("project creation cancelled")
+		}
+
+		opts.noAudit = true
+		return nil
+	}
+
+	if !opts.noAudit {
+		return fmt.Errorf("shopware %s is affected by known security advisories; re-run with --no-audit to proceed. We strongly recommend installing the Shopware Security plugin (https://store.shopware.com/en/swag136939272659f/shopware-6-security-plugin.html) which backports security fixes to older versions", chosenVersion)
+	}
+
+	return nil
+}
+
+func checkIncompatibilities(ctx context.Context, opts *createOptions) error {
+	incompatibilities := system.CheckIncompatibilities(opts.useDocker, opts.projectFolder)
+
+	for _, incompatibility := range incompatibilities {
+		if opts.interactive {
+			var continueAnyway string
+			if err := huh.NewForm(huh.NewGroup(
+				tui.NewYesNo().
+					Title(incompatibility.Title).
+					Description(fmt.Sprintf("%s. Do you want to continue anyway?", incompatibility.Description)).
+					Value(&continueAnyway),
+			)).Run(); err != nil {
+				return err
+			}
+
+			if continueAnyway == tui.No {
+				return fmt.Errorf("project creation cancelled")
+			}
+		} else {
+			logging.FromContext(ctx).Warnf("%s. %s", incompatibility.Title, incompatibility.Description)
+		}
+	}
+
+	return nil
+}
+
+func renderSecurityAdvisories(chosenVersion string, advisories []packagist.SecurityAdvisory) string {
+	var b strings.Builder
+
+	b.WriteString(tui.RedText.Bold(true).Render(fmt.Sprintf("Security Advisories for Shopware %s", chosenVersion)))
+	b.WriteString("\n\n")
+
+	warn := tui.YellowText.Render("⚠")
+	for _, a := range advisories {
+		severity := strings.ToUpper(a.Severity)
+		if severity == "" {
+			severity = "UNKNOWN"
+		}
+		fmt.Fprintf(&b, "  %s [%s] %s\n", warn, tui.BoldText.Render(severity), a.Title)
+		if a.CVE != "" {
+			fmt.Fprintf(&b, "    %s: %s\n", tui.DimText.Render("CVE"), a.CVE)
+		}
+		if a.Link != "" {
+			fmt.Fprintf(&b, "    %s\n", tui.BlueText.Render(a.Link))
+		}
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(tui.BlueColor).
+		Padding(1, 2).
+		Render(strings.TrimRight(b.String(), "\n"))
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+func resolveVersion(selectedVersion string, filteredVersions []*version.Version) string {
+	if selectedVersion == versionLatest {
+		// pick the most recent stable (non-RC) version
+		for _, v := range filteredVersions {
+			vs := v.String()
+			if !strings.Contains(strings.ToLower(vs), "rc") {
+				return vs
+			}
+		}
+		// if no stable found, fall back to top entry
+		if len(filteredVersions) > 0 {
+			return filteredVersions[0].String()
+		}
+		return ""
+	}
+
+	if strings.HasPrefix(selectedVersion, "dev-") {
+		return selectedVersion
+	}
+
+	for _, release := range filteredVersions {
+		if release.String() == selectedVersion {
+			return release.String()
+		}
+	}
+
+	return ""
+}
+
+func filterInstallVersions(releases []packagist.ComposerPackageVersion) []*version.Version {
+	filteredVersions := make([]*version.Version, 0)
+	constraint, _ := version.NewConstraint(">=6.4.18.0")
+
+	for _, release := range releases {
+		if strings.HasPrefix(release.Version, "dev-") {
+			continue
+		}
+
+		parsed, err := version.NewVersion(release.Version)
+		if err != nil {
+			continue
+		}
+
+		if constraint.Check(parsed) {
+			filteredVersions = append(filteredVersions, parsed)
+		}
+	}
+
+	sort.Sort(sort.Reverse(version.Collection(filteredVersions)))
+
+	for i, v := range filteredVersions {
+		filteredVersions[i], _ = version.NewVersion(strings.TrimPrefix(v.String(), "v"))
+	}
+
+	return filteredVersions
+}


### PR DESCRIPTION
## Summary

`cmd/project/project_create.go` was 888 lines with a single ~570-line `RunE` closure that mixed flag parsing, the interactive `huh` form, validation, file scaffolding, composer install, and summary rendering. This PR splits it into one orchestrator plus four phase files in the same package — no behavior changes.

| File | Lines | Responsibility |
|---|---|---|
| `project_create.go` | 171 | Cobra command, `createOptions`, `parseCreateFlags`, `applyNonInteractiveDefaults`, `init` |
| `project_create_form.go` | 286 | `runCreateForm` — interactive form loop |
| `project_create_validate.go` | 236 | `validateAndPreflight`, advisory/incompatibility prompts, `resolveVersion`, `filterInstallVersions`, `renderSecurityAdvisories` |
| `project_create_scaffold.go` | 159 | `scaffoldProject` + `setupDeployment` + `setupCI`, template embeds |
| `project_create_install.go` | 175 | `installAndFinalize`, `printCreateSummary`, `runComposerInstall` |

`RunE` is now ~25 lines of orchestration. The `createOptions` struct carries state across phases instead of 10+ local vars in a closure.

This is a pure restructuring: same files written, same prompts shown, same flag semantics. `os.ModePerm` usages in the scaffolding code are preserved as-is and tracked separately in #1020.

Addresses item #3 in the post-merge review of `next` (CODE_IMPROVEMENTS.md).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/project/...`
- [x] `go test ./cmd/project/...` — existing `TestResolveVersion`, `TestSetupDeployment`, `TestSetupCI`, `TestValidDeploymentMethods`, `TestValidCISystems` still pass
- [ ] Manual: `shopware-cli project create my-test` (interactive, restart form, cancel)
- [ ] Manual: `shopware-cli project create my-test 6.7.0.0 --no-audit --deployment=none --ci=github --docker` (non-interactive)
- [ ] Manual: confirm security-advisory prompt still appears for an affected version