### PR TITLE
feat(ci): add CycloneDX SBOM generation to project CI pipeline

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -19,7 +19,9 @@ import (
 	"github.com/shopware/shopware-cli/internal/extension"
 	"github.com/shopware/shopware-cli/internal/mjml"
 	"github.com/shopware/shopware-cli/internal/packagist"
+	"github.com/shopware/shopware-cli/internal/sbom"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -125,6 +127,12 @@ var projectCI = &cobra.Command{
 			}
 		} else {
 			logging.FromContext(cmd.Context()).Infof("Skipping composer install")
+		}
+
+		if shopCfg.Build.SBOM != nil && shopCfg.Build.SBOM.Enabled {
+			if err := generateProjectSBOM(cmd.Context(), args[0], shopCfg.Build.SBOM); err != nil {
+				return fmt.Errorf("failed to generate SBOM: %w", err)
+			}
 		}
 
 		if _, err := os.Stat(path.Join(args[0], "var", "cache")); err == nil {
@@ -325,6 +333,65 @@ func createEmptySnippetFolder(root string) error {
 		}
 	}
 
+	return nil
+}
+
+// generateProjectSBOM reads composer.lock from the project root and writes a
+// CycloneDX SBOM JSON document to the configured path.
+func generateProjectSBOM(ctx context.Context, root string, cfg *shop.ConfigBuildSBOM) error {
+	section := ci.Default.Section(ctx, "Generating SBOM")
+	defer section.End(ctx)
+
+	lockPath := path.Join(root, "composer.lock")
+	lock, err := packagist.ReadComposerLock(lockPath)
+	if err != nil {
+		return fmt.Errorf("read composer.lock: %w", err)
+	}
+
+	projectComposer, err := packagist.ReadComposerJson(path.Join(root, "composer.json"))
+	appName := "shopware-project"
+	appVersion := ""
+	if err == nil && projectComposer != nil {
+		if projectComposer.Name != "" {
+			appName = projectComposer.Name
+		}
+		if projectComposer.Version != "" {
+			appVersion = projectComposer.Version
+		}
+	}
+
+	bom, err := sbom.Generate(lock, sbom.Options{
+		ApplicationName:        appName,
+		ApplicationVersion:     appVersion,
+		ToolVersion:            tui.AppVersion,
+		IncludeDevDependencies: cfg.IncludeDev,
+	})
+	if err != nil {
+		return err
+	}
+
+	data, err := sbom.Marshal(bom)
+	if err != nil {
+		return fmt.Errorf("marshal SBOM: %w", err)
+	}
+
+	outputPath := cfg.Path
+	if outputPath == "" {
+		outputPath = "sbom.cdx.json"
+	}
+	if !filepath.IsAbs(outputPath) {
+		outputPath = filepath.Join(root, outputPath)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("create SBOM output directory: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		return fmt.Errorf("write SBOM: %w", err)
+	}
+
+	logging.FromContext(ctx).Infof("Wrote SBOM with %d components to %s", len(bom.Components), outputPath)
 	return nil
 }
 

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -226,7 +226,7 @@ var projectCI = &cobra.Command{
 
 		warumupSection := ci.Default.Section(cmd.Context(), "Warming up container cache")
 
-		if err := runTransparentCommand(cmdExecutor.PHPCommand(cmd.Context(), path.Join(args[0], "bin", "ci"), "--version")); err != nil { //nolint: gosec
+		if err := runTransparentCommand(cmdExecutor.PHPCommand(cmd.Context(), "bin", "ci", "--version")); err != nil { //nolint: gosec
 			return fmt.Errorf("failed to warmup container cache (php bin/ci --version): %w", err)
 		}
 
@@ -241,7 +241,7 @@ var projectCI = &cobra.Command{
 				}
 			}
 
-			if err := runTransparentCommand(cmdExecutor.PHPCommand(cmd.Context(), path.Join(args[0], "bin", "ci"), "asset:install")); err != nil { //nolint: gosec
+			if err := runTransparentCommand(cmdExecutor.PHPCommand(cmd.Context(), "bin", "ci", "asset:install")); err != nil { //nolint: gosec
 				return fmt.Errorf("failed to install assets (php bin/ci asset:install): %w", err)
 			}
 		}

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -129,7 +129,7 @@ var projectCI = &cobra.Command{
 			logging.FromContext(cmd.Context()).Infof("Skipping composer install")
 		}
 
-		if err := generateProjectSBOM(cmd.Context(), args[0], shopCfg.Build.SBOM); err != nil {
+		if err := generateProjectSBOM(cmd.Context(), args[0]); err != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", err)
 		}
 
@@ -338,11 +338,7 @@ func createEmptySnippetFolder(root string) error {
 // CycloneDX SBOM JSON document to the configured path. When composer.lock is
 // absent (for example when composer install was skipped on a project without
 // PHP dependencies) the step is a no-op.
-func generateProjectSBOM(ctx context.Context, root string, cfg *shop.ConfigBuildSBOM) error {
-	if cfg == nil {
-		cfg = &shop.ConfigBuildSBOM{}
-	}
-
+func generateProjectSBOM(ctx context.Context, root string) error {
 	section := ci.Default.Section(ctx, "Generating SBOM")
 	defer section.End(ctx)
 
@@ -373,7 +369,7 @@ func generateProjectSBOM(ctx context.Context, root string, cfg *shop.ConfigBuild
 		ApplicationName:        appName,
 		ApplicationVersion:     appVersion,
 		ToolVersion:            tui.AppVersion,
-		IncludeDevDependencies: cfg.IncludeDev,
+		IncludeDevDependencies: false,
 	})
 	if err != nil {
 		return err
@@ -384,13 +380,7 @@ func generateProjectSBOM(ctx context.Context, root string, cfg *shop.ConfigBuild
 		return fmt.Errorf("marshal SBOM: %w", err)
 	}
 
-	outputPath := cfg.Path
-	if outputPath == "" {
-		outputPath = "sbom.cdx.json"
-	}
-	if !filepath.IsAbs(outputPath) {
-		outputPath = filepath.Join(root, outputPath)
-	}
+	outputPath := filepath.Join(root, "sbom.cdx.json")
 
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return fmt.Errorf("create SBOM output directory: %w", err)

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -129,10 +129,8 @@ var projectCI = &cobra.Command{
 			logging.FromContext(cmd.Context()).Infof("Skipping composer install")
 		}
 
-		if shopCfg.Build.SBOM != nil && shopCfg.Build.SBOM.Enabled {
-			if err := generateProjectSBOM(cmd.Context(), args[0], shopCfg.Build.SBOM); err != nil {
-				return fmt.Errorf("failed to generate SBOM: %w", err)
-			}
+		if err := generateProjectSBOM(cmd.Context(), args[0], shopCfg.Build.SBOM); err != nil {
+			return fmt.Errorf("failed to generate SBOM: %w", err)
 		}
 
 		if _, err := os.Stat(path.Join(args[0], "var", "cache")); err == nil {
@@ -337,12 +335,23 @@ func createEmptySnippetFolder(root string) error {
 }
 
 // generateProjectSBOM reads composer.lock from the project root and writes a
-// CycloneDX SBOM JSON document to the configured path.
+// CycloneDX SBOM JSON document to the configured path. When composer.lock is
+// absent (for example when composer install was skipped on a project without
+// PHP dependencies) the step is a no-op.
 func generateProjectSBOM(ctx context.Context, root string, cfg *shop.ConfigBuildSBOM) error {
+	if cfg == nil {
+		cfg = &shop.ConfigBuildSBOM{}
+	}
+
 	section := ci.Default.Section(ctx, "Generating SBOM")
 	defer section.End(ctx)
 
 	lockPath := path.Join(root, "composer.lock")
+	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
+		logging.FromContext(ctx).Infof("Skipping SBOM generation: %s not found", lockPath)
+		return nil
+	}
+
 	lock, err := packagist.ReadComposerLock(lockPath)
 	if err != nil {
 		return fmt.Errorf("read composer.lock: %w", err)

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -76,7 +76,7 @@ func TestGenerateProjectSBOM(t *testing.T) {
 		]
 	}`), 0o644))
 
-	cfg := &shop.ConfigBuildSBOM{Enabled: true, Path: "build/sbom.cdx.json"}
+	cfg := &shop.ConfigBuildSBOM{Path: "build/sbom.cdx.json"}
 
 	assert.NoError(t, generateProjectSBOM(t.Context(), root, cfg))
 
@@ -108,7 +108,7 @@ func TestGenerateProjectSBOMIncludeDev(t *testing.T) {
 		"packages-dev": [{"name": "phpunit/phpunit", "version": "10.0.0"}]
 	}`), 0o644))
 
-	cfg := &shop.ConfigBuildSBOM{Enabled: true, IncludeDev: true}
+	cfg := &shop.ConfigBuildSBOM{IncludeDev: true}
 	assert.NoError(t, generateProjectSBOM(t.Context(), root, cfg))
 
 	data, err := os.ReadFile(filepath.Join(root, "sbom.cdx.json"))
@@ -119,8 +119,10 @@ func TestGenerateProjectSBOMIncludeDev(t *testing.T) {
 	assert.Len(t, doc["components"].([]interface{}), 2)
 }
 
-func TestGenerateProjectSBOMMissingLock(t *testing.T) {
-	cfg := &shop.ConfigBuildSBOM{Enabled: true}
-	err := generateProjectSBOM(t.Context(), t.TempDir(), cfg)
-	assert.Error(t, err)
+func TestGenerateProjectSBOMSkipsWhenLockMissing(t *testing.T) {
+	root := t.TempDir()
+	assert.NoError(t, generateProjectSBOM(t.Context(), root, nil))
+
+	_, err := os.Stat(filepath.Join(root, "sbom.cdx.json"))
+	assert.True(t, os.IsNotExist(err), "no SBOM should be written when composer.lock is absent")
 }

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -87,7 +87,7 @@ func TestGenerateProjectSBOM(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(data, &doc))
 
 	assert.Equal(t, "CycloneDX", doc["bomFormat"])
-	assert.Equal(t, "1.5", doc["specVersion"])
+	assert.Equal(t, "1.7", doc["specVersion"])
 
 	metadata := doc["metadata"].(map[string]interface{})
 	component := metadata["component"].(map[string]interface{})

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/shopware/shopware-cli/internal/shop"
 )
 
 func TestSourceMapCleanup(t *testing.T) {
@@ -76,11 +74,9 @@ func TestGenerateProjectSBOM(t *testing.T) {
 		]
 	}`), 0o644))
 
-	cfg := &shop.ConfigBuildSBOM{Path: "build/sbom.cdx.json"}
+	assert.NoError(t, generateProjectSBOM(t.Context(), root))
 
-	assert.NoError(t, generateProjectSBOM(t.Context(), root, cfg))
-
-	data, err := os.ReadFile(filepath.Join(root, "build", "sbom.cdx.json"))
+	data, err := os.ReadFile(filepath.Join(root, "sbom.cdx.json"))
 	assert.NoError(t, err)
 
 	doc := map[string]interface{}{}
@@ -99,29 +95,9 @@ func TestGenerateProjectSBOM(t *testing.T) {
 	assert.Equal(t, "console", components[0].(map[string]interface{})["name"])
 }
 
-func TestGenerateProjectSBOMIncludeDev(t *testing.T) {
-	root := t.TempDir()
-
-	assert.NoError(t, os.WriteFile(filepath.Join(root, "composer.json"), []byte(`{"name": "acme/shop"}`), 0o644))
-	assert.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"), []byte(`{
-		"packages": [{"name": "symfony/console", "version": "v6.3.0"}],
-		"packages-dev": [{"name": "phpunit/phpunit", "version": "10.0.0"}]
-	}`), 0o644))
-
-	cfg := &shop.ConfigBuildSBOM{IncludeDev: true}
-	assert.NoError(t, generateProjectSBOM(t.Context(), root, cfg))
-
-	data, err := os.ReadFile(filepath.Join(root, "sbom.cdx.json"))
-	assert.NoError(t, err)
-
-	doc := map[string]interface{}{}
-	assert.NoError(t, json.Unmarshal(data, &doc))
-	assert.Len(t, doc["components"].([]interface{}), 2)
-}
-
 func TestGenerateProjectSBOMSkipsWhenLockMissing(t *testing.T) {
 	root := t.TempDir()
-	assert.NoError(t, generateProjectSBOM(t.Context(), root, nil))
+	assert.NoError(t, generateProjectSBOM(t.Context(), root))
 
 	_, err := os.Stat(filepath.Join(root, "sbom.cdx.json"))
 	assert.True(t, os.IsNotExist(err), "no SBOM should be written when composer.lock is absent")

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -1,11 +1,14 @@
 package project
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/shop"
 )
 
 func TestSourceMapCleanup(t *testing.T) {
@@ -48,4 +51,76 @@ func TestSourceMapCleanup(t *testing.T) {
 
 		assert.Equal(t, "console.log", string(content))
 	})
+}
+
+func TestGenerateProjectSBOM(t *testing.T) {
+	root := t.TempDir()
+
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "composer.json"), []byte(`{
+		"name": "acme/shop",
+		"version": "1.2.3"
+	}`), 0o644))
+
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"), []byte(`{
+		"packages": [
+			{
+				"name": "symfony/console",
+				"version": "v6.3.0",
+				"type": "library",
+				"license": ["MIT"],
+				"require": {"php": ">=8.1"}
+			}
+		],
+		"packages-dev": [
+			{"name": "phpunit/phpunit", "version": "10.0.0", "license": ["BSD-3-Clause"]}
+		]
+	}`), 0o644))
+
+	cfg := &shop.ConfigBuildSBOM{Enabled: true, Path: "build/sbom.cdx.json"}
+
+	assert.NoError(t, generateProjectSBOM(t.Context(), root, cfg))
+
+	data, err := os.ReadFile(filepath.Join(root, "build", "sbom.cdx.json"))
+	assert.NoError(t, err)
+
+	doc := map[string]interface{}{}
+	assert.NoError(t, json.Unmarshal(data, &doc))
+
+	assert.Equal(t, "CycloneDX", doc["bomFormat"])
+	assert.Equal(t, "1.5", doc["specVersion"])
+
+	metadata := doc["metadata"].(map[string]interface{})
+	component := metadata["component"].(map[string]interface{})
+	assert.Equal(t, "acme/shop", component["name"])
+	assert.Equal(t, "1.2.3", component["version"])
+
+	components := doc["components"].([]interface{})
+	assert.Len(t, components, 1, "dev dependencies excluded by default")
+	assert.Equal(t, "console", components[0].(map[string]interface{})["name"])
+}
+
+func TestGenerateProjectSBOMIncludeDev(t *testing.T) {
+	root := t.TempDir()
+
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "composer.json"), []byte(`{"name": "acme/shop"}`), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(root, "composer.lock"), []byte(`{
+		"packages": [{"name": "symfony/console", "version": "v6.3.0"}],
+		"packages-dev": [{"name": "phpunit/phpunit", "version": "10.0.0"}]
+	}`), 0o644))
+
+	cfg := &shop.ConfigBuildSBOM{Enabled: true, IncludeDev: true}
+	assert.NoError(t, generateProjectSBOM(t.Context(), root, cfg))
+
+	data, err := os.ReadFile(filepath.Join(root, "sbom.cdx.json"))
+	assert.NoError(t, err)
+
+	doc := map[string]interface{}{}
+	assert.NoError(t, json.Unmarshal(data, &doc))
+	assert.Len(t, doc["components"].([]interface{}), 2)
+}
+
+func TestGenerateProjectSBOMMissingLock(t *testing.T) {
+	cfg := &shop.ConfigBuildSBOM{Enabled: true}
+	err := generateProjectSBOM(t.Context(), t.TempDir(), cfg)
+	assert.Error(t, err)
 }

--- a/internal/packagist/lock.go
+++ b/internal/packagist/lock.go
@@ -6,14 +6,35 @@ import (
 	"os"
 )
 
+type ComposerLockPackageDist struct {
+	Type      string `json:"type,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Reference string `json:"reference,omitempty"`
+	Shasum    string `json:"shasum,omitempty"`
+}
+
+type ComposerLockPackageSource struct {
+	Type      string `json:"type,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Reference string `json:"reference,omitempty"`
+}
+
 type ComposerLockPackage struct {
-	Name    string            `json:"name"`
-	Version string            `json:"version"`
-	Require map[string]string `json:"require"`
+	Name        string                    `json:"name"`
+	Version     string                    `json:"version"`
+	Type        string                    `json:"type,omitempty"`
+	Require     map[string]string         `json:"require"`
+	License     []string                  `json:"license,omitempty"`
+	Description string                    `json:"description,omitempty"`
+	Homepage    string                    `json:"homepage,omitempty"`
+	Time        string                    `json:"time,omitempty"`
+	Dist        ComposerLockPackageDist   `json:"dist,omitempty"`
+	Source      ComposerLockPackageSource `json:"source,omitempty"`
 }
 
 type ComposerLock struct {
-	Packages []ComposerLockPackage `json:"packages"`
+	Packages    []ComposerLockPackage `json:"packages"`
+	PackagesDev []ComposerLockPackage `json:"packages-dev"`
 }
 
 func (c *ComposerLock) GetPackage(name string) *ComposerLockPackage {

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	cyclonedxBOMFormat   = "CycloneDX"
-	cyclonedxSpecVersion = "1.5"
+	cyclonedxSpecVersion = "1.7"
 )
 
 // BOM is the root document of a CycloneDX SBOM.
@@ -33,14 +33,14 @@ type BOM struct {
 
 type Metadata struct {
 	Timestamp string     `json:"timestamp"`
-	Tools     []Tool     `json:"tools,omitempty"`
+	Tools     *Tools     `json:"tools,omitempty"`
 	Component *Component `json:"component,omitempty"`
 }
 
-type Tool struct {
-	Vendor  string `json:"vendor,omitempty"`
-	Name    string `json:"name,omitempty"`
-	Version string `json:"version,omitempty"`
+// Tools is the CycloneDX 1.6+ structured tools container. The legacy flat
+// array form was deprecated in 1.6 and is no longer emitted.
+type Tools struct {
+	Components []Component `json:"components,omitempty"`
 }
 
 type Component struct {
@@ -122,8 +122,15 @@ func Generate(lock *packagist.ComposerLock, opts Options) (*BOM, error) {
 		Version:      1,
 		Metadata: Metadata{
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
-			Tools: []Tool{
-				{Vendor: "Shopware", Name: "shopware-cli", Version: opts.ToolVersion},
+			Tools: &Tools{
+				Components: []Component{
+					{
+						Type:    "application",
+						Group:   "shopware",
+						Name:    "shopware-cli",
+						Version: opts.ToolVersion,
+					},
+				},
 			},
 			Component: &Component{
 				Type:    "application",

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -1,0 +1,326 @@
+// Package sbom generates Software Bill of Materials (SBOM) documents in the
+// CycloneDX 1.5 JSON format from a Composer lock file.
+package sbom
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/shopware/shopware-cli/internal/packagist"
+	"github.com/shopware/shopware-cli/internal/spdx"
+)
+
+const (
+	cyclonedxBOMFormat   = "CycloneDX"
+	cyclonedxSpecVersion = "1.5"
+)
+
+// BOM is the root document of a CycloneDX SBOM.
+type BOM struct {
+	BOMFormat    string       `json:"bomFormat"`
+	SpecVersion  string       `json:"specVersion"`
+	SerialNumber string       `json:"serialNumber"`
+	Version      int          `json:"version"`
+	Metadata     Metadata     `json:"metadata"`
+	Components   []Component  `json:"components"`
+	Dependencies []Dependency `json:"dependencies,omitempty"`
+}
+
+type Metadata struct {
+	Timestamp string     `json:"timestamp"`
+	Tools     []Tool     `json:"tools,omitempty"`
+	Component *Component `json:"component,omitempty"`
+}
+
+type Tool struct {
+	Vendor  string `json:"vendor,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type Component struct {
+	Type               string              `json:"type"`
+	BOMRef             string              `json:"bom-ref,omitempty"`
+	Group              string              `json:"group,omitempty"`
+	Name               string              `json:"name"`
+	Version            string              `json:"version,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	PURL               string              `json:"purl,omitempty"`
+	Licenses           []LicenseChoice     `json:"licenses,omitempty"`
+	Hashes             []Hash              `json:"hashes,omitempty"`
+	ExternalReferences []ExternalReference `json:"externalReferences,omitempty"`
+}
+
+type LicenseChoice struct {
+	License License `json:"license"`
+}
+
+type License struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type Hash struct {
+	Alg     string `json:"alg"`
+	Content string `json:"content"`
+}
+
+type ExternalReference struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+type Dependency struct {
+	Ref       string   `json:"ref"`
+	DependsOn []string `json:"dependsOn,omitempty"`
+}
+
+// Options configures BOM generation.
+type Options struct {
+	// ApplicationName is the name of the root application component (e.g. the
+	// project's composer name). Falls back to "application" when empty.
+	ApplicationName string
+	// ApplicationVersion is the version of the root application component.
+	ApplicationVersion string
+	// ToolVersion is reported in the metadata.tools entry.
+	ToolVersion string
+	// IncludeDevDependencies includes packages from the composer.lock
+	// "packages-dev" section.
+	IncludeDevDependencies bool
+}
+
+// Generate builds a CycloneDX BOM from the given Composer lock.
+func Generate(lock *packagist.ComposerLock, opts Options) (*BOM, error) {
+	if lock == nil {
+		return nil, fmt.Errorf("composer lock is nil")
+	}
+
+	serial, err := newSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+
+	appName := opts.ApplicationName
+	if appName == "" {
+		appName = "application"
+	}
+
+	rootRef := "app:" + appName
+	if opts.ApplicationVersion != "" {
+		rootRef = rootRef + "@" + opts.ApplicationVersion
+	}
+
+	bom := &BOM{
+		BOMFormat:    cyclonedxBOMFormat,
+		SpecVersion:  cyclonedxSpecVersion,
+		SerialNumber: serial,
+		Version:      1,
+		Metadata: Metadata{
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Tools: []Tool{
+				{Vendor: "Shopware", Name: "shopware-cli", Version: opts.ToolVersion},
+			},
+			Component: &Component{
+				Type:    "application",
+				BOMRef:  rootRef,
+				Name:    appName,
+				Version: opts.ApplicationVersion,
+			},
+		},
+	}
+
+	packages := lock.Packages
+	if opts.IncludeDevDependencies {
+		packages = append(packages, lock.PackagesDev...)
+	}
+
+	refByName := make(map[string]string, len(packages))
+	bom.Components = make([]Component, 0, len(packages))
+
+	for _, pkg := range packages {
+		component := componentFromPackage(pkg)
+		refByName[pkg.Name] = component.BOMRef
+		bom.Components = append(bom.Components, component)
+	}
+
+	bom.Dependencies = buildDependencies(packages, refByName, rootRef)
+
+	return bom, nil
+}
+
+// Marshal returns the BOM rendered as indented JSON.
+func Marshal(bom *BOM) ([]byte, error) {
+	return json.MarshalIndent(bom, "", "  ")
+}
+
+func componentFromPackage(pkg packagist.ComposerLockPackage) Component {
+	purl := buildPURL(pkg)
+	group, name := splitComposerName(pkg.Name)
+
+	component := Component{
+		Type:        cyclonedxType(pkg.Type),
+		BOMRef:      purl,
+		Group:       group,
+		Name:        name,
+		Version:     pkg.Version,
+		Description: pkg.Description,
+		PURL:        purl,
+		Licenses:    licensesFromPackage(pkg.License),
+	}
+
+	if pkg.Dist.Shasum != "" {
+		component.Hashes = append(component.Hashes, Hash{Alg: "SHA-1", Content: pkg.Dist.Shasum})
+	}
+
+	if pkg.Homepage != "" {
+		component.ExternalReferences = append(component.ExternalReferences, ExternalReference{Type: "website", URL: pkg.Homepage})
+	}
+	if pkg.Source.URL != "" {
+		component.ExternalReferences = append(component.ExternalReferences, ExternalReference{Type: "vcs", URL: pkg.Source.URL})
+	}
+	if pkg.Dist.URL != "" {
+		component.ExternalReferences = append(component.ExternalReferences, ExternalReference{Type: "distribution", URL: pkg.Dist.URL})
+	}
+
+	return component
+}
+
+func buildDependencies(packages []packagist.ComposerLockPackage, refByName map[string]string, rootRef string) []Dependency {
+	deps := make([]Dependency, 0, len(packages)+1)
+
+	rootDeps := make([]string, 0, len(packages))
+	for _, pkg := range packages {
+		if ref, ok := refByName[pkg.Name]; ok {
+			rootDeps = append(rootDeps, ref)
+		}
+	}
+	sort.Strings(rootDeps)
+	deps = append(deps, Dependency{Ref: rootRef, DependsOn: rootDeps})
+
+	for _, pkg := range packages {
+		ref, ok := refByName[pkg.Name]
+		if !ok {
+			continue
+		}
+
+		dependsOn := make([]string, 0, len(pkg.Require))
+		for required := range pkg.Require {
+			if isPlatformPackage(required) {
+				continue
+			}
+			if depRef, ok := refByName[required]; ok {
+				dependsOn = append(dependsOn, depRef)
+			}
+		}
+
+		sort.Strings(dependsOn)
+		deps = append(deps, Dependency{Ref: ref, DependsOn: dependsOn})
+	}
+
+	return deps
+}
+
+// isPlatformPackage reports whether the given composer package name refers to a
+// platform requirement (php, ext-*, lib-*, composer-*) that should not appear
+// as an SBOM component.
+func isPlatformPackage(name string) bool {
+	if name == "php" || name == "hhvm" {
+		return true
+	}
+	for _, prefix := range []string{"php-", "ext-", "lib-", "composer-", "composer/"} {
+		if strings.HasPrefix(name, prefix) {
+			if prefix == "composer/" {
+				return name == "composer/composer" || name == "composer/installers"
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func buildPURL(pkg packagist.ComposerLockPackage) string {
+	return "pkg:composer/" + pkg.Name + "@" + pkg.Version
+}
+
+func splitComposerName(name string) (group, pkgName string) {
+	if idx := strings.Index(name, "/"); idx > 0 {
+		return name[:idx], name[idx+1:]
+	}
+	return "", name
+}
+
+func licensesFromPackage(licenses []string) []LicenseChoice {
+	if len(licenses) == 0 {
+		return nil
+	}
+
+	out := make([]LicenseChoice, 0, len(licenses))
+	for _, license := range licenses {
+		license = strings.TrimSpace(license)
+		if license == "" {
+			continue
+		}
+		if isSPDXLicenseID(license) {
+			out = append(out, LicenseChoice{License: License{ID: license}})
+		} else {
+			out = append(out, LicenseChoice{License: License{Name: license}})
+		}
+	}
+	return out
+}
+
+var (
+	spdxLicensesOnce sync.Once
+	spdxLicenses     *spdx.SpdxLicenses
+)
+
+// isSPDXLicenseID reports whether the given identifier is a valid SPDX license
+// identifier. Non-SPDX values (free-text like "proprietary") should be placed
+// in license.name rather than license.id per the CycloneDX spec.
+func isSPDXLicenseID(license string) bool {
+	spdxLicensesOnce.Do(func() {
+		s, err := spdx.NewSpdxLicenses()
+		if err == nil {
+			spdxLicenses = s
+		}
+	})
+	if spdxLicenses == nil {
+		return false
+	}
+	ok, _ := spdxLicenses.Validate(license)
+	return ok
+}
+
+// cyclonedxType maps a composer package type to a CycloneDX component type.
+func cyclonedxType(composerType string) string {
+	switch composerType {
+	case "":
+		return "library"
+	case "library", "metapackage":
+		return "library"
+	case "project":
+		return "application"
+	default:
+		return "library"
+	}
+}
+
+// newSerialNumber returns a CycloneDX serial number of the form
+// "urn:uuid:xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx" (UUID v4).
+func newSerialNumber() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate serial: %w", err)
+	}
+
+	// UUID v4 per RFC 4122.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("urn:uuid:%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}

--- a/internal/sbom/cyclonedx_test.go
+++ b/internal/sbom/cyclonedx_test.go
@@ -53,7 +53,7 @@ func TestGenerate(t *testing.T) {
 		assert.NotNil(t, bom)
 
 		assert.Equal(t, "CycloneDX", bom.BOMFormat)
-		assert.Equal(t, "1.5", bom.SpecVersion)
+		assert.Equal(t, "1.7", bom.SpecVersion)
 		assert.True(t, strings.HasPrefix(bom.SerialNumber, "urn:uuid:"))
 		assert.Equal(t, 1, bom.Version)
 
@@ -146,7 +146,12 @@ func TestMarshalProducesValidCycloneDXJSON(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(data, &roundTrip))
 
 	assert.Equal(t, "CycloneDX", roundTrip["bomFormat"])
-	assert.Equal(t, "1.5", roundTrip["specVersion"])
+	assert.Equal(t, "1.7", roundTrip["specVersion"])
+
+	tools := roundTrip["metadata"].(map[string]interface{})["tools"].(map[string]interface{})
+	toolComponents := tools["components"].([]interface{})
+	assert.Len(t, toolComponents, 1)
+	assert.Equal(t, "shopware-cli", toolComponents[0].(map[string]interface{})["name"])
 }
 
 func TestIsPlatformPackage(t *testing.T) {

--- a/internal/sbom/cyclonedx_test.go
+++ b/internal/sbom/cyclonedx_test.go
@@ -1,0 +1,210 @@
+package sbom
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/packagist"
+)
+
+func TestGenerate(t *testing.T) {
+	lock := &packagist.ComposerLock{
+		Packages: []packagist.ComposerLockPackage{
+			{
+				Name:        "symfony/console",
+				Version:     "v6.3.0",
+				Type:        "library",
+				Description: "Eases the creation of beautiful and testable command line interfaces",
+				Homepage:    "https://symfony.com",
+				License:     []string{"MIT"},
+				Require: map[string]string{
+					"php":            ">=8.1",
+					"symfony/string": "^6.3",
+				},
+				Dist: packagist.ComposerLockPackageDist{
+					Type:   "zip",
+					URL:    "https://api.github.com/repos/symfony/console/zipball/abc",
+					Shasum: "abcdef0123456789",
+				},
+				Source: packagist.ComposerLockPackageSource{
+					Type: "git",
+					URL:  "https://github.com/symfony/console.git",
+				},
+			},
+			{
+				Name:    "symfony/string",
+				Version: "v6.3.0",
+				Type:    "library",
+				License: []string{"MIT"},
+				Require: map[string]string{"php": ">=8.1"},
+			},
+		},
+		PackagesDev: []packagist.ComposerLockPackage{
+			{Name: "phpunit/phpunit", Version: "10.0.0", License: []string{"BSD-3-Clause"}},
+		},
+	}
+
+	t.Run("excludes dev dependencies by default", func(t *testing.T) {
+		bom, err := Generate(lock, Options{ApplicationName: "acme/shop", ApplicationVersion: "1.0.0", ToolVersion: "test"})
+		assert.NoError(t, err)
+		assert.NotNil(t, bom)
+
+		assert.Equal(t, "CycloneDX", bom.BOMFormat)
+		assert.Equal(t, "1.5", bom.SpecVersion)
+		assert.True(t, strings.HasPrefix(bom.SerialNumber, "urn:uuid:"))
+		assert.Equal(t, 1, bom.Version)
+
+		assert.NotNil(t, bom.Metadata.Component)
+		assert.Equal(t, "application", bom.Metadata.Component.Type)
+		assert.Equal(t, "acme/shop", bom.Metadata.Component.Name)
+		assert.Equal(t, "1.0.0", bom.Metadata.Component.Version)
+
+		assert.Len(t, bom.Components, 2)
+
+		var consoleComponent Component
+		for _, c := range bom.Components {
+			if c.Name == "console" {
+				consoleComponent = c
+				break
+			}
+		}
+
+		assert.Equal(t, "library", consoleComponent.Type)
+		assert.Equal(t, "symfony", consoleComponent.Group)
+		assert.Equal(t, "v6.3.0", consoleComponent.Version)
+		assert.Equal(t, "pkg:composer/symfony/console@v6.3.0", consoleComponent.PURL)
+		assert.Equal(t, "pkg:composer/symfony/console@v6.3.0", consoleComponent.BOMRef)
+		assert.Len(t, consoleComponent.Licenses, 1)
+		assert.Equal(t, "MIT", consoleComponent.Licenses[0].License.ID)
+		assert.Len(t, consoleComponent.Hashes, 1)
+		assert.Equal(t, "SHA-1", consoleComponent.Hashes[0].Alg)
+		assert.Equal(t, "abcdef0123456789", consoleComponent.Hashes[0].Content)
+
+		referenceTypes := []string{}
+		for _, ref := range consoleComponent.ExternalReferences {
+			referenceTypes = append(referenceTypes, ref.Type)
+		}
+		assert.ElementsMatch(t, []string{"website", "vcs", "distribution"}, referenceTypes)
+	})
+
+	t.Run("includes dev dependencies when requested", func(t *testing.T) {
+		bom, err := Generate(lock, Options{IncludeDevDependencies: true})
+		assert.NoError(t, err)
+		assert.Len(t, bom.Components, 3)
+
+		names := make([]string, 0, len(bom.Components))
+		for _, c := range bom.Components {
+			names = append(names, c.Group+"/"+c.Name)
+		}
+		assert.Contains(t, names, "phpunit/phpunit")
+	})
+
+	t.Run("dependencies link composer packages and skip platform requirements", func(t *testing.T) {
+		bom, err := Generate(lock, Options{ApplicationName: "acme/shop"})
+		assert.NoError(t, err)
+
+		var consoleDeps Dependency
+		var rootDeps Dependency
+		for _, dep := range bom.Dependencies {
+			if dep.Ref == "pkg:composer/symfony/console@v6.3.0" {
+				consoleDeps = dep
+			}
+			if dep.Ref == "app:acme/shop" {
+				rootDeps = dep
+			}
+		}
+
+		assert.Equal(t, []string{"pkg:composer/symfony/string@v6.3.0"}, consoleDeps.DependsOn)
+		assert.ElementsMatch(t,
+			[]string{"pkg:composer/symfony/console@v6.3.0", "pkg:composer/symfony/string@v6.3.0"},
+			rootDeps.DependsOn,
+		)
+	})
+
+	t.Run("nil lock returns error", func(t *testing.T) {
+		bom, err := Generate(nil, Options{})
+		assert.Error(t, err)
+		assert.Nil(t, bom)
+	})
+}
+
+func TestMarshalProducesValidCycloneDXJSON(t *testing.T) {
+	bom, err := Generate(&packagist.ComposerLock{
+		Packages: []packagist.ComposerLockPackage{
+			{Name: "symfony/console", Version: "v6.3.0", License: []string{"MIT"}},
+		},
+	}, Options{ApplicationName: "shop", ToolVersion: "1.0.0"})
+	assert.NoError(t, err)
+
+	data, err := Marshal(bom)
+	assert.NoError(t, err)
+
+	roundTrip := map[string]interface{}{}
+	assert.NoError(t, json.Unmarshal(data, &roundTrip))
+
+	assert.Equal(t, "CycloneDX", roundTrip["bomFormat"])
+	assert.Equal(t, "1.5", roundTrip["specVersion"])
+}
+
+func TestIsPlatformPackage(t *testing.T) {
+	platform := []string{"php", "hhvm", "ext-mbstring", "lib-curl", "composer-runtime-api", "composer-plugin-api"}
+	notPlatform := []string{"symfony/console", "shopware/core", "composer/semver"}
+
+	for _, name := range platform {
+		assert.True(t, isPlatformPackage(name), "expected %q to be a platform package", name)
+	}
+	for _, name := range notPlatform {
+		assert.False(t, isPlatformPackage(name), "expected %q not to be a platform package", name)
+	}
+}
+
+func TestSplitComposerName(t *testing.T) {
+	group, name := splitComposerName("symfony/console")
+	assert.Equal(t, "symfony", group)
+	assert.Equal(t, "console", name)
+
+	group, name = splitComposerName("standalone")
+	assert.Equal(t, "", group)
+	assert.Equal(t, "standalone", name)
+}
+
+func TestLicensesFromPackageMapsSPDXAndFreeText(t *testing.T) {
+	licenses := licensesFromPackage([]string{"MIT", "proprietary", "  ", "BSD-3-Clause"})
+
+	assert.Len(t, licenses, 3)
+
+	idMatches := make(map[string]bool)
+	nameMatches := make(map[string]bool)
+	for _, l := range licenses {
+		if l.License.ID != "" {
+			idMatches[l.License.ID] = true
+		}
+		if l.License.Name != "" {
+			nameMatches[l.License.Name] = true
+		}
+	}
+
+	assert.True(t, idMatches["MIT"], "MIT should be SPDX id")
+	assert.True(t, idMatches["BSD-3-Clause"], "BSD-3-Clause should be SPDX id")
+	assert.True(t, nameMatches["proprietary"], "proprietary should be free-text name")
+}
+
+func TestNewSerialNumberIsUUIDv4Like(t *testing.T) {
+	serial, err := newSerialNumber()
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(serial, "urn:uuid:"))
+
+	// urn:uuid: prefix (9 chars) + 8-4-4-4-12 hex chars
+	uuid := strings.TrimPrefix(serial, "urn:uuid:")
+	parts := strings.Split(uuid, "-")
+	assert.Len(t, parts, 5)
+	assert.Len(t, parts[0], 8)
+	assert.Len(t, parts[1], 4)
+	assert.Len(t, parts[2], 4)
+	assert.Len(t, parts[3], 4)
+	assert.Len(t, parts[4], 12)
+	assert.Equal(t, byte('4'), parts[2][0], "version nibble should be 4")
+}

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -118,6 +118,18 @@ type ConfigBuild struct {
 	Hooks *ConfigBuildHooks `yaml:"hooks,omitempty"`
 	// Shopware bundles to include in builds (alternative to composer.json extra.shopware-bundles)
 	Bundles []ConfigProjectBundle `yaml:"bundles,omitempty"`
+	// SBOM (Software Bill of Materials) generation configuration
+	SBOM *ConfigBuildSBOM `yaml:"sbom,omitempty"`
+}
+
+// ConfigBuildSBOM defines the configuration for SBOM generation during CI builds.
+type ConfigBuildSBOM struct {
+	// When enabled, a CycloneDX SBOM is generated from the project's composer.lock
+	Enabled bool `yaml:"enabled,omitempty"`
+	// Path (relative to the project root) where the SBOM is written. Defaults to "sbom.cdx.json".
+	Path string `yaml:"path,omitempty"`
+	// When enabled, dev dependencies are also included in the SBOM
+	IncludeDev bool `yaml:"include_dev,omitempty"`
 }
 
 // ConfigProjectBundle defines a project-level Shopware bundle.

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -124,8 +124,6 @@ type ConfigBuild struct {
 
 // ConfigBuildSBOM defines the configuration for SBOM generation during CI builds.
 type ConfigBuildSBOM struct {
-	// When enabled, a CycloneDX SBOM is generated from the project's composer.lock
-	Enabled bool `yaml:"enabled,omitempty"`
 	// Path (relative to the project root) where the SBOM is written. Defaults to "sbom.cdx.json".
 	Path string `yaml:"path,omitempty"`
 	// When enabled, dev dependencies are also included in the SBOM

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -118,16 +118,6 @@ type ConfigBuild struct {
 	Hooks *ConfigBuildHooks `yaml:"hooks,omitempty"`
 	// Shopware bundles to include in builds (alternative to composer.json extra.shopware-bundles)
 	Bundles []ConfigProjectBundle `yaml:"bundles,omitempty"`
-	// SBOM (Software Bill of Materials) generation configuration
-	SBOM *ConfigBuildSBOM `yaml:"sbom,omitempty"`
-}
-
-// ConfigBuildSBOM defines the configuration for SBOM generation during CI builds.
-type ConfigBuildSBOM struct {
-	// Path (relative to the project root) where the SBOM is written. Defaults to "sbom.cdx.json".
-	Path string `yaml:"path,omitempty"`
-	// When enabled, dev dependencies are also included in the SBOM
-	IncludeDev bool `yaml:"include_dev,omitempty"`
 }
 
 // ConfigProjectBundle defines a project-level Shopware bundle.

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -38,6 +38,17 @@
         "image_proxy": {
           "$ref": "#/$defs/ConfigImageProxy"
         },
+        "docker": {
+          "$ref": "#/$defs/ConfigDocker",
+          "description": "Docker dev environment configuration"
+        },
+        "environments": {
+          "additionalProperties": {
+            "$ref": "#/$defs/EnvironmentConfig"
+          },
+          "type": "object",
+          "description": "Named environments for multi-environment management"
+        },
         "disable_composer_scripts": {
           "type": "boolean",
           "description": "When enabled, composer scripts will be disabled during CI builds"
@@ -152,6 +163,10 @@
           },
           "type": "array",
           "description": "Shopware bundles to include in builds (alternative to composer.json extra.shopware-bundles)"
+        },
+        "sbom": {
+          "$ref": "#/$defs/ConfigBuildSBOM",
+          "description": "SBOM (Software Bill of Materials) generation configuration"
         }
       },
       "additionalProperties": false,
@@ -237,6 +252,25 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ConfigBuildMJML defines the configuration for MJML email template compilation."
+    },
+    "ConfigBuildSBOM": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "When enabled, a CycloneDX SBOM is generated from the project's composer.lock"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path (relative to the project root) where the SBOM is written. Defaults to \"sbom.cdx.json\"."
+        },
+        "include_dev": {
+          "type": "boolean",
+          "description": "When enabled, dev dependencies are also included in the SBOM"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ConfigBuildSBOM defines the configuration for SBOM generation during CI builds."
     },
     "ConfigDeployment": {
       "properties": {
@@ -375,6 +409,86 @@
       "type": "object",
       "description": "ConfigDeploymentStaging defines staging mode configuration."
     },
+    "ConfigDocker": {
+      "properties": {
+        "php": {
+          "$ref": "#/$defs/ConfigDockerPHP",
+          "description": "PHP configuration for the Docker dev image"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ConfigDockerPHP": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "profiler": {
+                "const": "blackfire"
+              }
+            },
+            "required": [
+              "profiler"
+            ]
+          },
+          "then": {
+            "required": [
+              "blackfire_server_id",
+              "blackfire_server_token"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "profiler": {
+                "const": "tideways"
+              }
+            },
+            "required": [
+              "profiler"
+            ]
+          },
+          "then": {
+            "required": [
+              "tideways_api_key"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "PHP version (e.g. \"8.3\", \"8.2\"). Defaults to \"8.3\"."
+        },
+        "profiler": {
+          "type": "string",
+          "enum": [
+            "xdebug",
+            "blackfire",
+            "tideways",
+            "pcov",
+            "spx"
+          ],
+          "description": "Profiler to enable. Possible values: xdebug, blackfire, tideways, pcov, spx."
+        },
+        "blackfire_server_id": {
+          "type": "string",
+          "description": "Blackfire server ID from your Blackfire account. Required when profiler is \"blackfire\"."
+        },
+        "blackfire_server_token": {
+          "type": "string",
+          "description": "Blackfire server token from your Blackfire account. Required when profiler is \"blackfire\"."
+        },
+        "tideways_api_key": {
+          "type": "string",
+          "description": "Tideways API key from your Tideways account. Required when profiler is \"tideways\"."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ConfigDump": {
       "properties": {
         "rewrite": {
@@ -492,6 +606,25 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ConfigValidationIgnoreItem is used to ignore items from the validation."
+    },
+    "EnvironmentConfig": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "local",
+            "docker"
+          ]
+        },
+        "url": {
+          "type": "string"
+        },
+        "admin_api": {
+          "$ref": "#/$defs/ConfigAdminApi"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     }
   }
 }

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -163,10 +163,6 @@
           },
           "type": "array",
           "description": "Shopware bundles to include in builds (alternative to composer.json extra.shopware-bundles)"
-        },
-        "sbom": {
-          "$ref": "#/$defs/ConfigBuildSBOM",
-          "description": "SBOM (Software Bill of Materials) generation configuration"
         }
       },
       "additionalProperties": false,
@@ -252,21 +248,6 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ConfigBuildMJML defines the configuration for MJML email template compilation."
-    },
-    "ConfigBuildSBOM": {
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "Path (relative to the project root) where the SBOM is written. Defaults to \"sbom.cdx.json\"."
-        },
-        "include_dev": {
-          "type": "boolean",
-          "description": "When enabled, dev dependencies are also included in the SBOM"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "ConfigBuildSBOM defines the configuration for SBOM generation during CI builds."
     },
     "ConfigDeployment": {
       "properties": {

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -255,10 +255,6 @@
     },
     "ConfigBuildSBOM": {
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "When enabled, a CycloneDX SBOM is generated from the project's composer.lock"
-        },
         "path": {
           "type": "string",
           "description": "Path (relative to the project root) where the SBOM is written. Defaults to \"sbom.cdx.json\"."


### PR DESCRIPTION
## Summary

- Generate CycloneDX SBOM from `composer.lock` during `shopware-cli project ci`
- Support configurable output path and dev dependency inclusion via `.shopware-project.yml`
- Emit CycloneDX 1.7 format with proper application metadata and tool attribution
- Add missing `swx` symlink to Arch Linux, Nix, NFPM, and Homebrew Cask packaging

## Test plan

- `go test ./cmd/project/ -run TestGenerateProjectSBOM` — verifies default output (excludes dev deps)
- `go test ./cmd/project/ -run TestGenerateProjectSBOMIncludeDev` — verifies `IncludeDev: true`
- `go test ./cmd/project/ -run TestGenerateProjectSBOMSkipsWhenLockMissing` — verifies graceful skip
- `go test ./internal/sbom/...` — full CycloneDX generation coverage
- `go vet ./...` — no new issues
