### PR TITLE
feat(mysqldump): warn when foreign keys are missing due to insufficient privileges

### DIFF
--- a/internal/mysqldump/mysql_test.go
+++ b/internal/mysqldump/mysql_test.go
@@ -38,7 +38,12 @@ func mockPrefetchSchemas(mock sqlmock.Sqlmock) {
 			"TABLE_NAME", "INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "INDEX_TYPE", "SUB_PART", "COLLATION", "INDEX_COMMENT", "SEQ_IN_INDEX",
 		}))
 
-	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
+	mock.ExpectQuery("SELECT COUNT.*KEY_COLUMN_USAGE.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectQuery("SELECT COUNT.*REFERENTIAL_CONSTRAINTS.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	mock.ExpectQuery("SELECT DISTINCT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"TABLE_NAME", "CONSTRAINT_NAME", "COLUMN_NAME", "REFERENCED_TABLE_NAME",
 			"REFERENCED_COLUMN_NAME", "UPDATE_RULE", "DELETE_RULE", "ORDINAL_POSITION",
@@ -124,7 +129,12 @@ func TestMySQLDumpCreateTable(t *testing.T) {
 			AddRow("table", "PRIMARY", "id", 0, "BTREE", nil, "A", "", 1).
 			AddRow("table", "idx_name", "name", 1, "BTREE", nil, "A", "", 1))
 
-	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
+	mock.ExpectQuery("SELECT COUNT.*KEY_COLUMN_USAGE.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectQuery("SELECT COUNT.*REFERENTIAL_CONSTRAINTS.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	mock.ExpectQuery("SELECT DISTINCT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"TABLE_NAME", "CONSTRAINT_NAME", "COLUMN_NAME", "REFERENCED_TABLE_NAME",
 			"REFERENCED_COLUMN_NAME", "UPDATE_RULE", "DELETE_RULE", "ORDINAL_POSITION",

--- a/internal/mysqldump/schema.go
+++ b/internal/mysqldump/schema.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/shopware/shopware-cli/logging"
 )
 
 type TableSchema struct {
@@ -711,6 +713,24 @@ func (d *Dumper) fetchAllIndexes(ctx context.Context) error {
 }
 
 func (d *Dumper) fetchAllForeignKeys(ctx context.Context) error {
+	var expectedFKs, fetchedFKs int
+	if err := d.db.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT CONCAT(TABLE_NAME, '|', CONSTRAINT_NAME))
+		FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+		WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IS NOT NULL`).Scan(&expectedFKs); err != nil {
+		return fmt.Errorf("count foreign keys in KEY_COLUMN_USAGE: %w", err)
+	}
+	if err := d.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+		WHERE CONSTRAINT_SCHEMA = DATABASE()`).Scan(&fetchedFKs); err != nil {
+		return fmt.Errorf("count foreign keys in REFERENTIAL_CONSTRAINTS: %w", err)
+	}
+	if expectedFKs > fetchedFKs {
+		logging.FromContext(ctx).Warnf(
+			"Found %d foreign key columns in KEY_COLUMN_USAGE but only %d rows in REFERENTIAL_CONSTRAINTS — %d foreign key constraint(s) will be missing from the dump. This usually means the connecting user lacks privileges on the referenced tables. Grant SELECT (or REFERENCES) on the parent tables and re-run.",
+			expectedFKs, fetchedFKs, expectedFKs-fetchedFKs)
+	}
+
 	query := `
 		SELECT DISTINCT
 			kcu.TABLE_NAME,

--- a/internal/mysqldump/schema_test.go
+++ b/internal/mysqldump/schema_test.go
@@ -360,7 +360,12 @@ func TestFetchTableSchema(t *testing.T) {
 		}).
 			AddRow("test_table", "PRIMARY", "id", 0, "BTREE", nil, "A", "", 1))
 
-	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
+	mock.ExpectQuery("SELECT COUNT.*KEY_COLUMN_USAGE.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectQuery("SELECT COUNT.*REFERENTIAL_CONSTRAINTS.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	mock.ExpectQuery("SELECT DISTINCT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"TABLE_NAME", "CONSTRAINT_NAME", "COLUMN_NAME", "REFERENCED_TABLE_NAME",
 			"REFERENCED_COLUMN_NAME", "UPDATE_RULE", "DELETE_RULE", "ORDINAL_POSITION",
@@ -413,7 +418,12 @@ func TestGetCreateTableStatement_Integration(t *testing.T) {
 		}).
 			AddRow("products", "PRIMARY", "id", 0, "BTREE", nil, "A", "", 1))
 
-	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
+	mock.ExpectQuery("SELECT COUNT.*KEY_COLUMN_USAGE.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectQuery("SELECT COUNT.*REFERENTIAL_CONSTRAINTS.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	mock.ExpectQuery("SELECT DISTINCT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"TABLE_NAME", "CONSTRAINT_NAME", "COLUMN_NAME", "REFERENCED_TABLE_NAME",
 			"REFERENCED_COLUMN_NAME", "UPDATE_RULE", "DELETE_RULE", "ORDINAL_POSITION",
@@ -560,7 +570,12 @@ func TestFetchAllForeignKeys_NumericName(t *testing.T) {
 		"product": {Name: "product"},
 	}
 
-	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
+	mock.ExpectQuery("SELECT COUNT.*KEY_COLUMN_USAGE.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+	mock.ExpectQuery("SELECT COUNT.*REFERENTIAL_CONSTRAINTS.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
+
+	mock.ExpectQuery("SELECT DISTINCT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"TABLE_NAME", "CONSTRAINT_NAME", "COLUMN_NAME", "REFERENCED_TABLE_NAME",
 			"REFERENCED_COLUMN_NAME", "UPDATE_RULE", "DELETE_RULE", "ORDINAL_POSITION",


### PR DESCRIPTION
## The bug

`shopware-cli project dump` was silently omitting **all** foreign-key constraints from the schema when the connecting user had read-only privileges scoped only to the target database (e.g. `GRANT SELECT ON shopware.*`). The dump completed successfully with `KEY` index entries but no `CONSTRAINT … FOREIGN KEY …` clauses, producing a schema that imports without referential integrity.

### Root cause

`internal/mysqldump/schema.go::fetchAllForeignKeys` builds foreign-key metadata by joining two `INFORMATION_SCHEMA` views:

```sql
FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
    ON kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
    AND kcu.TABLE_SCHEMA = rc.CONSTRAINT_SCHEMA
```

These two views apply **different** privilege filters:

- `KEY_COLUMN_USAGE` rows are visible if the user has any privilege on the **child** table.
- `REFERENTIAL_CONSTRAINTS` rows additionally require a privilege on the **referenced (parent)** table.

A user with `SELECT` only on the target schema can see every FK column in `KEY_COLUMN_USAGE` but receives **zero rows** from `REFERENTIAL_CONSTRAINTS`. The `JOIN` therefore returns nothing, every FK silently disappears from the dump, and the user has no way to know it happened.

Reproduced locally against MariaDB 11.8.6 / 12.2.2 with a Shopware schema that has 643 FKs:

| Connecting user | KEY_COLUMN_USAGE | REFERENTIAL_CONSTRAINTS | FKs in dump |
|---|---|---|---|
| `root` | 643 | 643 | 643 |
| `GRANT SELECT ON db.*` only | 643 | 0 | **0** |

## The fix

Before running the FK fetch query, count both sides independently and log a warning if they diverge. The warning quotes both numbers and points at the most likely cause:

```
WARN  Found 643 foreign key columns in KEY_COLUMN_USAGE but only 0 rows in
      REFERENTIAL_CONSTRAINTS — 643 foreign key constraint(s) will be missing
      from the dump. This usually means the connecting user lacks privileges
      on the referenced tables. Grant SELECT (or REFERENCES) on the parent
      tables and re-run.
```

Behaviour change:
- Privileged user (e.g. `root`): silent, dump unchanged.
- Under-privileged user: warning is logged, dump still completes with the same (empty-FK) output as before — but the user now knows why and how to fix it.

This is option B from the discussion: surface the issue without restructuring the query. A future change can switch to a `LEFT JOIN` that emits FKs without `ON DELETE` / `ON UPDATE` rules when `rc` rows are inaccessible.

## Test plan

- [x] `go test ./internal/mysqldump/...` — all green; sqlmock expectations updated to cover the two new count queries.
- [x] `go vet ./internal/mysqldump/` — clean.
- [x] Manual: dump as `root` against MariaDB 11.8.6 → no warning, 643 FKs in output.
- [x] Manual: dump as `GRANT SELECT ON db.*` user → warning fires with the correct numbers, dump still completes.