### PR TITLE
fix: surface docker compose up failures in devtui

### DIFF
--- a/internal/devtui/lifecycle.go
+++ b/internal/devtui/lifecycle.go
@@ -48,6 +48,7 @@ func (m Model) updateLifecycle(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case dockerStartedMsg:
 		if msg.err != nil {
+			m.dockerShowLogs = true
 			m.overlayLines = append(m.overlayLines, errorStyle.Render("Failed: "+msg.err.Error()))
 			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Press q to exit"))
 			return m, nil

--- a/internal/devtui/lifecycle_test.go
+++ b/internal/devtui/lifecycle_test.go
@@ -117,6 +117,7 @@ func TestUpdateLifecycle_DockerStarted_ErrorStaysAndRendersError(t *testing.T) {
 
 	// Phase stays on starting so the error overlay remains visible.
 	assert.Equal(t, phaseStarting, final.phase)
+	assert.True(t, final.dockerShowLogs, "logs view must be forced on so the error is visible without pressing 'l'")
 	assert.Nil(t, cmd)
 	joined := strings.Join(final.overlayLines, "\n")
 	assert.Contains(t, joined, "Failed:")


### PR DESCRIPTION
## Summary
- When `docker compose up -d` failed in devtui, the user was stuck on the spinning "Starting Docker containers..." screen with no error info. The captured stderr and `Failed: …` line were appended to `overlayLines` but only rendered when `dockerShowLogs` was true, which required pressing `l`.
- Force `dockerShowLogs = true` on the error path in `updateLifecycle` so the docker output and error message are visible immediately.

## Test plan
- [x] `go test ./internal/devtui/`
- [x] Added assertion in `TestUpdateLifecycle_DockerStarted_ErrorStaysAndRendersError` that `dockerShowLogs` is true after an error