### PR TITLE
refactor: migrate to goreleaser native Cloudsmith support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,20 +94,4 @@ jobs:
           APPLE_APP_STORE_CONNECT_ISSUER: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER }}
           APPLE_APP_STORE_CONNECT_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_KEY_ID }}
           APPLE_APP_STORE_CONNECT_KEY: ${{ secrets.APPLE_APP_STORE_CONNECT_KEY }}
-
-      - name: Install Cloudsmith CLI
-        run: pip install --upgrade cloudsmith-cli
-
-      - name: Cloudsmith Uploads
-        env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
-        run: |
-          for filename in dist/*.deb; do
-              cloudsmith push deb friendsofshopware/stable/any-distro/any-version $filename
-          done
-          for filename in dist/*.rpm; do
-              cloudsmith push rpm friendsofshopware/stable/any-distro/any-version $filename
-          done
-          for filename in dist/*.apk; do
-              cloudsmith push alpine friendsofshopware/stable/alpine/any-version $filename
-          done

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -247,6 +247,16 @@ npms:
     access: public
     tag: '{{ if .Prerelease }}prerelease{{ else }}latest{{ end }}'
 
+cloudsmiths:
+  - organization: friendsofshopware
+    repository: stable
+    secret_name: CLOUDSMITH_API_KEY
+    disable: '{{ if .Prerelease }}true{{ end }}'
+    distributions:
+      deb: "any-distro/any-version"
+      rpm: "any-distro/any-version"
+      alpine: "alpine/any-version"
+
 notarize:
   macos:
     - enabled: '{{ isEnvSet "APPLE_CODE_SIGNING_KEY" }}'


### PR DESCRIPTION
## Summary

- Replace manual `cloudsmith-cli` pip install and push steps in `release.yml` with goreleaser's built-in `cloudsmiths` configuration in `.goreleaser.yaml`
- This removes the dependency on the `cloudsmith-cli` Python package and lets goreleaser handle distribution uploads natively

## Test plan

- [ ] Verify goreleaser dry-run produces correct Cloudsmith upload config
- [ ] Verify release pipeline pushes .deb, .rpm, and .apk packages to friendsofshopware/stable

💘 Generated with Crush