### PR TITLE
fix(goreleaser): correctly skip aur/nix/homebrew on prereleases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -151,7 +151,7 @@ aurs:
   - homepage: https://developer.shopware.com/
     description: A cli which contains handy helpful commands for daily Shopware tasks
     license: MIT
-    disable: '{{ .Prerelease }}'
+    disable: '{{ if .Prerelease }}true{{ end }}'
     maintainers:
       - "Soner Sayakci <s.sayakci@shopware.com>"
       - "Max <max@swk-web.com>"
@@ -178,7 +178,7 @@ aurs:
 
 nix:
   - name: shopware-cli
-    skip_upload: '{{ .Prerelease }}'
+    skip_upload: auto
     repository:
       owner: FriendsOfShopware
       name: nur-packages
@@ -218,7 +218,7 @@ nfpms:
 
 homebrew_casks:
   - name: shopware-cli
-    skip_upload: '{{ .Prerelease }}'
+    skip_upload: auto
     repository:
       owner: shopware
       name: homebrew-tap


### PR DESCRIPTION
## Summary
- The `.Prerelease` template variable renders the SemVer prerelease *string* (e.g. `"alpha-1"`), not a boolean. Using `'{{ .Prerelease }}'` directly as `disable` / `skip_upload` left AUR, Nix, and Homebrew cask publishers active for prerelease tags like `0.15.0-alpha-1` (observed after tagging the alpha).
- Switch `nix` and `homebrew_casks` to `skip_upload: auto` — goreleaser's idiomatic value that pairs with its internal `ctx.Semver.Prerelease != ""` check.
- For `aurs`, whose `disable` field doesn't recognize `auto`, use `'{{ if .Prerelease }}true{{ end }}'` so it renders to an empty string on stable releases and `"true"` on prereleases.

## Test plan
- [ ] Next prerelease tag (e.g. `0.15.0-alpha-2`) does not publish to AUR, Nix, or the Homebrew cask repo
- [ ] Next stable tag still publishes to all three