### PR TITLE
refactor(devtui): update install overlay text to 'initialized'

### DIFF
--- a/internal/devtui/install_wizard.go
+++ b/internal/devtui/install_wizard.go
@@ -219,11 +219,11 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 	switch m.install.step {
 	case installStepAsk:
 		warnStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ErrorColor)
-		b.WriteString(warnStyle.Render("Shopware is not installed"))
+		b.WriteString(warnStyle.Render("Shopware is not initialized yet"))
 		b.WriteString("\n")
 		b.WriteString(tui.DimStyle.Render("This project has not been set up yet. The installation\nwill create the database, run migrations and configure\nyour local development environment."))
 		b.WriteString("\n\n")
-		b.WriteString(renderConfirmButtons("Yes, install now", "No, skip", m.install.confirmYes))
+		b.WriteString(renderConfirmButtons("Initialize now", "No, skip", m.install.confirmYes))
 
 	case installStepLanguage:
 		b.WriteString(tui.TextBadge("Step 1/4"))

--- a/internal/devtui/install_wizard_test.go
+++ b/internal/devtui/install_wizard_test.go
@@ -250,7 +250,7 @@ func TestRenderInstallPrompt_AllStepsDoNotPanic(t *testing.T) {
 		step    installStep
 		expects []string
 	}{
-		{installStepAsk, []string{"Shopware is not installed", "Yes, install now"}},
+		{installStepAsk, []string{"Shopware is not initialized yet", "Initialize now"}},
 		{installStepLanguage, []string{"Step 1/4", "Default Language"}},
 		{installStepCurrency, []string{"Step 2/4", "Default Currency"}},
 		{installStepUsername, []string{"Step 3/4", "Admin Username"}},


### PR DESCRIPTION
Change the install overlay heading from 'Shopware is not installed' to 'Shopware is not initialized yet' and update the action button from 'Yes, install now' to 'Initialize now' for better clarity.