### PR TITLE
feat: add code coverage upload via actions/upload-code-coverage

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  code-quality: write
 
 env:
   GOTOOLCHAIN: local
@@ -53,3 +54,13 @@ jobs:
 
       - name: Test (sandboxed, no network)
         run: ./scripts/run-tests.sh
+        env:
+          COVERAGE_FILE: coverage.out
+
+      - name: Upload code coverage
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage.xml
+          language: Go
+          label: code-coverage/go-test
+          fail-on-error: false

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -32,6 +32,7 @@ jobs:
             proxy.golang.org:443
             release-assets.githubusercontent.com:443
             storage.googleapis.com:443
+            sum.golang.org:443
 
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,6 +6,8 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_DIR"
 
+COVERPROFILE="${COVERAGE_FILE:-}"
+
 if [ $# -eq 0 ]; then
     set -- -v ./...
 fi
@@ -13,6 +15,11 @@ fi
 # Warm the build cache while we still have network so the sandboxed run
 # does not need to fetch or compile anything from the module proxy.
 go test -run='^$' ./...
+
+# If a coverage file is requested, install gocover-cobertura while we have network.
+if [ -n "$COVERPROFILE" ]; then
+    go install github.com/boumenot/gocover-cobertura@v1.5.0
+fi
 
 # Inside the sandbox, force the toolchain to fail fast on any cache miss
 # instead of attempting (and hanging on) a network fetch.
@@ -23,13 +30,18 @@ export GOPROXY=off
 # binaries or dart-sass) to skip themselves instead of failing on DNS.
 export SHOPWARE_CLI_NO_NETWORK=1
 
+COVER_FLAG=""
+if [ -n "$COVERPROFILE" ]; then
+    COVER_FLAG="-coverprofile=$COVERPROFILE"
+fi
+
 case "$(uname -s)" in
     Darwin)
         if ! command -v sandbox-exec >/dev/null 2>&1; then
             echo "error: sandbox-exec not found" >&2
             exit 1
         fi
-        exec sandbox-exec -f "$REPO_DIR/sandbox-no-network.sb" go test "$@"
+        sandbox-exec -f "$REPO_DIR/sandbox-no-network.sb" go test $COVER_FLAG "$@"
         ;;
     Linux)
         if ! command -v unshare >/dev/null 2>&1; then
@@ -39,7 +51,7 @@ case "$(uname -s)" in
         # Bring loopback up inside the new netns so tests that use
         # httptest.NewServer (127.0.0.1) keep working; only external
         # network is blocked, matching the nix-build sandbox.
-        exec unshare --user --map-root-user --net -- bash -c '
+        unshare --user --map-root-user --net -- bash -c '
             if command -v ip >/dev/null 2>&1; then
                 ip link set dev lo up
             elif command -v ifconfig >/dev/null 2>&1; then
@@ -48,7 +60,7 @@ case "$(uname -s)" in
                 echo "error: need either ip (iproute2) or ifconfig to bring up loopback" >&2
                 exit 1
             fi
-            exec go test "$@"
+            exec go test '"$COVER_FLAG"' "$@"
         ' bash "$@"
         ;;
     *)
@@ -56,3 +68,10 @@ case "$(uname -s)" in
         exit 1
         ;;
 esac
+
+# Convert Go coverage profile to Cobertura XML if requested.
+if [ -n "$COVERPROFILE" ]; then
+    echo "Converting coverage to Cobertura XML..."
+    gocover-cobertura < "$COVERPROFILE" > "${COVERPROFILE%.out}.xml"
+    echo "Coverage report: ${COVERPROFILE%.out}.xml"
+fi


### PR DESCRIPTION
Integrates GitHub's new code coverage API using [actions/upload-code-coverage](https://github.com/actions/upload-code-coverage).

### Changes
- Generate Go coverage profile during test run via `COVERAGE_FILE` env var
- Convert coverage to Cobertura XML using `gocover-cobertura@v1.5.0`
- Upload report to GitHub's code coverage API
- Added `code-quality: write` permission to test workflow
- Coverage upload is non-blocking (`fail-on-error: false`)