### PR TITLE
Fix anonymization rewrite precedence to preserve user config

### DIFF
--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -257,13 +257,15 @@ func (c *ConfigDump) EnableAnonymization() {
 		},
 	}
 
-	// Merge with existing rewrites
+	// Merge with existing rewrites; user-supplied values take precedence over defaults
 	for table, columns := range anonymizationRewrites {
 		if _, exists := c.Rewrite[table]; !exists {
 			c.Rewrite[table] = columns
-		} else {
-			// Merge column rewrites for existing table
-			for column, rewrite := range columns {
+			continue
+		}
+
+		for column, rewrite := range columns {
+			if _, columnExists := c.Rewrite[table][column]; !columnExists {
 				c.Rewrite[table][column] = rewrite
 			}
 		}

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -228,7 +228,7 @@ func TestConfigDump_EnableAnonymization(t *testing.T) {
 		assert.Equal(t, "faker.Internet.Email()", customerRewrites["email"])
 	})
 
-	t.Run("override existing column rewrites", func(t *testing.T) {
+	t.Run("user rewrites take precedence over defaults", func(t *testing.T) {
 		config := &ConfigDump{
 			Rewrite: map[string]map[string]string{
 				"customer": {
@@ -240,10 +240,11 @@ func TestConfigDump_EnableAnonymization(t *testing.T) {
 
 		config.EnableAnonymization()
 
-		// Anonymization should override existing rewrites
+		// User-supplied column rewrites must not be overwritten by the defaults
 		customerRewrites := config.Rewrite["customer"]
-		assert.Equal(t, "faker.Person.FirstName()", customerRewrites["first_name"])
-		assert.Equal(t, "faker.Person.LastName()", customerRewrites["last_name"])
+		assert.Equal(t, "my_custom_rewrite", customerRewrites["first_name"])
+		assert.Equal(t, "another_custom_rewrite", customerRewrites["last_name"])
+		// Columns not configured by the user still get the default
 		assert.Equal(t, "faker.Internet.Email()", customerRewrites["email"])
 	})
 


### PR DESCRIPTION
## Summary
Fixed the anonymization rewrite logic to properly respect user-supplied configuration values, ensuring they take precedence over default anonymization rules rather than being overwritten.

## Key Changes
- **Improved merge logic**: Restructured the rewrite merging to check for existing column-level rewrites before applying defaults, preventing user configuration from being overwritten
- **Added early continue**: When a table doesn't exist in user config, skip to the next table immediately rather than entering unnecessary conditional blocks
- **Updated test expectations**: Modified the test case to verify that user-supplied rewrites are preserved while defaults are still applied to unconfigured columns
- **Clarified comments**: Updated code comments to explicitly document that user-supplied values take precedence over defaults

## Implementation Details
The fix changes the merge behavior from an "all-or-nothing" table-level approach to a column-level approach:
- If a table doesn't exist in user config, all default columns are added
- If a table exists in user config, only columns not already configured by the user receive default values
- This allows users to override specific column rewrites while still benefiting from defaults for other columns

The test now correctly validates that custom rewrites like `"my_custom_rewrite"` are preserved while unconfigured columns like `"email"` still receive the default `"faker.Internet.Email()"` rewrite.

https://claude.ai/code/session_01PL4bCiVZHXC3ACFLzH4pmM