### PR TITLE
feat(mjml): allow mj-include via build config

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -240,10 +240,13 @@ var projectCI = &cobra.Command{
 		if shopCfg.Build.IsMjmlEnabled() {
 			mjmlSection := ci.Default.Section(cmd.Context(), "Compiling MJML templates")
 
+			extraIncludePaths := shopCfg.Build.MJML.ResolveIncludePaths(args[0])
+
 			for _, searchPath := range shopCfg.Build.MJML.GetPaths(args[0]) {
 				if _, err := os.Stat(searchPath); !os.IsNotExist(err) {
 					logging.FromContext(cmd.Context()).Infof("Processing MJML files in: %s", searchPath)
-					if err := mjml.ProcessDirectory(cmd.Context(), searchPath); err != nil {
+					mjmlOpts := mjml.NewCompileOptions(searchPath, shopCfg.Build.MJML.AllowIncludes, extraIncludePaths)
+					if err := mjml.ProcessDirectory(cmd.Context(), searchPath, mjmlOpts); err != nil {
 						logging.FromContext(cmd.Context()).Warnf("MJML compilation had issues in %s: %v", searchPath, err)
 					}
 				} else {

--- a/internal/mjml/compiler.go
+++ b/internal/mjml/compiler.go
@@ -3,6 +3,7 @@ package mjml
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,9 +13,58 @@ import (
 	"github.com/shopware/shopware-cli/logging"
 )
 
-func Compile(ctx context.Context, mjmlPath string) (string, error) {
-	// Run mjml command with the file
-	cmd := exec.CommandContext(ctx, "npx", "mjml", mjmlPath, "--stdout")
+// CompileOptions controls how the underlying mjml CLI is invoked.
+type CompileOptions struct {
+	// When true, passes --config.allowIncludes=true to mjml so that
+	// <mj-include> directives are processed. MJML 5 ignores them by default.
+	AllowIncludes bool
+	// Allowlist of directories that mj-include is permitted to read from, on
+	// top of the directory of the file being compiled. Values are forwarded to
+	// mjml verbatim as --config.includePath=[...]; relative paths are resolved
+	// by mjml against its own working directory, so callers should pass
+	// absolute paths. Setting any value implies AllowIncludes.
+	IncludePaths []string
+}
+
+// NewCompileOptions builds CompileOptions for files compiled inside the given
+// search-path root. When mj-include is in use, searchPathRoot is automatically
+// allowlisted so that templates can include any partial inside the same search
+// path (e.g. a sibling _includes/ folder) without having to enumerate each
+// directory. extraIncludePaths are appended after the search-path root.
+//
+// When both allowIncludes is false and extraIncludePaths is empty, the
+// returned CompileOptions is the zero value and no include flags are
+// forwarded to mjml.
+func NewCompileOptions(searchPathRoot string, allowIncludes bool, extraIncludePaths []string) CompileOptions {
+	if !allowIncludes && len(extraIncludePaths) == 0 {
+		return CompileOptions{}
+	}
+
+	paths := make([]string, 0, 1+len(extraIncludePaths))
+	if searchPathRoot != "" {
+		paths = append(paths, searchPathRoot)
+	}
+	paths = append(paths, extraIncludePaths...)
+
+	return CompileOptions{AllowIncludes: true, IncludePaths: paths}
+}
+
+func Compile(ctx context.Context, mjmlPath string, opts CompileOptions) (string, error) {
+	args := []string{"mjml", mjmlPath, "--stdout"}
+
+	if opts.AllowIncludes || len(opts.IncludePaths) > 0 {
+		args = append(args, "--config.allowIncludes=true")
+	}
+
+	if len(opts.IncludePaths) > 0 {
+		encoded, err := json.Marshal(opts.IncludePaths)
+		if err != nil {
+			return "", fmt.Errorf("failed to encode mjml include paths: %w", err)
+		}
+		args = append(args, fmt.Sprintf("--config.includePath=%s", string(encoded)))
+	}
+
+	cmd := exec.CommandContext(ctx, "npx", args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -32,7 +82,7 @@ func Compile(ctx context.Context, mjmlPath string) (string, error) {
 }
 
 // ProcessDirectory walks through a directory and compiles all MJML files
-func ProcessDirectory(ctx context.Context, rootDir string) error {
+func ProcessDirectory(ctx context.Context, rootDir string, opts CompileOptions) error {
 	var processedCount int
 	var errorCount int
 	var skippedCount int
@@ -69,7 +119,7 @@ func ProcessDirectory(ctx context.Context, rootDir string) error {
 		logging.FromContext(ctx).Infof("Processing MJML file: %s", relPath)
 
 		// Always compile to check for errors
-		compiled, err := Compile(ctx, path)
+		compiled, err := Compile(ctx, path, opts)
 		if err != nil {
 			errorCount++
 			logging.FromContext(ctx).Errorf("Failed to compile MJML %s: %v", relPath, err)

--- a/internal/mjml/compiler_test.go
+++ b/internal/mjml/compiler_test.go
@@ -63,6 +63,18 @@ func newMockExec(t *testing.T, scriptContent string) {
 	t.Setenv("PATH", fmt.Sprintf("%s%c%s", binDir, filepath.ListSeparator, originalPath))
 }
 
+// newArgRecordingMockExec creates a mock npx that writes its full argv to a
+// file so tests can assert which CLI flags Compile forwarded.
+func newArgRecordingMockExec(t *testing.T, argsFile string) {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" > %q
+echo "<h1>Hello</h1>"
+exit 0
+`, argsFile)
+	newMockExec(t, script)
+}
+
 func TestCompile(t *testing.T) {
 	ctx := t.Context()
 
@@ -82,7 +94,7 @@ exit 0`
 			}
 		}()
 
-		output, err := Compile(ctx, tmpFile.Name())
+		output, err := Compile(ctx, tmpFile.Name(), CompileOptions{})
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
@@ -108,7 +120,7 @@ exit 1`
 			}
 		}()
 
-		_, err = Compile(ctx, tmpFile.Name())
+		_, err = Compile(ctx, tmpFile.Name(), CompileOptions{})
 		if err == nil {
 			t.Error("expected an error, got nil")
 		}
@@ -137,13 +149,83 @@ exit 0`
 			}
 		}()
 
-		output, err := Compile(ctx, tmpFile.Name())
+		output, err := Compile(ctx, tmpFile.Name(), CompileOptions{})
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 
 		if strings.TrimSpace(output) != "<h1>Hello</h1>" {
 			t.Errorf("unexpected output: got %q", output)
+		}
+	})
+
+	t.Run("default options pass no include flags", func(t *testing.T) {
+		argsFile := filepath.Join(t.TempDir(), "args.txt")
+		newArgRecordingMockExec(t, argsFile)
+
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test.mjml")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, err := Compile(ctx, tmpFile.Name(), CompileOptions{}); err != nil {
+			t.Fatalf("compile failed: %v", err)
+		}
+
+		args := readArgs(t, argsFile)
+		if containsArg(args, "--config.allowIncludes=true") {
+			t.Errorf("did not expect --config.allowIncludes=true with default options, got %v", args)
+		}
+		for _, a := range args {
+			if strings.HasPrefix(a, "--config.includePath=") {
+				t.Errorf("did not expect --config.includePath flag with default options, got %q", a)
+			}
+		}
+	})
+
+	t.Run("allow_includes forwards --config.allowIncludes=true", func(t *testing.T) {
+		argsFile := filepath.Join(t.TempDir(), "args.txt")
+		newArgRecordingMockExec(t, argsFile)
+
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test.mjml")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, err := Compile(ctx, tmpFile.Name(), CompileOptions{AllowIncludes: true}); err != nil {
+			t.Fatalf("compile failed: %v", err)
+		}
+
+		args := readArgs(t, argsFile)
+		if !containsArg(args, "--config.allowIncludes=true") {
+			t.Errorf("expected --config.allowIncludes=true in args, got %v", args)
+		}
+	})
+
+	t.Run("include_paths forwards JSON-encoded array and implies allow_includes", func(t *testing.T) {
+		argsFile := filepath.Join(t.TempDir(), "args.txt")
+		newArgRecordingMockExec(t, argsFile)
+
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test.mjml")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		opts := CompileOptions{IncludePaths: []string{"../_includes", "../_shared"}}
+		if _, err := Compile(ctx, tmpFile.Name(), opts); err != nil {
+			t.Fatalf("compile failed: %v", err)
+		}
+
+		args := readArgs(t, argsFile)
+		if !containsArg(args, "--config.allowIncludes=true") {
+			t.Errorf("expected include_paths to imply --config.allowIncludes=true, got %v", args)
+		}
+		want := `--config.includePath=["../_includes","../_shared"]`
+		if !containsArg(args, want) {
+			t.Errorf("expected %q in args, got %v", want, args)
 		}
 	})
 }
@@ -194,7 +276,7 @@ exit 0`
 			t.Fatalf("failed to write test file: %v", err)
 		}
 
-		err := ProcessDirectory(ctx, tmpDir)
+		err := ProcessDirectory(ctx, tmpDir, CompileOptions{})
 		if err != nil {
 			t.Fatalf("ProcessDirectory failed: %v", err)
 		}
@@ -254,7 +336,7 @@ exit 1`
 			t.Fatalf("failed to write test file: %v", err)
 		}
 
-		err := ProcessDirectory(ctx, tmpDir)
+		err := ProcessDirectory(ctx, tmpDir, CompileOptions{})
 		if err == nil {
 			t.Fatal("expected ProcessDirectory to return an error, but it didn't")
 		}
@@ -267,4 +349,112 @@ exit 1`
 			t.Error("original mjml file should still exist after compilation failure")
 		}
 	})
+
+	t.Run("forwards include options to each file", func(t *testing.T) {
+		argsFile := filepath.Join(t.TempDir(), "args.txt")
+		newArgRecordingMockExec(t, argsFile)
+
+		tmpDir := t.TempDir()
+		mailDir := filepath.Join(tmpDir, "mail", "welcome")
+		if err := os.MkdirAll(mailDir, 0755); err != nil {
+			t.Fatalf("failed to create test dir: %v", err)
+		}
+		mjmlFile := filepath.Join(mailDir, "html.mjml")
+		if err := os.WriteFile(mjmlFile, []byte("<mjml></mjml>"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		opts := CompileOptions{AllowIncludes: true, IncludePaths: []string{"../_includes"}}
+		if err := ProcessDirectory(ctx, tmpDir, opts); err != nil {
+			t.Fatalf("ProcessDirectory failed: %v", err)
+		}
+
+		args := readArgs(t, argsFile)
+		if !containsArg(args, "--config.allowIncludes=true") {
+			t.Errorf("expected --config.allowIncludes=true, got %v", args)
+		}
+		if !containsArg(args, `--config.includePath=["../_includes"]`) {
+			t.Errorf("expected JSON-encoded includePath, got %v", args)
+		}
+	})
+}
+
+func readArgs(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read args file: %v", err)
+	}
+	return strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewCompileOptions(t *testing.T) {
+	t.Run("returns zero value when nothing is opted in", func(t *testing.T) {
+		opts := NewCompileOptions("/abs/search", false, nil)
+		if opts.AllowIncludes {
+			t.Errorf("expected AllowIncludes=false, got true")
+		}
+		if len(opts.IncludePaths) != 0 {
+			t.Errorf("expected no IncludePaths, got %v", opts.IncludePaths)
+		}
+	})
+
+	t.Run("allow_includes auto-allowlists the search path root", func(t *testing.T) {
+		opts := NewCompileOptions("/abs/search", true, nil)
+		if !opts.AllowIncludes {
+			t.Errorf("expected AllowIncludes=true")
+		}
+		want := []string{"/abs/search"}
+		if !slicesEqual(opts.IncludePaths, want) {
+			t.Errorf("expected IncludePaths=%v, got %v", want, opts.IncludePaths)
+		}
+	})
+
+	t.Run("extra include paths are appended after the search path root", func(t *testing.T) {
+		opts := NewCompileOptions("/abs/search", true, []string{"/abs/other", "/abs/shared"})
+		want := []string{"/abs/search", "/abs/other", "/abs/shared"}
+		if !slicesEqual(opts.IncludePaths, want) {
+			t.Errorf("expected IncludePaths=%v, got %v", want, opts.IncludePaths)
+		}
+	})
+
+	t.Run("extra include paths alone imply allow_includes", func(t *testing.T) {
+		opts := NewCompileOptions("/abs/search", false, []string{"/abs/shared"})
+		if !opts.AllowIncludes {
+			t.Errorf("expected extras to imply AllowIncludes=true")
+		}
+		want := []string{"/abs/search", "/abs/shared"}
+		if !slicesEqual(opts.IncludePaths, want) {
+			t.Errorf("expected IncludePaths=%v, got %v", want, opts.IncludePaths)
+		}
+	})
+
+	t.Run("empty search path root is skipped", func(t *testing.T) {
+		opts := NewCompileOptions("", true, []string{"/abs/shared"})
+		want := []string{"/abs/shared"}
+		if !slicesEqual(opts.IncludePaths, want) {
+			t.Errorf("expected IncludePaths=%v, got %v", want, opts.IncludePaths)
+		}
+	})
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/mjml/compiler_test.go
+++ b/internal/mjml/compiler_test.go
@@ -167,7 +167,6 @@ exit 0`
 		if err != nil {
 			t.Fatalf("failed to create temp file: %v", err)
 		}
-		defer os.Remove(tmpFile.Name())
 
 		if _, err := Compile(ctx, tmpFile.Name(), CompileOptions{}); err != nil {
 			t.Fatalf("compile failed: %v", err)
@@ -192,7 +191,6 @@ exit 0`
 		if err != nil {
 			t.Fatalf("failed to create temp file: %v", err)
 		}
-		defer os.Remove(tmpFile.Name())
 
 		if _, err := Compile(ctx, tmpFile.Name(), CompileOptions{AllowIncludes: true}); err != nil {
 			t.Fatalf("compile failed: %v", err)
@@ -212,7 +210,6 @@ exit 0`
 		if err != nil {
 			t.Fatalf("failed to create temp file: %v", err)
 		}
-		defer os.Remove(tmpFile.Name())
 
 		opts := CompileOptions{IncludePaths: []string{"../_includes", "../_shared"}}
 		if _, err := Compile(ctx, tmpFile.Name(), opts); err != nil {

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -130,6 +130,19 @@ type ConfigBuildMJML struct {
 	Enabled bool `yaml:"enabled,omitempty"`
 	// Directories to search for MJML files
 	SearchPaths []string `yaml:"search_paths,omitempty"`
+	// When enabled, mj-include directives in MJML templates are processed.
+	// MJML 5 ignores mj-include by default for security reasons; set this to
+	// true to opt back in. Each search_path is automatically added to the
+	// mj-include allowlist for files compiled inside it, so templates can
+	// include siblings under the same search_path (e.g. a shared _includes/
+	// folder) without further configuration.
+	AllowIncludes bool `yaml:"allow_includes,omitempty"`
+	// Extra directories outside any search_path that mj-include is allowed to
+	// read from. Relative paths are resolved against the project root.
+	// Absolute paths are used as-is. Most projects do not need this — set it
+	// only when partials live outside the search_path tree. Implies
+	// allow_includes.
+	IncludePaths []string `yaml:"include_paths,omitempty"`
 }
 
 func (c ConfigBuildMJML) GetPaths(projectRoot string) []string {
@@ -150,6 +163,25 @@ func (c ConfigBuildMJML) GetPaths(projectRoot string) []string {
 		filepath.Join(projectRoot, "custom", "plugins"),
 		filepath.Join(projectRoot, "custom", "static-plugins"),
 	}
+}
+
+// ResolveIncludePaths returns IncludePaths as absolute paths. Relative entries
+// are resolved against projectRoot; absolute entries are returned unchanged.
+// Returns nil when no paths are configured.
+func (c ConfigBuildMJML) ResolveIncludePaths(projectRoot string) []string {
+	if len(c.IncludePaths) == 0 {
+		return nil
+	}
+
+	resolved := make([]string, len(c.IncludePaths))
+	for i, p := range c.IncludePaths {
+		if filepath.IsAbs(p) {
+			resolved[i] = p
+		} else {
+			resolved[i] = filepath.Join(projectRoot, p)
+		}
+	}
+	return resolved
 }
 
 type ConfigAdminApi struct {

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -232,6 +232,17 @@
           },
           "type": "array",
           "description": "Directories to search for MJML files"
+        },
+        "allow_includes": {
+          "type": "boolean",
+          "description": "When enabled, mj-include directives in MJML templates are processed.\nMJML 5 ignores mj-include by default for security reasons; set this to\ntrue to opt back in. Each search_path is automatically added to the\nmj-include allowlist for files compiled inside it, so templates can\ninclude siblings under the same search_path (e.g. a shared _includes/\nfolder) without further configuration."
+        },
+        "include_paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Extra directories outside any search_path that mj-include is allowed to\nread from. Relative paths are resolved against the project root.\nAbsolute paths are used as-is. Most projects do not need this — set it\nonly when partials live outside the search_path tree. Implies\nallow_includes."
         }
       },
       "additionalProperties": false,

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -505,3 +505,40 @@ func TestConfigDump_EnableClean(t *testing.T) {
 		assert.Equal(t, "cart", config.NoData[3])
 	})
 }
+
+func TestConfigBuildMJMLResolveIncludePaths(t *testing.T) {
+	projectRoot := filepath.FromSlash("/abs/project")
+
+	t.Run("returns nil when no paths configured", func(t *testing.T) {
+		c := ConfigBuildMJML{}
+		assert.Nil(t, c.ResolveIncludePaths(projectRoot))
+	})
+
+	t.Run("relative paths are joined with project root", func(t *testing.T) {
+		c := ConfigBuildMJML{IncludePaths: []string{
+			"shared/email",
+			filepath.FromSlash("custom/static-plugins/Other/Resources/views/email/_includes"),
+		}}
+		got := c.ResolveIncludePaths(projectRoot)
+		want := []string{
+			filepath.Join(projectRoot, "shared/email"),
+			filepath.Join(projectRoot, "custom/static-plugins/Other/Resources/views/email/_includes"),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("absolute paths are returned unchanged", func(t *testing.T) {
+		abs := filepath.FromSlash("/somewhere/else/_includes")
+		c := ConfigBuildMJML{IncludePaths: []string{abs}}
+		got := c.ResolveIncludePaths(projectRoot)
+		assert.Equal(t, []string{abs}, got)
+	})
+
+	t.Run("mixed entries are resolved independently", func(t *testing.T) {
+		abs := filepath.FromSlash("/somewhere/else/_includes")
+		c := ConfigBuildMJML{IncludePaths: []string{"shared/email", abs}}
+		got := c.ResolveIncludePaths(projectRoot)
+		want := []string{filepath.Join(projectRoot, "shared/email"), abs}
+		assert.Equal(t, want, got)
+	})
+}


### PR DESCRIPTION
## Summary
MJML 5 ignores `<mj-include>` by default and sandboxes resolved include paths to the file's own parent directory. Templates that share partials from a sibling `_includes/` folder silently break.

This PR adds two opt-in knobs under `build.mjml` in `.shopware-project.yml` and threads them through the `project ci` MJML compilation step.

### Configuration

```yaml
build:
  mjml:
    enabled: true
    search_paths:
      - custom/static-plugins
    allow_includes: true
```

Setting `allow_includes: true` is enough for the common layout where shared partials live somewhere inside an existing `search_path` tree, e.g.:

```
custom/static-plugins/MyPlugin/src/Resources/views/email/global/
├── _includes/
│   ├── header.mjml
│   └── footer.mjml
├── order.state.completed/
│   └── html.mjml          # <mj-include path="../_includes/header.mjml" />
└── … (40+ mail-type dirs)
```

For partials that live *outside* any `search_path`, an additional escape hatch is available:

```yaml
build:
  mjml:
    allow_includes: true
    include_paths:
      - shared/email/_includes
```

### How it works

- `allow_includes` forwards `--config.allowIncludes=true` to the mjml CLI.
- Each `search_path` is automatically added to the mj-include allowlist when compiling files inside it. mjml resolves `mj-include path="…"` relative to the current `.mjml` file's own directory; the allowlist just authorises reads outside the file's parent. Auto-allowlisting the search_path root means "anywhere inside this tree is permitted to include from anywhere else inside this tree" — which matches how plugins actually organise templates.
- `include_paths` entries are resolved against the project root (relative) or used as-is (absolute) and appended after the auto-allowlisted root. Any value in `include_paths` implies `allow_includes`.
- The two values are forwarded to mjml as `--config.allowIncludes=true` and `--config.includePath=[…]` (JSON-encoded).

### Code changes

- `internal/mjml/compiler.go` — `Compile()` and `ProcessDirectory()` now take a `CompileOptions` struct. New `NewCompileOptions(searchPathRoot, allowIncludes, extras)` helper builds per-search-path options with auto-allowlisting.
- `internal/shop/config.go` — adds `AllowIncludes` and `IncludePaths` fields on `ConfigBuildMJML` plus a `ResolveIncludePaths(projectRoot)` method that mirrors `GetPaths` semantics (relative entries joined with project root, absolute entries untouched).
- `cmd/project/ci.go` — builds `CompileOptions` per search_path, threading the resolved extras through.
- `internal/shop/config_schema.json` — regenerated via `go run scripts/schema.go`.

## Test plan
- [x] `go test ./...` — all packages green, including 9 new subtests:
  - `TestNewCompileOptions`: zero opts, allow_includes only, extras-only-implies-allow, both set, empty search-path root.
  - `TestConfigBuildMJMLResolveIncludePaths`: nil when unset, relative paths joined with project root, absolute paths preserved, mixed entries.
  - `TestCompile`: existing pass-through assertions (default flags absent, `allow_includes` flag, JSON-encoded `--config.includePath`) — covered by the file-recording mock that shadows `npx` in `PATH` and writes argv to a file.
  - `TestProcessDirectory`: forwards options to each compiled file.
- [x] `go vet ./...` — clean.
- [ ] Verified locally against a real project with `npx mjml` installed and a shared `_includes/` sibling — config collapses to just `allow_includes: true`.
