### PR TITLE
Improve Git label clarity in project creation form

### DIFF
--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -254,7 +254,7 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 		fmt.Printf("  %s %s\n", labelStyle.Render("Deployment:"), opts.selectedDeployment)
 		fmt.Printf("  %s %s\n", labelStyle.Render("CI/CD:"), opts.selectedCI)
 		fmt.Printf("  %s %s\n", labelStyle.Render("Docker:"), onOff(opts.useDocker))
-		fmt.Printf("  %s %s\n", labelStyle.Render("Git:"), onOff(opts.initGit))
+		fmt.Printf("  %s %s\n", labelStyle.Render("Git Repository:"), onOff(opts.initGit))
 		fmt.Printf("  %s %s\n", labelStyle.Render("OpenSearch:"), onOff(opts.withElasticsearch))
 		fmt.Printf("  %s %s\n", labelStyle.Render("AMQP:"), onOff(opts.withAMQP))
 		fmt.Println()


### PR DESCRIPTION
## Summary
Updated the label text for the Git configuration option in the project creation form to be more descriptive and user-friendly.

## Changes
- Changed the "Git:" label to "Git Repository:" in the project creation form summary display to better clarify what the option controls

## Details
This is a minor UX improvement that makes the purpose of the Git initialization option clearer to users during the interactive project creation process. The label now explicitly indicates that this option relates to Git repository initialization, reducing potential ambiguity.

https://claude.ai/code/session_01BMe8tcKSZ5RUhr9ZYm1Ktj