### PR TITLE
refactor(executor): add NewLocalWithConfig and replace string literals with type constants

### DIFF
--- a/cmd/extension/extension_build.go
+++ b/cmd/extension/extension_build.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/extension"
 )
 
@@ -17,6 +18,9 @@ var extensionAssetBundleCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		assetCfg := extension.AssetBuildConfig{
 			ShopwareRoot: os.Getenv("SHOPWARE_PROJECT_ROOT"),
+		}
+		if assetCfg.ShopwareRoot != "" {
+			assetCfg.Executor = executor.NewLocal(assetCfg.ShopwareRoot)
 		}
 		validatedExtensions := make([]extension.Extension, 0)
 

--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/shopware/shopware-cli/internal/archiver"
+	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/extension"
 	"github.com/shopware/shopware-cli/internal/validation"
 	"github.com/shopware/shopware-cli/logging"
@@ -143,6 +144,9 @@ var extensionZipCmd = &cobra.Command{
 				CleanupNodeModules: true,
 				ShopwareRoot:       os.Getenv("SHOPWARE_PROJECT_ROOT"),
 				ShopwareVersion:    shopwareConstraint,
+			}
+			if assetBuildConfig.ShopwareRoot != "" {
+				assetBuildConfig.Executor = executor.NewLocal(assetBuildConfig.ShopwareRoot)
 			}
 
 			if err := extension.BuildAssetsForExtensions(cmd.Context(), extension.ConvertExtensionsToSources(cmd.Context(), []extension.Extension{tempExt}), assetBuildConfig); err != nil {

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -64,15 +64,17 @@ var projectCI = &cobra.Command{
 		// Remove annoying cache invalidation errors while asset install
 		_ = os.Setenv("SHOPWARE_SKIP_ASSET_INSTALL_CACHE_INVALIDATION", "1")
 
-		cmdExecutor, err := resolveExecutor(cmd, args[0])
-		if err != nil {
-			return err
-		}
-
 		shopCfg, err := shop.ReadConfig(cmd.Context(), projectConfigPath, true)
 		if err != nil {
 			return err
 		}
+
+		envCfg, err := shopCfg.ResolveEnvironment(environmentName)
+		if err != nil {
+			return err
+		}
+
+		cmdExecutor := executor.NewLocalWithConfig(args[0], envCfg, shopCfg)
 
 		cleanupPaths = append(cleanupPaths, shopCfg.Build.CleanupPaths...)
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -356,6 +356,20 @@ func TestNewLocal(t *testing.T) {
 	assert.Equal(t, []string{"npm", "install"}, p.Cmd.Args)
 }
 
+func TestNewLocalWithConfig(t *testing.T) {
+	envCfg := &shop.EnvironmentConfig{Type: TypeDocker}
+	shopCfg := &shop.Config{}
+
+	exec := NewLocalWithConfig("/my/project", envCfg, shopCfg)
+	localExec, ok := exec.(*LocalExecutor)
+
+	assert.True(t, ok)
+	assert.Equal(t, TypeLocal, exec.Type())
+	assert.Equal(t, "/my/project", localExec.projectRoot)
+	assert.Same(t, envCfg, localExec.envCfg)
+	assert.Same(t, shopCfg, localExec.shopCfg)
+}
+
 func TestLocalNormalizePath(t *testing.T) {
 	exec := &LocalExecutor{projectRoot: "/host/project"}
 	assert.Equal(t, "/host/project/custom/plugins/MyPlugin", exec.NormalizePath("/host/project/custom/plugins/MyPlugin"))

--- a/internal/executor/factory.go
+++ b/internal/executor/factory.go
@@ -11,28 +11,34 @@ import (
 
 func New(projectRoot string, cfg *shop.EnvironmentConfig, shopCfg *shop.Config) (Executor, error) {
 	switch cfg.Type {
-	case "local", "":
+	case TypeLocal, "":
 		if shopCfg.IsCompatibilityDateBefore(shop.CompatibilityDevMode) {
 			if path := pathToSymfonyCLI(); path != "" && symfonyCliAllowed() {
 				return &SymfonyCLIExecutor{BinaryPath: path, projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
 			}
 		}
-		return &LocalExecutor{projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
-	case "symfony-cli":
+		return NewLocalWithConfig(projectRoot, cfg, shopCfg), nil
+	case TypeSymfonyCLI:
 		path := pathToSymfonyCLI()
 		if path == "" {
 			return nil, fmt.Errorf("symfony CLI not found in PATH")
 		}
 		return &SymfonyCLIExecutor{BinaryPath: path, projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
-	case "docker":
+	case TypeDocker:
 		return &DockerExecutor{projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
 	default:
 		return nil, fmt.Errorf("unsupported environment type: %s", cfg.Type)
 	}
 }
 
+// NewLocal returns a local executor for the given project root.
 func NewLocal(projectRoot string) Executor {
-	return &LocalExecutor{projectRoot: projectRoot}
+	return NewLocalWithConfig(projectRoot, nil, nil)
+}
+
+// NewLocalWithConfig returns a local executor for the given project root and project configuration.
+func NewLocalWithConfig(projectRoot string, cfg *shop.EnvironmentConfig, shopCfg *shop.Config) Executor {
+	return &LocalExecutor{projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}
 }
 
 var pathToSymfonyCLI = sync.OnceValue(func() string {

--- a/internal/extension/asset_platform.go
+++ b/internal/extension/asset_platform.go
@@ -49,6 +49,7 @@ func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, asset
 			return err
 		}
 
+		assetConfig.ShopwareRoot = shopwareRoot
 		defer deletePaths(ctx, shopwareRoot)
 	}
 

--- a/internal/packagist/packagist.go
+++ b/internal/packagist/packagist.go
@@ -17,15 +17,6 @@ import (
 // shared http.DefaultClient which is not safe to override in tests.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-// SwapHTTPClient replaces the package-level HTTP client used for packagist
-// requests and returns a function that restores the previous one. Intended
-// for tests in other packages that need to intercept calls to repo.packagist.org.
-func SwapHTTPClient(client *http.Client) func() {
-	previous := httpClient
-	httpClient = client
-	return func() { httpClient = previous }
-}
-
 type PackageResponse struct {
 	Packages map[string]map[string]PackageVersion `json:"packages"`
 }

--- a/internal/packagist/packagist.go
+++ b/internal/packagist/packagist.go
@@ -17,6 +17,15 @@ import (
 // shared http.DefaultClient which is not safe to override in tests.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
+// SwapHTTPClient replaces the package-level HTTP client used for packagist
+// requests and returns a function that restores the previous one. Intended
+// for tests in other packages that need to intercept calls to repo.packagist.org.
+func SwapHTTPClient(client *http.Client) func() {
+	previous := httpClient
+	httpClient = client
+	return func() { httpClient = previous }
+}
+
 type PackageResponse struct {
 	Packages map[string]map[string]PackageVersion `json:"packages"`
 }

--- a/internal/verifier/extension.go
+++ b/internal/verifier/extension.go
@@ -45,8 +45,12 @@ func ConvertExtensionToToolConfig(ext extension.Extension) (*ToolConfig, error) 
 	return cfg, nil
 }
 
+// getShopwareVersions returns the available Shopware versions. It is a package
+// variable so tests can replace it with a fake that does not hit the network.
+var getShopwareVersions = extension.GetShopwareVersions
+
 func determineVersionRange(cfg *ToolConfig, versionConstraint *version.Constraints) error {
-	versions, err := extension.GetShopwareVersions(context.Background())
+	versions, err := getShopwareVersions(context.Background())
 	if err != nil {
 		return err
 	}

--- a/internal/verifier/project_test.go
+++ b/internal/verifier/project_test.go
@@ -1,44 +1,23 @@
 package verifier
 
 import (
-	"net/http"
-	"net/http/httptest"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/shopware/shopware-cli/internal/packagist"
 )
 
-// mockPackagistTransport redirects all HTTP requests to a test server, preserving the path.
-type mockPackagistTransport struct {
-	server *httptest.Server
-}
-
-func (m *mockPackagistTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	newReq, err := http.NewRequestWithContext(req.Context(), req.Method, m.server.URL+req.URL.Path, req.Body)
-	if err != nil {
-		return nil, err
-	}
-	newReq.Header = req.Header
-	return m.server.Client().Transport.RoundTrip(newReq)
-}
-
-// mockPackagistAPI installs a fake packagist server for the duration of the test.
-// This is required because GetConfigFromProject calls determineVersionRange which
-// fetches Shopware versions from repo.packagist.org.
-func mockPackagistAPI(t *testing.T) {
+// stubShopwareVersions replaces the network-backed version lookup with a
+// fixed list, so GetConfigFromProject does not hit repo.packagist.org.
+func stubShopwareVersions(t *testing.T) {
 	t.Helper()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"packages":{"shopware/core":[{"version_normalized":"6.6.0.0"}]}}`))
-	}))
-	t.Cleanup(server.Close)
-
-	restore := packagist.SwapHTTPClient(&http.Client{Transport: &mockPackagistTransport{server: server}})
-	t.Cleanup(restore)
+	original := getShopwareVersions
+	t.Cleanup(func() { getShopwareVersions = original })
+	getShopwareVersions = func(context.Context) ([]string, error) {
+		return []string{"6.6.0.0"}, nil
+	}
 }
 
 const testProjectYAMLSingleBundle = `compatibility_date: "2024-01-01"
@@ -48,7 +27,7 @@ build:
 `
 
 func TestGetConfigFromProjectYAMLBundles(t *testing.T) {
-	mockPackagistAPI(t)
+	stubShopwareVersions(t)
 	tmpDir := t.TempDir()
 
 	// Minimal composer.json with shopware/core requirement
@@ -72,7 +51,7 @@ func TestGetConfigFromProjectYAMLBundles(t *testing.T) {
 }
 
 func TestGetConfigFromProjectYAMLBundleStorefront(t *testing.T) {
-	mockPackagistAPI(t)
+	stubShopwareVersions(t)
 	tmpDir := t.TempDir()
 
 	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "composer.json"), []byte(`{
@@ -94,7 +73,7 @@ func TestGetConfigFromProjectYAMLBundleStorefront(t *testing.T) {
 }
 
 func TestGetConfigFromProjectYAMLBundleDeduplication(t *testing.T) {
-	mockPackagistAPI(t)
+	stubShopwareVersions(t)
 	tmpDir := t.TempDir()
 
 	// composer.json declares the same bundle

--- a/internal/verifier/project_test.go
+++ b/internal/verifier/project_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/shopware/shopware-cli/internal/packagist"
 )
 
 // mockPackagistTransport redirects all HTTP requests to a test server, preserving the path.
@@ -35,9 +37,8 @@ func mockPackagistAPI(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	original := http.DefaultClient
-	t.Cleanup(func() { http.DefaultClient = original })
-	http.DefaultClient = &http.Client{Transport: &mockPackagistTransport{server: server}}
+	restore := packagist.SwapHTTPClient(&http.Client{Transport: &mockPackagistTransport{server: server}})
+	t.Cleanup(restore)
 }
 
 const testProjectYAMLSingleBundle = `compatibility_date: "2024-01-01"


### PR DESCRIPTION

## Summary

- Add `NewLocalWithConfig` factory function to create local executors with project and environment configuration
- Replace magic string literals in `factory.go` with exported type constants (`TypeLocal`, `TypeSymfonyCLI`, `TypeDocker`)
- Refactor `NewLocal` to delegate to `NewLocalWithConfig` for consistency
- Update CI command to use `NewLocalWithConfig` directly and restructure config loading
- Configure the executor in extension build/zip commands when `ShopwareRoot` is set

## Test plan

- [ ] `go test ./internal/executor/...` passes
- [ ] `go build ./...` succeeds