### PR TITLE
fix: deduplicate PHP version and profiler lists

### DIFF
--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
 	"github.com/shopware/shopware-cli/internal/packagist"
 	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
@@ -29,13 +30,10 @@ const (
 	setupStepDone
 )
 
-var profilerChoices = []string{"none", "xdebug", "blackfire", "tideways", "pcov", "spx"}
-
-// profilerNeedsCreds reports whether the given profiler choice requires
-// additional credentials to be collected from the user.
-func profilerNeedsCreds(profiler string) bool {
-	return profiler == "blackfire" || profiler == "tideways"
-}
+// profilerChoices is the list of profiler options shown in the setup guide UI.
+// The first entry uses "none" for display; internally it maps to "" (empty string)
+// which is the canonical value stored in config.
+var profilerChoices = []string{"none", dockerpkg.ProfilerXdebug, dockerpkg.ProfilerBlackfire, dockerpkg.ProfilerTideways, dockerpkg.ProfilerPcov, dockerpkg.ProfilerSpx}
 
 type setupGuide struct {
 	step                  setupStep
@@ -380,7 +378,7 @@ func (sg *setupGuide) updateDockerProfiler(msg tea.KeyPressMsg) (setupGuide, tea
 		}
 	case keyEnter:
 		profiler := profilerChoices[sg.profilerCursor]
-		if !profilerNeedsCreds(profiler) {
+		if !dockerpkg.ProfilerNeedsCredentials(profiler) {
 			sg.step = setupStepReview
 			return *sg, nil
 		}
@@ -478,7 +476,7 @@ func stepBadge(stepNum, totalSteps int) string {
 func (sg setupGuide) totalSteps() int {
 	// admin user, admin password, PHP version, profiler, review
 	total := 5
-	if profilerNeedsCreds(profilerChoices[sg.profilerCursor]) {
+	if dockerpkg.ProfilerNeedsCredentials(profilerChoices[sg.profilerCursor]) {
 		total++
 	}
 	return total
@@ -500,7 +498,7 @@ func (sg setupGuide) stepNum(step setupStep) int {
 	case setupStepProfilerCreds:
 		return 5
 	case setupStepReview:
-		if profilerNeedsCreds(profilerChoices[sg.profilerCursor]) {
+		if dockerpkg.ProfilerNeedsCredentials(profilerChoices[sg.profilerCursor]) {
 			return 6
 		}
 		return 5

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -437,13 +437,3 @@ func TestSetupGuideStepNumbering_WithProfilerCreds(t *testing.T) {
 	assert.Equal(t, 5, sg.stepNum(setupStepProfilerCreds))
 	assert.Equal(t, 6, sg.stepNum(setupStepReview))
 }
-
-func TestProfilerNeedsCreds(t *testing.T) {
-	assert.False(t, profilerNeedsCreds("none"))
-	assert.False(t, profilerNeedsCreds(""))
-	assert.False(t, profilerNeedsCreds("xdebug"))
-	assert.False(t, profilerNeedsCreds("pcov"))
-	assert.False(t, profilerNeedsCreds("spx"))
-	assert.True(t, profilerNeedsCreds("blackfire"))
-	assert.True(t, profilerNeedsCreds("tideways"))
-}

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -7,6 +7,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
+	"github.com/shopware/shopware-cli/internal/packagist"
 	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
@@ -24,15 +26,15 @@ const (
 )
 
 const (
-	profilerBlackfire = "blackfire"
-	profilerTideways  = "tideways"
+	profilerBlackfire = dockerpkg.ProfilerBlackfire
+	profilerTideways  = dockerpkg.ProfilerTideways
 
 	defaultPHPVersionIndex = 1
 )
 
 var (
-	phpVersions = []string{"8.2", "8.3", "8.4", "8.5"}
-	profilers   = []string{"", "xdebug", profilerBlackfire, profilerTideways, "pcov", "spx"}
+	phpVersions = packagist.SupportedPHPVersions
+	profilers   = dockerpkg.Profilers
 )
 
 type ConfigModel struct {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -13,6 +13,24 @@ import (
 
 const nodeVersion = "24"
 
+// Profiler constants for the Docker dev environment.
+const (
+	ProfilerBlackfire = "blackfire"
+	ProfilerTideways  = "tideways"
+	ProfilerXdebug    = "xdebug"
+	ProfilerPcov      = "pcov"
+	ProfilerSpx       = "spx"
+)
+
+// Profilers is the ordered list of profiler names for the Docker dev environment.
+// The empty string means "no profiler".
+var Profilers = []string{"", ProfilerXdebug, ProfilerBlackfire, ProfilerTideways, ProfilerPcov, ProfilerSpx}
+
+// ProfilerNeedsCredentials reports whether the given profiler requires API credentials.
+func ProfilerNeedsCredentials(profiler string) bool {
+	return profiler == ProfilerBlackfire || profiler == ProfilerTideways
+}
+
 type ComposeOptions struct {
 	PHPVersion           string
 	PHPProfiler          string

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/shopware/shopware-cli/internal/packagist"
 )
 
+func TestProfilerNeedsCredentials(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ProfilerNeedsCredentials("none"))
+	assert.False(t, ProfilerNeedsCredentials(""))
+	assert.False(t, ProfilerNeedsCredentials(ProfilerXdebug))
+	assert.False(t, ProfilerNeedsCredentials(ProfilerPcov))
+	assert.False(t, ProfilerNeedsCredentials(ProfilerSpx))
+	assert.True(t, ProfilerNeedsCredentials(ProfilerBlackfire))
+	assert.True(t, ProfilerNeedsCredentials(ProfilerTideways))
+}
+
 func TestGenerateComposeFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

PHP version and profiler lists were duplicated across 3 files:
- internal/packagist/php_constraint.go: SupportedPHPVersions (canonical)
- internal/devtui/tab_config.go: hardcoded phpVersions and profilers lists
- internal/devtui/setup_guide.go: hardcoded profilerChoices list

Adding a new PHP version or profiler required updating multiple places with inconsistent sentinel values (empty string vs none).

## Changes

### New canonical source: internal/docker/
- Added profiler constants (ProfilerBlackfire, ProfilerTideways, ProfilerXdebug, ProfilerPcov, ProfilerSpx)
- Added Profilers list (canonical, empty string = no profiler)
- Added ProfilerNeedsCredentials() helper

### Updated consumers
- tab_config.go: Now references packagist.SupportedPHPVersions and dockerpkg.Profilers instead of hardcoded lists. Aliases profilerBlackfire/profilerTideways now point to dockerpkg constants.
- setup_guide.go: profilerChoices now built from dockerpkg.Profiler* constants. profilerNeedsCreds() delegates to dockerpkg.ProfilerNeedsCredentials().

### Single source of truth

| Data | Location |
|------|----------|
| PHP versions | packagist.SupportedPHPVersions |
| Profiler names | docker.Profilers |
| Profiler constants | docker.ProfilerBlackfire, etc. |
| Profiler credential check | docker.ProfilerNeedsCredentials() |

Related: Issues #5 and #6 in CODE_IMPROVEMENTS.md