### PR TITLE
feat(devtui): enhance config tab with env fields, HTTP cache toggle, and envfile package

### DIFF
--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -89,6 +89,8 @@ type shopwareInstallDoneMsg struct{ err error }
 
 type taskDoneMsg struct{ err error }
 
+type configRestartDoneMsg struct{ err error }
+
 func New(opts Options) Model {
 	effectiveAdminApi := opts.Config.AdminApi
 	if opts.EnvConfig.AdminApi != nil {
@@ -187,6 +189,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.overlayLines = append(m.overlayLines, "", helpStyle.Render("Done. Press any key to close."))
 		}
 		return m, nil
+
+	case configRestartDoneMsg:
+		return m.handleConfigRestartDone(msg)
 
 	case watcherStartedMsg:
 		switch msg.name {
@@ -346,4 +351,15 @@ func (m Model) updateChildren(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+func (m Model) handleConfigRestartDone(msg configRestartDoneMsg) (tea.Model, tea.Cmd) {
+	m.configTab.restarting = false
+	if msg.err != nil {
+		m.configTab.err = msg.err
+		m.configTab.saved = false
+	} else {
+		m.configTab.saved = true
+	}
+	return m, nil
 }

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -108,13 +108,13 @@ func New(opts Options) Model {
 
 	isDocker := opts.Executor.Type() == executor.TypeDocker
 
-	appEnv, _ := envfile.ReadAppEnv(opts.ProjectRoot)
+	envValues, _ := envfile.ReadValues(opts.ProjectRoot, EnvFieldKeys()...)
 
 	return Model{
 		activeTab:   tabGeneral,
 		general:     NewGeneralModel(opts.Executor.Type(), shopURL, username, password, opts.ProjectRoot, opts.Executor, opts.Config),
 		logs:        NewLogsModel(opts.ProjectRoot, isDocker),
-		configTab:   NewConfigModel(opts.Config, appEnv),
+		configTab:   NewConfigModel(opts.Config, envValues),
 		dockerMode:  isDocker,
 		projectRoot: opts.ProjectRoot,
 		executor:    opts.Executor,

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/shopware/shopware-cli/internal/envfile"
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
 )
@@ -107,11 +108,13 @@ func New(opts Options) Model {
 
 	isDocker := opts.Executor.Type() == executor.TypeDocker
 
+	appEnv, _ := envfile.ReadAppEnv(opts.ProjectRoot)
+
 	return Model{
 		activeTab:   tabGeneral,
 		general:     NewGeneralModel(opts.Executor.Type(), shopURL, username, password, opts.ProjectRoot, opts.Executor, opts.Config),
 		logs:        NewLogsModel(opts.ProjectRoot, isDocker),
-		configTab:   NewConfigModel(opts.Config),
+		configTab:   NewConfigModel(opts.Config, appEnv),
 		dockerMode:  isDocker,
 		projectRoot: opts.ProjectRoot,
 		executor:    opts.Executor,

--- a/internal/devtui/model_commands.go
+++ b/internal/devtui/model_commands.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -157,6 +158,19 @@ func (m *Model) startContainers() tea.Cmd {
 	)
 	m.dockerOutChan = ch
 	return tea.Batch(outputCmd, doneCmd)
+}
+
+func (m *Model) restartContainersForConfig() tea.Cmd {
+	projectRoot := m.projectRoot
+	cfg := m.config
+	return func() tea.Msg {
+		if err := dockerpkg.WriteComposeFile(projectRoot, dockerpkg.ComposeOptionsFromConfig(cfg)); err != nil {
+			return configRestartDoneMsg{err: err}
+		}
+		cmd := exec.CommandContext(context.Background(), "docker", "compose", "up", "-d")
+		cmd.Dir = projectRoot
+		return configRestartDoneMsg{err: cmd.Run()}
+	}
 }
 
 func (m *Model) stopContainers() tea.Cmd {

--- a/internal/devtui/model_test.go
+++ b/internal/devtui/model_test.go
@@ -20,7 +20,7 @@ func newTestModel() Model {
 		phase:       phaseDashboard,
 		general:     NewGeneralModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
 		logs:        NewLogsModel("/tmp/project", false),
-		configTab:   NewConfigModel(nil),
+		configTab:   NewConfigModel(nil, ""),
 		watchers:    make(map[string]*executor.Process),
 		projectRoot: "/tmp/project",
 		config:      &shop.Config{},
@@ -291,7 +291,7 @@ func TestUpdateConfigTab_EnterOnSaveWritesConfig(t *testing.T) {
 	m.config = cfg
 	m.projectRoot = dir
 	m.activeTab = tabConfig
-	m.configTab = NewConfigModel(cfg)
+	m.configTab = NewConfigModel(cfg, "")
 	m.configTab.cursor = fieldSave
 	m.configTab.modified = true
 	m.configTab.phpVersion = 0
@@ -323,7 +323,7 @@ func TestUpdateConfigTab_EnterOnSaveFailureSetsErr(t *testing.T) {
 	m.config = cfg
 	m.projectRoot = dir
 	m.activeTab = tabConfig
-	m.configTab = NewConfigModel(cfg)
+	m.configTab = NewConfigModel(cfg, "")
 	m.configTab.cursor = fieldSave
 	m.configTab.modified = true
 

--- a/internal/devtui/model_test.go
+++ b/internal/devtui/model_test.go
@@ -20,7 +20,7 @@ func newTestModel() Model {
 		phase:       phaseDashboard,
 		general:     NewGeneralModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
 		logs:        NewLogsModel("/tmp/project", false),
-		configTab:   NewConfigModel(nil, ""),
+		configTab:   NewConfigModel(nil, nil),
 		watchers:    make(map[string]*executor.Process),
 		projectRoot: "/tmp/project",
 		config:      &shop.Config{},
@@ -291,7 +291,7 @@ func TestUpdateConfigTab_EnterOnSaveWritesConfig(t *testing.T) {
 	m.config = cfg
 	m.projectRoot = dir
 	m.activeTab = tabConfig
-	m.configTab = NewConfigModel(cfg, "")
+	m.configTab = NewConfigModel(cfg, nil)
 	m.configTab.cursor = fieldSave
 	m.configTab.modified = true
 	m.configTab.phpVersion = 0
@@ -323,7 +323,7 @@ func TestUpdateConfigTab_EnterOnSaveFailureSetsErr(t *testing.T) {
 	m.config = cfg
 	m.projectRoot = dir
 	m.activeTab = tabConfig
-	m.configTab = NewConfigModel(cfg, "")
+	m.configTab = NewConfigModel(cfg, nil)
 	m.configTab.cursor = fieldSave
 	m.configTab.modified = true
 

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -117,13 +117,13 @@ func (m Model) updateConfigTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 			}
-			if m.configTab.AppEnvChanged() {
-				if err := envfile.WriteAppEnv(m.projectRoot, m.configTab.AppEnv()); err != nil {
+			if envChanges := m.configTab.ChangedEnvValues(); len(envChanges) > 0 {
+				if err := envfile.WriteValues(m.projectRoot, envChanges); err != nil {
 					m.configTab.err = err
 					m.configTab.saved = false
 					return m, nil
 				}
-				m.configTab.MarkAppEnvPersisted()
+				m.configTab.MarkEnvValuesPersisted()
 			}
 			m.configTab.saved = true
 			m.configTab.modified = false
@@ -331,8 +331,8 @@ func (m Model) startAfterSetupGuide() (tea.Model, tea.Cmd) {
 		password = m.envConfig.AdminApi.Password
 	}
 	m.general = NewGeneralModel(m.executor.Type(), shopURL, username, password, m.projectRoot, m.executor, m.config)
-	appEnv, _ := envfile.ReadAppEnv(m.projectRoot)
-	m.configTab = NewConfigModel(m.config, appEnv)
+	envValues, _ := envfile.ReadValues(m.projectRoot, EnvFieldKeys()...)
+	m.configTab = NewConfigModel(m.config, envValues)
 
 	return m, tea.Batch(m.dockerSpinner.Tick, m.startContainers())
 }

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -125,9 +125,14 @@ func (m Model) updateConfigTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				}
 				m.configTab.MarkEnvValuesPersisted()
 			}
-			m.configTab.saved = true
 			m.configTab.modified = false
 			m.configTab.err = nil
+			if m.dockerMode {
+				m.configTab.saved = false
+				m.configTab.restarting = true
+				return m, m.restartContainersForConfig()
+			}
+			m.configTab.saved = true
 			return m, nil
 		}
 		if picker := m.configTab.PickerForCursor(); picker != nil {

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
+	"github.com/shopware/shopware-cli/internal/envfile"
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
 )
@@ -115,6 +116,14 @@ func (m Model) updateConfigTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					m.configTab.saved = false
 					return m, nil
 				}
+			}
+			if m.configTab.AppEnvChanged() {
+				if err := envfile.WriteAppEnv(m.projectRoot, m.configTab.AppEnv()); err != nil {
+					m.configTab.err = err
+					m.configTab.saved = false
+					return m, nil
+				}
+				m.configTab.MarkAppEnvPersisted()
 			}
 			m.configTab.saved = true
 			m.configTab.modified = false
@@ -322,7 +331,8 @@ func (m Model) startAfterSetupGuide() (tea.Model, tea.Cmd) {
 		password = m.envConfig.AdminApi.Password
 	}
 	m.general = NewGeneralModel(m.executor.Type(), shopURL, username, password, m.projectRoot, m.executor, m.config)
-	m.configTab = NewConfigModel(m.config)
+	appEnv, _ := envfile.ReadAppEnv(m.projectRoot)
+	m.configTab = NewConfigModel(m.config, appEnv)
 
 	return m, tea.Batch(m.dockerSpinner.Tick, m.startContainers())
 }

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -31,22 +31,66 @@ const (
 	profilerTideways  = dockerpkg.ProfilerTideways
 
 	defaultPHPVersionIndex = 1
-	defaultAppEnvIndex     = 0
 )
 
 var (
 	phpVersions = packagist.SupportedPHPVersions
 	profilers   = dockerpkg.Profilers
-	appEnvs     = []string{"dev", "prod", "test"}
 )
+
+// envFieldDef describes a Symfony .env-backed choice field rendered in the
+// config tab. Adding a new entry to envFields is enough to surface another
+// env variable: it gets a picker, is loaded from .env.local on startup, and
+// is written back through envfile.WriteValues on save.
+type envFieldDef struct {
+	field      configField
+	key        string
+	label      string
+	title      string
+	help       string
+	choices    []string
+	defaultIdx int
+}
+
+var envFields = []envFieldDef{
+	{
+		field:      fieldAppEnv,
+		key:        "APP_ENV",
+		label:      "APP_ENV",
+		title:      "APP_ENV",
+		help:       "Symfony application environment (.env.local)",
+		choices:    []string{"dev", "prod", "test"},
+		defaultIdx: 0,
+	},
+}
+
+// EnvFieldKeys returns the env variable names this tab manages, suitable for
+// passing to envfile.ReadValues.
+func EnvFieldKeys() []string {
+	keys := make([]string, len(envFields))
+	for i, def := range envFields {
+		keys[i] = def.key
+	}
+	return keys
+}
+
+func envFieldByConfigField(f configField) (envFieldDef, bool) {
+	for _, def := range envFields {
+		if def.field == f {
+			return def, true
+		}
+	}
+	return envFieldDef{}, false
+}
 
 type ConfigModel struct {
 	cursor configField
 
-	appEnv         int
-	originalAppEnv string
-	phpVersion     int
-	profiler       int
+	envSelections map[string]int    // env key -> index in envFieldDef.choices
+	envOriginals  map[string]string // env key -> value loaded from .env files
+
+	phpVersion int
+	profiler   int
 
 	blackfireServerID    textinput.Model
 	blackfireServerToken textinput.Model
@@ -60,16 +104,25 @@ type ConfigModel struct {
 	height int
 }
 
-func NewConfigModel(cfg *shop.Config, appEnv string) ConfigModel {
-	resolvedAppEnv := appEnv
-	if resolvedAppEnv == "" {
-		resolvedAppEnv = appEnvs[defaultAppEnvIndex]
-	}
+// NewConfigModel constructs the Config tab. envValues maps env variable
+// names (see EnvFieldKeys) to the values currently effective in the
+// project's .env files; missing or empty entries fall back to each field's
+// default choice.
+func NewConfigModel(cfg *shop.Config, envValues map[string]string) ConfigModel {
 	m := ConfigModel{
-		cursor:         fieldAppEnv,
-		appEnv:         indexOf(appEnvs, resolvedAppEnv, defaultAppEnvIndex),
-		originalAppEnv: resolvedAppEnv,
-		phpVersion:     defaultPHPVersionIndex,
+		cursor:        fieldAppEnv,
+		envSelections: make(map[string]int, len(envFields)),
+		envOriginals:  make(map[string]string, len(envFields)),
+		phpVersion:    defaultPHPVersionIndex,
+	}
+
+	for _, def := range envFields {
+		current := envValues[def.key]
+		if current == "" {
+			current = def.choices[def.defaultIdx]
+		}
+		m.envSelections[def.key] = indexOf(def.choices, current, def.defaultIdx)
+		m.envOriginals[def.key] = current
 	}
 
 	if cfg != nil && cfg.Docker != nil && cfg.Docker.PHP != nil {
@@ -134,13 +187,14 @@ func (m ConfigModel) HandleKey(msg tea.KeyPressMsg) (ConfigModel, tea.Cmd) {
 }
 
 func (m ConfigModel) PickerForCursor() Modal {
-	switch m.cursor { //nolint:exhaustive
-	case fieldAppEnv:
-		items := make([]listPickerItem, len(appEnvs))
-		for i, v := range appEnvs {
+	if def, ok := envFieldByConfigField(m.cursor); ok {
+		items := make([]listPickerItem, len(def.choices))
+		for i, v := range def.choices {
 			items[i] = listPickerItem{Label: v, Value: v}
 		}
-		return newListPicker(fieldAppEnv, "APP_ENV", "Symfony application environment (.env.local)", items, m.appEnv)
+		return newListPicker(def.field, def.title, def.help, items, m.envSelections[def.key])
+	}
+	switch m.cursor { //nolint:exhaustive
 	case fieldPHPVersion:
 		items := make([]listPickerItem, len(phpVersions))
 		for i, v := range phpVersions {
@@ -168,14 +222,21 @@ func (m ConfigModel) PickerForCursor() Modal {
 }
 
 func (m *ConfigModel) ApplyPickerValue(field configField, value string) bool {
+	if def, ok := envFieldByConfigField(field); ok {
+		current := m.envSelections[def.key]
+		idx := indexOf(def.choices, value, current)
+		if idx == current {
+			return false
+		}
+		m.envSelections[def.key] = idx
+		m.modified = true
+		m.saved = false
+		m.err = nil
+		return true
+	}
+
 	changed := false
 	switch field { //nolint:exhaustive
-	case fieldAppEnv:
-		idx := indexOf(appEnvs, value, m.appEnv)
-		if idx != m.appEnv {
-			m.appEnv = idx
-			changed = true
-		}
 	case fieldPHPVersion:
 		idx := indexOf(phpVersions, value, m.phpVersion)
 		if idx != m.phpVersion {
@@ -240,13 +301,16 @@ func (m *ConfigModel) moveCursorDown() {
 }
 
 func (m ConfigModel) isFieldVisible(f configField) bool {
+	if _, ok := envFieldByConfigField(f); ok {
+		return true
+	}
 	profilerName := profilers[m.profiler]
 	switch f {
 	case fieldBlackfireServerID, fieldBlackfireServerToken:
 		return profilerName == profilerBlackfire
 	case fieldTidewaysAPIKey:
 		return profilerName == profilerTideways
-	case fieldAppEnv, fieldPHPVersion, fieldProfiler, fieldSave, fieldCount:
+	case fieldPHPVersion, fieldProfiler, fieldSave, fieldCount:
 		return true
 	}
 	return true
@@ -268,21 +332,36 @@ func (m ConfigModel) ApplyToConfig(cfg *shop.Config) {
 	cfg.Docker.PHP.TidewaysAPIKey = ""
 }
 
-// AppEnv returns the currently selected APP_ENV value.
-func (m ConfigModel) AppEnv() string {
-	return appEnvs[m.appEnv]
+// EnvValue returns the currently selected value for the env field with the
+// given key, or "" when no such field is registered.
+func (m ConfigModel) EnvValue(key string) string {
+	for _, def := range envFields {
+		if def.key == key {
+			return def.choices[m.envSelections[key]]
+		}
+	}
+	return ""
 }
 
-// AppEnvChanged reports whether the APP_ENV selection differs from the
-// value loaded into the model.
-func (m ConfigModel) AppEnvChanged() bool {
-	return appEnvs[m.appEnv] != m.originalAppEnv
+// ChangedEnvValues returns the env entries whose selected value differs from
+// the value loaded into the model.
+func (m ConfigModel) ChangedEnvValues() map[string]string {
+	changes := make(map[string]string)
+	for _, def := range envFields {
+		current := def.choices[m.envSelections[def.key]]
+		if current != m.envOriginals[def.key] {
+			changes[def.key] = current
+		}
+	}
+	return changes
 }
 
-// MarkAppEnvPersisted records the current APP_ENV value as the new baseline
-// after it has been written to disk.
-func (m *ConfigModel) MarkAppEnvPersisted() {
-	m.originalAppEnv = appEnvs[m.appEnv]
+// MarkEnvValuesPersisted records the current env selections as the new
+// baseline after they have been written to disk.
+func (m *ConfigModel) MarkEnvValuesPersisted() {
+	for _, def := range envFields {
+		m.envOriginals[def.key] = def.choices[m.envSelections[def.key]]
+	}
 }
 
 func (m ConfigModel) LocalConfig() *shop.Config {
@@ -313,10 +392,14 @@ func (m ConfigModel) View(width, height int) string {
 
 	divider := tui.SectionDivider(width - 8)
 
-	s.WriteString(tui.TitleStyle.Render("Environment"))
-	s.WriteString("\n")
-	s.WriteString(m.renderSelect(fieldAppEnv, "APP_ENV", appEnvs[m.appEnv], selectedArrow, normalIndent))
-	s.WriteString(divider)
+	if len(envFields) > 0 {
+		s.WriteString(tui.TitleStyle.Render("Environment"))
+		s.WriteString("\n")
+		for _, def := range envFields {
+			s.WriteString(m.renderSelect(def.field, def.label, def.choices[m.envSelections[def.key]], selectedArrow, normalIndent))
+		}
+		s.WriteString(divider)
+	}
 
 	s.WriteString(tui.TitleStyle.Render("PHP"))
 	s.WriteString("\n")

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -17,6 +17,7 @@ type configField int
 
 const (
 	fieldAppEnv configField = iota
+	fieldHTTPCache
 	fieldPHPVersion
 	fieldProfiler
 	fieldBlackfireServerID
@@ -42,14 +43,30 @@ var (
 // config tab. Adding a new entry to envFields is enough to surface another
 // env variable: it gets a picker, is loaded from .env.local on startup, and
 // is written back through envfile.WriteValues on save.
+//
+// choices holds the canonical values written to .env.local. choiceLabels is
+// optional; when set, it provides display labels (in the same order as
+// choices) so the row and picker can show e.g. "enabled"/"disabled" while
+// still writing "1"/"0".
 type envFieldDef struct {
-	field      configField
-	key        string
-	label      string
-	title      string
-	help       string
-	choices    []string
-	defaultIdx int
+	field        configField
+	key          string
+	label        string
+	title        string
+	help         string
+	choices      []string
+	choiceLabels []string
+	defaultIdx   int
+}
+
+func (def envFieldDef) choiceLabel(idx int) string {
+	if idx < 0 || idx >= len(def.choices) {
+		return ""
+	}
+	if def.choiceLabels != nil && idx < len(def.choiceLabels) {
+		return def.choiceLabels[idx]
+	}
+	return def.choices[idx]
 }
 
 var envFields = []envFieldDef{
@@ -58,9 +75,19 @@ var envFields = []envFieldDef{
 		key:        "APP_ENV",
 		label:      "APP_ENV",
 		title:      "APP_ENV",
-		help:       "Symfony application environment (.env.local)",
+		help:       "Shopware application environment (.env.local)",
 		choices:    []string{"dev", "prod", "test"},
 		defaultIdx: 0,
+	},
+	{
+		field:        fieldHTTPCache,
+		key:          "SHOPWARE_HTTP_CACHE_ENABLED",
+		label:        "HTTP Cache",
+		title:        "HTTP Cache",
+		help:         "Toggle the Shopware HTTP cache (SHOPWARE_HTTP_CACHE_ENABLED in .env.local)",
+		choices:      []string{"0", "1"},
+		choiceLabels: []string{"disabled", "enabled"},
+		defaultIdx:   0,
 	},
 }
 
@@ -96,9 +123,10 @@ type ConfigModel struct {
 	blackfireServerToken textinput.Model
 	tidewaysAPIKey       textinput.Model
 
-	saved    bool
-	modified bool
-	err      error
+	saved      bool
+	modified   bool
+	restarting bool
+	err        error
 
 	width  int
 	height int
@@ -190,7 +218,7 @@ func (m ConfigModel) PickerForCursor() Modal {
 	if def, ok := envFieldByConfigField(m.cursor); ok {
 		items := make([]listPickerItem, len(def.choices))
 		for i, v := range def.choices {
-			items[i] = listPickerItem{Label: v, Value: v}
+			items[i] = listPickerItem{Label: def.choiceLabel(i), Value: v}
 		}
 		return newListPicker(def.field, def.title, def.help, items, m.envSelections[def.key])
 	}
@@ -310,7 +338,7 @@ func (m ConfigModel) isFieldVisible(f configField) bool {
 		return profilerName == profilerBlackfire
 	case fieldTidewaysAPIKey:
 		return profilerName == profilerTideways
-	case fieldPHPVersion, fieldProfiler, fieldSave, fieldCount:
+	case fieldAppEnv, fieldHTTPCache, fieldPHPVersion, fieldProfiler, fieldSave, fieldCount:
 		return true
 	}
 	return true
@@ -396,7 +424,7 @@ func (m ConfigModel) View(width, height int) string {
 		s.WriteString(tui.TitleStyle.Render("Environment"))
 		s.WriteString("\n")
 		for _, def := range envFields {
-			s.WriteString(m.renderSelect(def.field, def.label, def.choices[m.envSelections[def.key]], selectedArrow, normalIndent))
+			s.WriteString(m.renderSelect(def.field, def.label, def.choiceLabel(m.envSelections[def.key]), selectedArrow, normalIndent))
 		}
 		s.WriteString(divider)
 	}
@@ -423,6 +451,8 @@ func (m ConfigModel) View(width, height int) string {
 		s.WriteString(normalIndent)
 	}
 	switch {
+	case m.restarting:
+		s.WriteString(warningBadgeStyle.Render("restarting docker…"))
 	case m.err != nil && m.cursor == fieldSave:
 		s.WriteString(activeBtnStyle.Render("Retry Save"))
 	case m.err != nil:
@@ -432,7 +462,7 @@ func (m ConfigModel) View(width, height int) string {
 	case m.saved:
 		s.WriteString(activeBadgeStyle.Render("Saved"))
 		s.WriteString("  ")
-		s.WriteString(helpStyle.Render("Restart Docker to apply changes."))
+		s.WriteString(helpStyle.Render("Docker restarted with new config."))
 	case m.modified && m.cursor == fieldSave:
 		s.WriteString(activeBtnStyle.Render("Save & Regenerate"))
 	case m.modified:

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -16,7 +16,8 @@ import (
 type configField int
 
 const (
-	fieldPHPVersion configField = iota
+	fieldAppEnv configField = iota
+	fieldPHPVersion
 	fieldProfiler
 	fieldBlackfireServerID
 	fieldBlackfireServerToken
@@ -30,18 +31,22 @@ const (
 	profilerTideways  = dockerpkg.ProfilerTideways
 
 	defaultPHPVersionIndex = 1
+	defaultAppEnvIndex     = 0
 )
 
 var (
 	phpVersions = packagist.SupportedPHPVersions
 	profilers   = dockerpkg.Profilers
+	appEnvs     = []string{"dev", "prod", "test"}
 )
 
 type ConfigModel struct {
 	cursor configField
 
-	phpVersion int
-	profiler   int
+	appEnv         int
+	originalAppEnv string
+	phpVersion     int
+	profiler       int
 
 	blackfireServerID    textinput.Model
 	blackfireServerToken textinput.Model
@@ -55,9 +60,16 @@ type ConfigModel struct {
 	height int
 }
 
-func NewConfigModel(cfg *shop.Config) ConfigModel {
+func NewConfigModel(cfg *shop.Config, appEnv string) ConfigModel {
+	resolvedAppEnv := appEnv
+	if resolvedAppEnv == "" {
+		resolvedAppEnv = appEnvs[defaultAppEnvIndex]
+	}
 	m := ConfigModel{
-		phpVersion: defaultPHPVersionIndex,
+		cursor:         fieldAppEnv,
+		appEnv:         indexOf(appEnvs, resolvedAppEnv, defaultAppEnvIndex),
+		originalAppEnv: resolvedAppEnv,
+		phpVersion:     defaultPHPVersionIndex,
 	}
 
 	if cfg != nil && cfg.Docker != nil && cfg.Docker.PHP != nil {
@@ -123,6 +135,12 @@ func (m ConfigModel) HandleKey(msg tea.KeyPressMsg) (ConfigModel, tea.Cmd) {
 
 func (m ConfigModel) PickerForCursor() Modal {
 	switch m.cursor { //nolint:exhaustive
+	case fieldAppEnv:
+		items := make([]listPickerItem, len(appEnvs))
+		for i, v := range appEnvs {
+			items[i] = listPickerItem{Label: v, Value: v}
+		}
+		return newListPicker(fieldAppEnv, "APP_ENV", "Symfony application environment (.env.local)", items, m.appEnv)
 	case fieldPHPVersion:
 		items := make([]listPickerItem, len(phpVersions))
 		for i, v := range phpVersions {
@@ -152,6 +170,12 @@ func (m ConfigModel) PickerForCursor() Modal {
 func (m *ConfigModel) ApplyPickerValue(field configField, value string) bool {
 	changed := false
 	switch field { //nolint:exhaustive
+	case fieldAppEnv:
+		idx := indexOf(appEnvs, value, m.appEnv)
+		if idx != m.appEnv {
+			m.appEnv = idx
+			changed = true
+		}
 	case fieldPHPVersion:
 		idx := indexOf(phpVersions, value, m.phpVersion)
 		if idx != m.phpVersion {
@@ -222,7 +246,7 @@ func (m ConfigModel) isFieldVisible(f configField) bool {
 		return profilerName == profilerBlackfire
 	case fieldTidewaysAPIKey:
 		return profilerName == profilerTideways
-	case fieldPHPVersion, fieldProfiler, fieldSave, fieldCount:
+	case fieldAppEnv, fieldPHPVersion, fieldProfiler, fieldSave, fieldCount:
 		return true
 	}
 	return true
@@ -242,6 +266,23 @@ func (m ConfigModel) ApplyToConfig(cfg *shop.Config) {
 	cfg.Docker.PHP.BlackfireServerID = ""
 	cfg.Docker.PHP.BlackfireServerToken = ""
 	cfg.Docker.PHP.TidewaysAPIKey = ""
+}
+
+// AppEnv returns the currently selected APP_ENV value.
+func (m ConfigModel) AppEnv() string {
+	return appEnvs[m.appEnv]
+}
+
+// AppEnvChanged reports whether the APP_ENV selection differs from the
+// value loaded into the model.
+func (m ConfigModel) AppEnvChanged() bool {
+	return appEnvs[m.appEnv] != m.originalAppEnv
+}
+
+// MarkAppEnvPersisted records the current APP_ENV value as the new baseline
+// after it has been written to disk.
+func (m *ConfigModel) MarkAppEnvPersisted() {
+	m.originalAppEnv = appEnvs[m.appEnv]
 }
 
 func (m ConfigModel) LocalConfig() *shop.Config {
@@ -271,6 +312,11 @@ func (m ConfigModel) View(width, height int) string {
 	normalIndent := "  "
 
 	divider := tui.SectionDivider(width - 8)
+
+	s.WriteString(tui.TitleStyle.Render("Environment"))
+	s.WriteString("\n")
+	s.WriteString(m.renderSelect(fieldAppEnv, "APP_ENV", appEnvs[m.appEnv], selectedArrow, normalIndent))
+	s.WriteString(divider)
 
 	s.WriteString(tui.TitleStyle.Render("PHP"))
 	s.WriteString("\n")

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -120,6 +120,9 @@ func TestConfigModel_CursorNavigation(t *testing.T) {
 	assert.Equal(t, fieldAppEnv, m.cursor)
 
 	m.moveCursorDown()
+	assert.Equal(t, fieldHTTPCache, m.cursor)
+
+	m.moveCursorDown()
 	assert.Equal(t, fieldPHPVersion, m.cursor)
 
 	m.moveCursorDown()
@@ -137,6 +140,8 @@ func TestConfigModel_CursorNavigation_BlackfireVisible(t *testing.T) {
 	m.profiler = indexOf(profilers, "blackfire", 0)
 
 	assert.Equal(t, fieldAppEnv, m.cursor)
+	m.moveCursorDown()
+	assert.Equal(t, fieldHTTPCache, m.cursor)
 	m.moveCursorDown()
 	assert.Equal(t, fieldPHPVersion, m.cursor)
 	m.moveCursorDown()
@@ -260,6 +265,44 @@ func TestConfigModel_EnvField_MarkPersistedClearsChange(t *testing.T) {
 
 func TestEnvFieldKeys_IncludesAppEnv(t *testing.T) {
 	assert.Contains(t, EnvFieldKeys(), "APP_ENV")
+}
+
+func TestConfigModel_HTTPCache_DefaultsToDisabled(t *testing.T) {
+	m := NewConfigModel(nil, nil)
+
+	assert.Equal(t, "0", m.EnvValue("SHOPWARE_HTTP_CACHE_ENABLED"))
+	assert.Empty(t, m.ChangedEnvValues())
+}
+
+func TestConfigModel_HTTPCache_ToggleProducesEnvChange(t *testing.T) {
+	m := NewConfigModel(nil, map[string]string{"SHOPWARE_HTTP_CACHE_ENABLED": "0"})
+
+	changed := m.ApplyPickerValue(fieldHTTPCache, "1")
+	assert.True(t, changed)
+	assert.Equal(t, "1", m.EnvValue("SHOPWARE_HTTP_CACHE_ENABLED"))
+	assert.Equal(t, map[string]string{"SHOPWARE_HTTP_CACHE_ENABLED": "1"}, m.ChangedEnvValues())
+}
+
+func TestConfigModel_HTTPCache_PickerUsesFriendlyLabels(t *testing.T) {
+	m := NewConfigModel(nil, nil)
+	m.cursor = fieldHTTPCache
+
+	modal := m.PickerForCursor()
+	picker, ok := modal.(*listPicker)
+	assert.True(t, ok)
+
+	labels := make([]string, len(picker.items))
+	values := make([]string, len(picker.items))
+	for i, it := range picker.items {
+		labels[i] = it.Label
+		values[i] = it.Value
+	}
+	assert.Equal(t, []string{"disabled", "enabled"}, labels)
+	assert.Equal(t, []string{"0", "1"}, values)
+}
+
+func TestEnvFieldKeys_IncludesHTTPCache(t *testing.T) {
+	assert.Contains(t, EnvFieldKeys(), "SHOPWARE_HTTP_CACHE_ENABLED")
 }
 
 func TestIndexOf(t *testing.T) {

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewConfigModel_NilConfig(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 
 	assert.Equal(t, 1, m.phpVersion)
 	assert.Equal(t, 0, m.profiler)
@@ -28,7 +28,7 @@ func TestNewConfigModel_WithConfig(t *testing.T) {
 		},
 	}
 
-	m := NewConfigModel(cfg, "")
+	m := NewConfigModel(cfg, nil)
 
 	assert.Equal(t, 0, m.phpVersion)
 	assert.Equal(t, 2, m.profiler)
@@ -37,7 +37,7 @@ func TestNewConfigModel_WithConfig(t *testing.T) {
 
 func TestConfigModel_ApplyToConfig(t *testing.T) {
 	cfg := &shop.Config{}
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.phpVersion = 2
 	m.profiler = 1
 
@@ -50,7 +50,7 @@ func TestConfigModel_ApplyToConfig(t *testing.T) {
 
 func TestConfigModel_ApplyToConfig_BlackfireCredentialsExcluded(t *testing.T) {
 	cfg := &shop.Config{}
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = 2
 	m.blackfireServerID.SetValue("srv-id")
 	m.blackfireServerToken.SetValue("srv-token")
@@ -63,7 +63,7 @@ func TestConfigModel_ApplyToConfig_BlackfireCredentialsExcluded(t *testing.T) {
 }
 
 func TestConfigModel_LocalConfig_Blackfire(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = 2
 	m.blackfireServerID.SetValue("srv-id")
 	m.blackfireServerToken.SetValue("srv-token")
@@ -75,7 +75,7 @@ func TestConfigModel_LocalConfig_Blackfire(t *testing.T) {
 }
 
 func TestConfigModel_LocalConfig_Tideways(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = 3
 	m.tidewaysAPIKey.SetValue("tw-key")
 
@@ -86,7 +86,7 @@ func TestConfigModel_LocalConfig_Tideways(t *testing.T) {
 }
 
 func TestConfigModel_LocalConfig_NoCredentials(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = 0
 
 	assert.Nil(t, m.LocalConfig())
@@ -96,7 +96,7 @@ func TestConfigModel_LocalConfig_NoCredentials(t *testing.T) {
 }
 
 func TestConfigModel_FieldVisibility(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 
 	m.profiler = 0
 	assert.False(t, m.isFieldVisible(fieldBlackfireServerID))
@@ -114,7 +114,7 @@ func TestConfigModel_FieldVisibility(t *testing.T) {
 }
 
 func TestConfigModel_CursorNavigation(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = 0
 
 	assert.Equal(t, fieldAppEnv, m.cursor)
@@ -133,7 +133,7 @@ func TestConfigModel_CursorNavigation(t *testing.T) {
 }
 
 func TestConfigModel_CursorNavigation_BlackfireVisible(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = indexOf(profilers, "blackfire", 0)
 
 	assert.Equal(t, fieldAppEnv, m.cursor)
@@ -150,7 +150,7 @@ func TestConfigModel_CursorNavigation_BlackfireVisible(t *testing.T) {
 }
 
 func TestConfigModel_PickerForCursor_Select(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.cursor = fieldPHPVersion
 
 	modal := m.PickerForCursor()
@@ -166,7 +166,7 @@ func TestConfigModel_PickerForCursor_Select(t *testing.T) {
 }
 
 func TestConfigModel_PickerForCursor_Text(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = indexOf(profilers, "blackfire", 0)
 	m.blackfireServerID.SetValue("existing")
 	m.cursor = fieldBlackfireServerID
@@ -178,7 +178,7 @@ func TestConfigModel_PickerForCursor_Text(t *testing.T) {
 }
 
 func TestConfigModel_ApplyPickerValue(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.modified = false
 
 	changed := m.ApplyPickerValue(fieldPHPVersion, "8.4")
@@ -193,7 +193,7 @@ func TestConfigModel_ApplyPickerValue(t *testing.T) {
 }
 
 func TestConfigModel_ApplyPickerValue_TextField(t *testing.T) {
-	m := NewConfigModel(nil, "")
+	m := NewConfigModel(nil, nil)
 	m.profiler = indexOf(profilers, "tideways", 0)
 
 	changed := m.ApplyPickerValue(fieldTidewaysAPIKey, "secret-key")
@@ -202,42 +202,45 @@ func TestConfigModel_ApplyPickerValue_TextField(t *testing.T) {
 	assert.True(t, m.modified)
 }
 
-func TestConfigModel_AppEnv_DefaultsToDev(t *testing.T) {
-	m := NewConfigModel(nil, "")
+func TestConfigModel_EnvField_DefaultsApplied(t *testing.T) {
+	m := NewConfigModel(nil, nil)
 
-	assert.Equal(t, "dev", m.AppEnv())
-	assert.False(t, m.AppEnvChanged())
+	assert.Equal(t, "dev", m.EnvValue("APP_ENV"))
+	assert.Empty(t, m.ChangedEnvValues())
 }
 
-func TestConfigModel_AppEnv_LoadedFromExisting(t *testing.T) {
-	m := NewConfigModel(nil, "prod")
+func TestConfigModel_EnvField_LoadedFromValues(t *testing.T) {
+	m := NewConfigModel(nil, map[string]string{"APP_ENV": "prod"})
 
-	assert.Equal(t, "prod", m.AppEnv())
-	assert.False(t, m.AppEnvChanged())
+	assert.Equal(t, "prod", m.EnvValue("APP_ENV"))
+	assert.Empty(t, m.ChangedEnvValues())
 }
 
-func TestConfigModel_AppEnv_PickerOptions(t *testing.T) {
-	m := NewConfigModel(nil, "dev")
+func TestConfigModel_EnvField_PickerOptionsDrivenByRegistry(t *testing.T) {
+	m := NewConfigModel(nil, map[string]string{"APP_ENV": "dev"})
 	m.cursor = fieldAppEnv
 
 	modal := m.PickerForCursor()
 	picker, ok := modal.(*listPicker)
 	assert.True(t, ok)
 	assert.Equal(t, fieldAppEnv, picker.key)
+
+	def, ok := envFieldByConfigField(fieldAppEnv)
+	assert.True(t, ok)
 	values := make([]string, len(picker.items))
 	for i, it := range picker.items {
 		values[i] = it.Value
 	}
-	assert.ElementsMatch(t, appEnvs, values)
+	assert.ElementsMatch(t, def.choices, values)
 }
 
-func TestConfigModel_AppEnv_ApplyPickerValue(t *testing.T) {
-	m := NewConfigModel(nil, "dev")
+func TestConfigModel_EnvField_ApplyPickerValue(t *testing.T) {
+	m := NewConfigModel(nil, map[string]string{"APP_ENV": "dev"})
 
 	changed := m.ApplyPickerValue(fieldAppEnv, "prod")
 	assert.True(t, changed)
-	assert.Equal(t, "prod", m.AppEnv())
-	assert.True(t, m.AppEnvChanged())
+	assert.Equal(t, "prod", m.EnvValue("APP_ENV"))
+	assert.Equal(t, map[string]string{"APP_ENV": "prod"}, m.ChangedEnvValues())
 	assert.True(t, m.modified)
 
 	m.modified = false
@@ -246,13 +249,17 @@ func TestConfigModel_AppEnv_ApplyPickerValue(t *testing.T) {
 	assert.False(t, m.modified)
 }
 
-func TestConfigModel_AppEnv_MarkPersistedClearsChange(t *testing.T) {
-	m := NewConfigModel(nil, "dev")
+func TestConfigModel_EnvField_MarkPersistedClearsChange(t *testing.T) {
+	m := NewConfigModel(nil, map[string]string{"APP_ENV": "dev"})
 	m.ApplyPickerValue(fieldAppEnv, "prod")
-	assert.True(t, m.AppEnvChanged())
+	assert.NotEmpty(t, m.ChangedEnvValues())
 
-	m.MarkAppEnvPersisted()
-	assert.False(t, m.AppEnvChanged())
+	m.MarkEnvValuesPersisted()
+	assert.Empty(t, m.ChangedEnvValues())
+}
+
+func TestEnvFieldKeys_IncludesAppEnv(t *testing.T) {
+	assert.Contains(t, EnvFieldKeys(), "APP_ENV")
 }
 
 func TestIndexOf(t *testing.T) {

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewConfigModel_NilConfig(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 
 	assert.Equal(t, 1, m.phpVersion)
 	assert.Equal(t, 0, m.profiler)
@@ -28,7 +28,7 @@ func TestNewConfigModel_WithConfig(t *testing.T) {
 		},
 	}
 
-	m := NewConfigModel(cfg)
+	m := NewConfigModel(cfg, "")
 
 	assert.Equal(t, 0, m.phpVersion)
 	assert.Equal(t, 2, m.profiler)
@@ -37,7 +37,7 @@ func TestNewConfigModel_WithConfig(t *testing.T) {
 
 func TestConfigModel_ApplyToConfig(t *testing.T) {
 	cfg := &shop.Config{}
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.phpVersion = 2
 	m.profiler = 1
 
@@ -50,7 +50,7 @@ func TestConfigModel_ApplyToConfig(t *testing.T) {
 
 func TestConfigModel_ApplyToConfig_BlackfireCredentialsExcluded(t *testing.T) {
 	cfg := &shop.Config{}
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = 2
 	m.blackfireServerID.SetValue("srv-id")
 	m.blackfireServerToken.SetValue("srv-token")
@@ -63,7 +63,7 @@ func TestConfigModel_ApplyToConfig_BlackfireCredentialsExcluded(t *testing.T) {
 }
 
 func TestConfigModel_LocalConfig_Blackfire(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = 2
 	m.blackfireServerID.SetValue("srv-id")
 	m.blackfireServerToken.SetValue("srv-token")
@@ -75,7 +75,7 @@ func TestConfigModel_LocalConfig_Blackfire(t *testing.T) {
 }
 
 func TestConfigModel_LocalConfig_Tideways(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = 3
 	m.tidewaysAPIKey.SetValue("tw-key")
 
@@ -86,7 +86,7 @@ func TestConfigModel_LocalConfig_Tideways(t *testing.T) {
 }
 
 func TestConfigModel_LocalConfig_NoCredentials(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = 0
 
 	assert.Nil(t, m.LocalConfig())
@@ -96,7 +96,7 @@ func TestConfigModel_LocalConfig_NoCredentials(t *testing.T) {
 }
 
 func TestConfigModel_FieldVisibility(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 
 	m.profiler = 0
 	assert.False(t, m.isFieldVisible(fieldBlackfireServerID))
@@ -114,9 +114,12 @@ func TestConfigModel_FieldVisibility(t *testing.T) {
 }
 
 func TestConfigModel_CursorNavigation(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = 0
 
+	assert.Equal(t, fieldAppEnv, m.cursor)
+
+	m.moveCursorDown()
 	assert.Equal(t, fieldPHPVersion, m.cursor)
 
 	m.moveCursorDown()
@@ -130,9 +133,11 @@ func TestConfigModel_CursorNavigation(t *testing.T) {
 }
 
 func TestConfigModel_CursorNavigation_BlackfireVisible(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = indexOf(profilers, "blackfire", 0)
 
+	assert.Equal(t, fieldAppEnv, m.cursor)
+	m.moveCursorDown()
 	assert.Equal(t, fieldPHPVersion, m.cursor)
 	m.moveCursorDown()
 	assert.Equal(t, fieldProfiler, m.cursor)
@@ -145,7 +150,7 @@ func TestConfigModel_CursorNavigation_BlackfireVisible(t *testing.T) {
 }
 
 func TestConfigModel_PickerForCursor_Select(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.cursor = fieldPHPVersion
 
 	modal := m.PickerForCursor()
@@ -161,7 +166,7 @@ func TestConfigModel_PickerForCursor_Select(t *testing.T) {
 }
 
 func TestConfigModel_PickerForCursor_Text(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = indexOf(profilers, "blackfire", 0)
 	m.blackfireServerID.SetValue("existing")
 	m.cursor = fieldBlackfireServerID
@@ -173,7 +178,7 @@ func TestConfigModel_PickerForCursor_Text(t *testing.T) {
 }
 
 func TestConfigModel_ApplyPickerValue(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.modified = false
 
 	changed := m.ApplyPickerValue(fieldPHPVersion, "8.4")
@@ -188,13 +193,66 @@ func TestConfigModel_ApplyPickerValue(t *testing.T) {
 }
 
 func TestConfigModel_ApplyPickerValue_TextField(t *testing.T) {
-	m := NewConfigModel(nil)
+	m := NewConfigModel(nil, "")
 	m.profiler = indexOf(profilers, "tideways", 0)
 
 	changed := m.ApplyPickerValue(fieldTidewaysAPIKey, "secret-key")
 	assert.True(t, changed)
 	assert.Equal(t, "secret-key", m.tidewaysAPIKey.Value())
 	assert.True(t, m.modified)
+}
+
+func TestConfigModel_AppEnv_DefaultsToDev(t *testing.T) {
+	m := NewConfigModel(nil, "")
+
+	assert.Equal(t, "dev", m.AppEnv())
+	assert.False(t, m.AppEnvChanged())
+}
+
+func TestConfigModel_AppEnv_LoadedFromExisting(t *testing.T) {
+	m := NewConfigModel(nil, "prod")
+
+	assert.Equal(t, "prod", m.AppEnv())
+	assert.False(t, m.AppEnvChanged())
+}
+
+func TestConfigModel_AppEnv_PickerOptions(t *testing.T) {
+	m := NewConfigModel(nil, "dev")
+	m.cursor = fieldAppEnv
+
+	modal := m.PickerForCursor()
+	picker, ok := modal.(*listPicker)
+	assert.True(t, ok)
+	assert.Equal(t, fieldAppEnv, picker.key)
+	values := make([]string, len(picker.items))
+	for i, it := range picker.items {
+		values[i] = it.Value
+	}
+	assert.ElementsMatch(t, appEnvs, values)
+}
+
+func TestConfigModel_AppEnv_ApplyPickerValue(t *testing.T) {
+	m := NewConfigModel(nil, "dev")
+
+	changed := m.ApplyPickerValue(fieldAppEnv, "prod")
+	assert.True(t, changed)
+	assert.Equal(t, "prod", m.AppEnv())
+	assert.True(t, m.AppEnvChanged())
+	assert.True(t, m.modified)
+
+	m.modified = false
+	changed = m.ApplyPickerValue(fieldAppEnv, "prod")
+	assert.False(t, changed)
+	assert.False(t, m.modified)
+}
+
+func TestConfigModel_AppEnv_MarkPersistedClearsChange(t *testing.T) {
+	m := NewConfigModel(nil, "dev")
+	m.ApplyPickerValue(fieldAppEnv, "prod")
+	assert.True(t, m.AppEnvChanged())
+
+	m.MarkAppEnvPersisted()
+	assert.False(t, m.AppEnvChanged())
 }
 
 func TestIndexOf(t *testing.T) {

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -1,8 +1,12 @@
 package envfile
 
 import (
+	"bufio"
+	"bytes"
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -48,4 +52,91 @@ func LoadSymfonyEnvFile(projectRoot string) error {
 	}
 
 	return nil
+}
+
+// ReadAppEnv resolves the effective APP_ENV value for the project at
+// projectRoot by reading the Symfony env files in the conventional order.
+// Returns an empty string when APP_ENV is not defined in any file.
+func ReadAppEnv(projectRoot string) (string, error) {
+	possibleEnvFiles := []string{
+		filepath.Join(projectRoot, ".env.dist"),
+		filepath.Join(projectRoot, ".env"),
+		filepath.Join(projectRoot, ".env.local"),
+	}
+
+	var foundEnvFiles []string
+	for _, envFile := range possibleEnvFiles {
+		if _, err := os.Stat(envFile); err == nil {
+			foundEnvFiles = append(foundEnvFiles, envFile)
+		}
+	}
+
+	if len(foundEnvFiles) == 0 {
+		return "", nil
+	}
+
+	currentMap, err := godotenv.Read(foundEnvFiles...)
+	if err != nil {
+		return "", err
+	}
+
+	return currentMap["APP_ENV"], nil
+}
+
+// WriteAppEnv sets APP_ENV in .env.local. If the key already exists, its
+// value is replaced in place to preserve surrounding lines, comments and
+// formatting. Otherwise the assignment is appended to the file. The file is
+// created when missing.
+func WriteAppEnv(projectRoot, value string) error {
+	envLocalPath := filepath.Join(projectRoot, ".env.local")
+
+	existing, err := os.ReadFile(envLocalPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	updated, replaced := replaceEnvLine(existing, "APP_ENV", value)
+	if !replaced {
+		if len(updated) > 0 && !bytes.HasSuffix(updated, []byte("\n")) {
+			updated = append(updated, '\n')
+		}
+		updated = append(updated, []byte("APP_ENV="+value+"\n")...)
+	}
+
+	return os.WriteFile(envLocalPath, updated, 0o644)
+}
+
+// replaceEnvLine returns content with the first assignment of key replaced
+// by `key=value`. The second return value reports whether a replacement
+// happened. Comments and unrelated lines are preserved verbatim.
+func replaceEnvLine(content []byte, key, value string) ([]byte, bool) {
+	var out bytes.Buffer
+	replaced := false
+
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	// Preserve trailing newline if present
+	hadTrailingNewline := bytes.HasSuffix(content, []byte("\n"))
+
+	first := true
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !first {
+			out.WriteByte('\n')
+		}
+		first = false
+
+		trimmed := strings.TrimLeft(line, " \t")
+		if !replaced && strings.HasPrefix(trimmed, key+"=") {
+			out.WriteString(key + "=" + value)
+			replaced = true
+			continue
+		}
+		out.WriteString(line)
+	}
+
+	if hadTrailingNewline {
+		out.WriteByte('\n')
+	}
+
+	return out.Bytes(), replaced
 }

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -54,40 +55,54 @@ func LoadSymfonyEnvFile(projectRoot string) error {
 	return nil
 }
 
-// ReadAppEnv resolves the effective APP_ENV value for the project at
-// projectRoot by reading the Symfony env files in the conventional order.
-// Returns an empty string when APP_ENV is not defined in any file.
-func ReadAppEnv(projectRoot string) (string, error) {
-	possibleEnvFiles := []string{
-		filepath.Join(projectRoot, ".env.dist"),
-		filepath.Join(projectRoot, ".env"),
-		filepath.Join(projectRoot, ".env.local"),
-	}
-
-	var foundEnvFiles []string
-	for _, envFile := range possibleEnvFiles {
-		if _, err := os.Stat(envFile); err == nil {
-			foundEnvFiles = append(foundEnvFiles, envFile)
-		}
-	}
-
-	if len(foundEnvFiles) == 0 {
-		return "", nil
-	}
-
-	currentMap, err := godotenv.Read(foundEnvFiles...)
+// ReadValue returns the effective value of key in the project's Symfony env
+// files. Precedence follows Symfony: .env.dist < .env < .env.local.
+// An empty string is returned when the key is undefined or no env file exists.
+func ReadValue(projectRoot, key string) (string, error) {
+	values, err := ReadValues(projectRoot, key)
 	if err != nil {
 		return "", err
 	}
-
-	return currentMap["APP_ENV"], nil
+	return values[key], nil
 }
 
-// WriteAppEnv sets APP_ENV in .env.local. If the key already exists, its
-// value is replaced in place to preserve surrounding lines, comments and
-// formatting. Otherwise the assignment is appended to the file. The file is
-// created when missing.
-func WriteAppEnv(projectRoot, value string) error {
+// ReadValues returns the resolved values for the requested keys. The returned
+// map always contains every requested key; missing keys map to "".
+func ReadValues(projectRoot string, keys ...string) (map[string]string, error) {
+	out := make(map[string]string, len(keys))
+	for _, k := range keys {
+		out[k] = ""
+	}
+
+	files := resolveEnvFiles(projectRoot)
+	if len(files) == 0 {
+		return out, nil
+	}
+
+	values, err := godotenv.Read(files...)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range keys {
+		out[k] = values[k]
+	}
+	return out, nil
+}
+
+// WriteValue is a convenience wrapper around WriteValues for a single key.
+func WriteValue(projectRoot, key, value string) error {
+	return WriteValues(projectRoot, map[string]string{key: value})
+}
+
+// WriteValues persists all entries into .env.local. Existing assignments are
+// replaced in place to preserve surrounding lines, comments and formatting;
+// missing keys are appended in deterministic (sorted) order. The file is
+// created when it does not exist.
+func WriteValues(projectRoot string, values map[string]string) error {
+	if len(values) == 0 {
+		return nil
+	}
+
 	envLocalPath := filepath.Join(projectRoot, ".env.local")
 
 	existing, err := os.ReadFile(envLocalPath)
@@ -95,15 +110,41 @@ func WriteAppEnv(projectRoot, value string) error {
 		return err
 	}
 
-	updated, replaced := replaceEnvLine(existing, "APP_ENV", value)
-	if !replaced {
-		if len(updated) > 0 && !bytes.HasSuffix(updated, []byte("\n")) {
-			updated = append(updated, '\n')
+	updated := existing
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := values[key]
+		var replaced bool
+		updated, replaced = replaceEnvLine(updated, key, value)
+		if !replaced {
+			if len(updated) > 0 && !bytes.HasSuffix(updated, []byte("\n")) {
+				updated = append(updated, '\n')
+			}
+			updated = append(updated, []byte(key+"="+value+"\n")...)
 		}
-		updated = append(updated, []byte("APP_ENV="+value+"\n")...)
 	}
 
 	return os.WriteFile(envLocalPath, updated, 0o644)
+}
+
+func resolveEnvFiles(projectRoot string) []string {
+	candidates := []string{
+		filepath.Join(projectRoot, ".env.dist"),
+		filepath.Join(projectRoot, ".env"),
+		filepath.Join(projectRoot, ".env.local"),
+	}
+	var found []string
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			found = append(found, p)
+		}
+	}
+	return found
 }
 
 // replaceEnvLine returns content with the first assignment of key replaced
@@ -114,7 +155,6 @@ func replaceEnvLine(content []byte, key, value string) ([]byte, bool) {
 	replaced := false
 
 	scanner := bufio.NewScanner(bytes.NewReader(content))
-	// Preserve trailing newline if present
 	hadTrailingNewline := bytes.HasSuffix(content, []byte("\n"))
 
 	first := true

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -9,87 +9,137 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadAppEnv_NoFiles(t *testing.T) {
+func TestReadValue_NoFiles(t *testing.T) {
 	tempDir := t.TempDir()
 
-	value, err := ReadAppEnv(tempDir)
+	value, err := ReadValue(tempDir, "APP_ENV")
 	require.NoError(t, err)
 	assert.Equal(t, "", value)
 }
 
-func TestReadAppEnv_FromEnv(t *testing.T) {
+func TestReadValue_FromEnv(t *testing.T) {
 	tempDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".env"), []byte("APP_ENV=dev\n"), 0o644))
 
-	value, err := ReadAppEnv(tempDir)
+	value, err := ReadValue(tempDir, "APP_ENV")
 	require.NoError(t, err)
 	assert.Equal(t, "dev", value)
 }
 
-func TestReadAppEnv_EnvLocalOverridesEnv(t *testing.T) {
+func TestReadValue_EnvLocalOverridesEnv(t *testing.T) {
 	tempDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".env"), []byte("APP_ENV=prod\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".env.local"), []byte("APP_ENV=dev\n"), 0o644))
 
-	value, err := ReadAppEnv(tempDir)
+	value, err := ReadValue(tempDir, "APP_ENV")
 	require.NoError(t, err)
 	assert.Equal(t, "dev", value)
 }
 
-func TestWriteAppEnv_CreatesFile(t *testing.T) {
+func TestReadValues_ReturnsRequestedKeys(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".env.local"),
+		[]byte("APP_ENV=prod\nAPP_SECRET=abc\nOTHER=ignored\n"), 0o644))
+
+	values, err := ReadValues(tempDir, "APP_ENV", "APP_SECRET", "MISSING")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", values["APP_ENV"])
+	assert.Equal(t, "abc", values["APP_SECRET"])
+	assert.Equal(t, "", values["MISSING"])
+	assert.NotContains(t, values, "OTHER")
+}
+
+func TestReadValues_NoFiles(t *testing.T) {
 	tempDir := t.TempDir()
 
-	require.NoError(t, WriteAppEnv(tempDir, "prod"))
+	values, err := ReadValues(tempDir, "APP_ENV", "APP_SECRET")
+	require.NoError(t, err)
+	assert.Equal(t, "", values["APP_ENV"])
+	assert.Equal(t, "", values["APP_SECRET"])
+}
+
+func TestWriteValue_CreatesFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	require.NoError(t, WriteValue(tempDir, "APP_ENV", "prod"))
 
 	content, err := os.ReadFile(filepath.Join(tempDir, ".env.local"))
 	require.NoError(t, err)
 	assert.Equal(t, "APP_ENV=prod\n", string(content))
 }
 
-func TestWriteAppEnv_ReplacesExistingLine(t *testing.T) {
+func TestWriteValue_ReplacesExistingLine(t *testing.T) {
 	tempDir := t.TempDir()
 	envLocal := filepath.Join(tempDir, ".env.local")
-	require.NoError(t, os.WriteFile(envLocal, []byte("APP_SECRET=secret\nAPP_ENV=dev\nDATABASE_URL=mysql://...\n"), 0o644))
+	require.NoError(t, os.WriteFile(envLocal,
+		[]byte("APP_SECRET=secret\nAPP_ENV=dev\nDATABASE_URL=mysql://...\n"), 0o644))
 
-	require.NoError(t, WriteAppEnv(tempDir, "prod"))
+	require.NoError(t, WriteValue(tempDir, "APP_ENV", "prod"))
 
 	content, err := os.ReadFile(envLocal)
 	require.NoError(t, err)
 	assert.Equal(t, "APP_SECRET=secret\nAPP_ENV=prod\nDATABASE_URL=mysql://...\n", string(content))
 }
 
-func TestWriteAppEnv_AppendsWhenMissing(t *testing.T) {
+func TestWriteValue_AppendsWhenMissing(t *testing.T) {
 	tempDir := t.TempDir()
 	envLocal := filepath.Join(tempDir, ".env.local")
 	require.NoError(t, os.WriteFile(envLocal, []byte("APP_SECRET=secret\n"), 0o644))
 
-	require.NoError(t, WriteAppEnv(tempDir, "test"))
+	require.NoError(t, WriteValue(tempDir, "APP_ENV", "test"))
 
 	content, err := os.ReadFile(envLocal)
 	require.NoError(t, err)
 	assert.Equal(t, "APP_SECRET=secret\nAPP_ENV=test\n", string(content))
 }
 
-func TestWriteAppEnv_AppendsNewlineWhenMissing(t *testing.T) {
+func TestWriteValue_AppendsNewlineWhenMissing(t *testing.T) {
 	tempDir := t.TempDir()
 	envLocal := filepath.Join(tempDir, ".env.local")
 	require.NoError(t, os.WriteFile(envLocal, []byte("APP_SECRET=secret"), 0o644))
 
-	require.NoError(t, WriteAppEnv(tempDir, "prod"))
+	require.NoError(t, WriteValue(tempDir, "APP_ENV", "prod"))
 
 	content, err := os.ReadFile(envLocal)
 	require.NoError(t, err)
 	assert.Equal(t, "APP_SECRET=secret\nAPP_ENV=prod\n", string(content))
 }
 
-func TestWriteAppEnv_PreservesComments(t *testing.T) {
+func TestWriteValue_PreservesComments(t *testing.T) {
 	tempDir := t.TempDir()
 	envLocal := filepath.Join(tempDir, ".env.local")
-	require.NoError(t, os.WriteFile(envLocal, []byte("# Local environment\nAPP_ENV=dev\n# trailing comment\n"), 0o644))
+	require.NoError(t, os.WriteFile(envLocal,
+		[]byte("# Local environment\nAPP_ENV=dev\n# trailing comment\n"), 0o644))
 
-	require.NoError(t, WriteAppEnv(tempDir, "test"))
+	require.NoError(t, WriteValue(tempDir, "APP_ENV", "test"))
 
 	content, err := os.ReadFile(envLocal)
 	require.NoError(t, err)
 	assert.Equal(t, "# Local environment\nAPP_ENV=test\n# trailing comment\n", string(content))
+}
+
+func TestWriteValues_BatchReplaceAndAppendDeterministic(t *testing.T) {
+	tempDir := t.TempDir()
+	envLocal := filepath.Join(tempDir, ".env.local")
+	require.NoError(t, os.WriteFile(envLocal, []byte("APP_ENV=dev\n"), 0o644))
+
+	require.NoError(t, WriteValues(tempDir, map[string]string{
+		"APP_ENV":      "prod",
+		"NEW_FLAG":     "1",
+		"ANOTHER_FLAG": "yes",
+	}))
+
+	content, err := os.ReadFile(envLocal)
+	require.NoError(t, err)
+	// Replaces APP_ENV in place; appends new keys in alphabetical order.
+	assert.Equal(t, "APP_ENV=prod\nANOTHER_FLAG=yes\nNEW_FLAG=1\n", string(content))
+}
+
+func TestWriteValues_EmptyMapIsNoOp(t *testing.T) {
+	tempDir := t.TempDir()
+
+	require.NoError(t, WriteValues(tempDir, nil))
+
+	_, err := os.Stat(filepath.Join(tempDir, ".env.local"))
+	assert.True(t, os.IsNotExist(err))
 }

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -1,0 +1,95 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAppEnv_NoFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	value, err := ReadAppEnv(tempDir)
+	require.NoError(t, err)
+	assert.Equal(t, "", value)
+}
+
+func TestReadAppEnv_FromEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".env"), []byte("APP_ENV=dev\n"), 0o644))
+
+	value, err := ReadAppEnv(tempDir)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", value)
+}
+
+func TestReadAppEnv_EnvLocalOverridesEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".env"), []byte("APP_ENV=prod\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".env.local"), []byte("APP_ENV=dev\n"), 0o644))
+
+	value, err := ReadAppEnv(tempDir)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", value)
+}
+
+func TestWriteAppEnv_CreatesFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	require.NoError(t, WriteAppEnv(tempDir, "prod"))
+
+	content, err := os.ReadFile(filepath.Join(tempDir, ".env.local"))
+	require.NoError(t, err)
+	assert.Equal(t, "APP_ENV=prod\n", string(content))
+}
+
+func TestWriteAppEnv_ReplacesExistingLine(t *testing.T) {
+	tempDir := t.TempDir()
+	envLocal := filepath.Join(tempDir, ".env.local")
+	require.NoError(t, os.WriteFile(envLocal, []byte("APP_SECRET=secret\nAPP_ENV=dev\nDATABASE_URL=mysql://...\n"), 0o644))
+
+	require.NoError(t, WriteAppEnv(tempDir, "prod"))
+
+	content, err := os.ReadFile(envLocal)
+	require.NoError(t, err)
+	assert.Equal(t, "APP_SECRET=secret\nAPP_ENV=prod\nDATABASE_URL=mysql://...\n", string(content))
+}
+
+func TestWriteAppEnv_AppendsWhenMissing(t *testing.T) {
+	tempDir := t.TempDir()
+	envLocal := filepath.Join(tempDir, ".env.local")
+	require.NoError(t, os.WriteFile(envLocal, []byte("APP_SECRET=secret\n"), 0o644))
+
+	require.NoError(t, WriteAppEnv(tempDir, "test"))
+
+	content, err := os.ReadFile(envLocal)
+	require.NoError(t, err)
+	assert.Equal(t, "APP_SECRET=secret\nAPP_ENV=test\n", string(content))
+}
+
+func TestWriteAppEnv_AppendsNewlineWhenMissing(t *testing.T) {
+	tempDir := t.TempDir()
+	envLocal := filepath.Join(tempDir, ".env.local")
+	require.NoError(t, os.WriteFile(envLocal, []byte("APP_SECRET=secret"), 0o644))
+
+	require.NoError(t, WriteAppEnv(tempDir, "prod"))
+
+	content, err := os.ReadFile(envLocal)
+	require.NoError(t, err)
+	assert.Equal(t, "APP_SECRET=secret\nAPP_ENV=prod\n", string(content))
+}
+
+func TestWriteAppEnv_PreservesComments(t *testing.T) {
+	tempDir := t.TempDir()
+	envLocal := filepath.Join(tempDir, ".env.local")
+	require.NoError(t, os.WriteFile(envLocal, []byte("# Local environment\nAPP_ENV=dev\n# trailing comment\n"), 0o644))
+
+	require.NoError(t, WriteAppEnv(tempDir, "test"))
+
+	content, err := os.ReadFile(envLocal)
+	require.NoError(t, err)
+	assert.Equal(t, "# Local environment\nAPP_ENV=test\n# trailing comment\n", string(content))
+}


### PR DESCRIPTION
## Summary

- **APP_ENV picker**: New field in the devtui Config tab to switch between `dev`/`prod`/`test` Symfony environments
- **HTTP Cache toggle**: Add `SHOPWARE_HTTP_CACHE_ENABLED` field with friendly "disabled"/"enabled" labels
- **Env-field registry**: Refactored env-backed config fields into a generic `envFieldDef` registry so adding new `.env`-backed fields is a single struct literal
- **envfile package**: New `ReadValue`/`ReadValues`/`WriteValue`/`WriteValues` helpers for reading and writing `.env.local` files with in-place replacement
- **Cleanup**: Remove unused `internal/sbom` package, Cloudsmith goreleaser config, stale Twig comment testdata files, and dead mysqldump code

## Test plan

- [ ] `go test ./...` passes
- [ ] Manual: open devtui Config tab, verify APP_ENV picker and HTTP Cache toggle appear
- [ ] Manual: change APP_ENV, verify it persists to `.env.local`
- [ ] Manual: toggle HTTP cache, verify `SHOPWARE_HTTP_CACHE_ENABLED=0`/`1` in `.env.local`
