### PR TITLE
feat(project): add dev status command

### DIFF
--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -18,6 +19,11 @@ import (
 	"github.com/shopware/shopware-cli/internal/shop"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
+
+// ErrEnvironmentDown is returned by the `project dev status` command when the
+// development environment is not running. It causes the CLI to exit with code 1
+// without printing an additional error message.
+var ErrEnvironmentDown = errors.New("development environment is down")
 
 type devEnvironment struct {
 	projectRoot string
@@ -103,6 +109,21 @@ var projectDevStopCmd = &cobra.Command{
 		}
 
 		return env.stop(cmd)
+	},
+}
+
+var projectDevStatusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "Report whether the development environment is running",
+	Long:         "Report whether the development environment is running. Exits with code 0 when it is up and code 1 when it is down.",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		env, err := setupDevEnvironment(cmd)
+		if err != nil {
+			return err
+		}
+
+		return env.status(cmd)
 	},
 }
 
@@ -243,6 +264,24 @@ func (e *devEnvironment) stop(cmd *cobra.Command) error {
 	return nil
 }
 
+func (e *devEnvironment) status(cmd *cobra.Command) error {
+	running, err := e.executor.EnvironmentStatus(cmd.Context())
+	if err != nil {
+		if errors.Is(err, executor.ErrNotSupported) {
+			return fmt.Errorf("the %s environment does not manage a development environment", e.executor.Type())
+		}
+		return fmt.Errorf("checking environment status: %w", err)
+	}
+
+	if running {
+		fmt.Println(tui.GreenText.Bold(true).Render("  ✓ Development environment is up"))
+		return nil
+	}
+
+	fmt.Println(tui.RedText.Bold(true).Render("  ✗ Development environment is down"))
+	return ErrEnvironmentDown
+}
+
 func (e *devEnvironment) runTUI() error {
 	m := devtui.New(devtui.Options{
 		ProjectRoot: e.projectRoot,
@@ -260,4 +299,5 @@ func init() {
 	projectRootCmd.AddCommand(projectDevCmd)
 	projectDevCmd.AddCommand(projectDevStartCmd)
 	projectDevCmd.AddCommand(projectDevStopCmd)
+	projectDevCmd.AddCommand(projectDevStatusCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func Execute(ctx context.Context) {
 
 	if cmd, _, findErr := rootCmd.Find(os.Args[1:]); findErr == nil && cmd != rootCmd && cmd.RunE != nil {
 		result := "success"
-		if err != nil {
+		if err != nil && !errors.Is(err, project.ErrEnvironmentDown) {
 			if errors.Is(err, context.Canceled) {
 				result = "cancelled"
 			} else {
@@ -74,6 +74,12 @@ func Execute(ctx context.Context) {
 			"os":           runtime.GOOS,
 			"is_tui":       strconv.FormatBool(system.IsInteractionEnabled(ctx)),
 		})
+	}
+
+	if errors.Is(err, project.ErrEnvironmentDown) {
+		// The command already printed a human-readable status; exit 1 without
+		// logging an error.
+		os.Exit(1)
 	}
 
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func Execute(ctx context.Context) {
 
 	if cmd, _, findErr := rootCmd.Find(os.Args[1:]); findErr == nil && cmd != rootCmd && cmd.RunE != nil {
 		result := "success"
-		if err != nil && !errors.Is(err, project.ErrEnvironmentDown) {
+		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				result = "cancelled"
 			} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,12 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute(ctx context.Context) {
+	os.Exit(run(ctx))
+}
+
+// run executes the root command and returns the process exit code. It is kept
+// separate from Execute so its deferred cleanup runs before os.Exit is called.
+func run(ctx context.Context) int {
 	rootCmd.Use = commandNameFromArgs(os.Args)
 	args := mapAliasArgs(os.Args)
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
@@ -79,12 +85,15 @@ func Execute(ctx context.Context) {
 	if errors.Is(err, project.ErrEnvironmentDown) {
 		// The command already printed a human-readable status; exit 1 without
 		// logging an error.
-		os.Exit(1)
+		return 1
 	}
 
 	if err != nil {
-		logging.FromContext(ctx).Fatalln(err)
+		logging.FromContext(ctx).Errorln(err)
+		return 1
 	}
+
+	return 0
 }
 
 func mapAliasArgs(argv []string) []string {

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -157,6 +157,18 @@ func (d *DockerExecutor) StopEnvironment(ctx context.Context) error {
 	return nil
 }
 
+func (d *DockerExecutor) EnvironmentStatus(ctx context.Context) (bool, error) {
+	cmd := exec.CommandContext(ctx, "docker", "compose", "ps", "--status=running", "-q")
+	cmd.Dir = d.projectRoot
+
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("checking environment status: %w", err)
+	}
+
+	return len(strings.TrimSpace(string(output))) > 0, nil
+}
+
 func (d *DockerExecutor) baseArgs() []string {
 	args := []string{"compose", "exec"}
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -34,6 +34,7 @@ type Executor interface {
 	WithRelDir(relDir string) Executor
 	StartEnvironment(ctx context.Context) error
 	StopEnvironment(ctx context.Context) error
+	EnvironmentStatus(ctx context.Context) (bool, error)
 	AdminAPIClient(ctx context.Context) (*adminSdk.Client, error)
 }
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -385,3 +385,19 @@ func TestSymfonyCLINormalizePath(t *testing.T) {
 	exec := &SymfonyCLIExecutor{BinaryPath: "/usr/local/bin/symfony", projectRoot: "/host/project"}
 	assert.Equal(t, "/host/project/custom/plugins/MyPlugin", exec.NormalizePath("/host/project/custom/plugins/MyPlugin"))
 }
+
+func TestLocalExecutorEnvironmentStatusNotSupported(t *testing.T) {
+	exec := &LocalExecutor{projectRoot: "/project"}
+
+	running, err := exec.EnvironmentStatus(t.Context())
+	assert.False(t, running)
+	assert.ErrorIs(t, err, ErrNotSupported)
+}
+
+func TestSymfonyCLIExecutorEnvironmentStatusNotSupported(t *testing.T) {
+	exec := &SymfonyCLIExecutor{BinaryPath: "/usr/local/bin/symfony", projectRoot: "/project"}
+
+	running, err := exec.EnvironmentStatus(t.Context())
+	assert.False(t, running)
+	assert.ErrorIs(t, err, ErrNotSupported)
+}

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -80,6 +80,10 @@ func (l *LocalExecutor) StopEnvironment(_ context.Context) error {
 	return ErrNotSupported
 }
 
+func (l *LocalExecutor) EnvironmentStatus(_ context.Context) (bool, error) {
+	return false, ErrNotSupported
+}
+
 func applyLocalEnv(projectRoot string, env map[string]string, cmd *exec.Cmd) {
 	cmd.Env = os.Environ()
 

--- a/internal/executor/symfony_cli.go
+++ b/internal/executor/symfony_cli.go
@@ -82,3 +82,7 @@ func (s *SymfonyCLIExecutor) StartEnvironment(_ context.Context) error {
 func (s *SymfonyCLIExecutor) StopEnvironment(_ context.Context) error {
 	return ErrNotSupported
 }
+
+func (s *SymfonyCLIExecutor) EnvironmentStatus(_ context.Context) (bool, error) {
+	return false, ErrNotSupported
+}


### PR DESCRIPTION
## What

Adds `shopware-cli project dev status`, a counterpart to `dev start` / `dev stop` that reports whether the development environment is running.

- Prints a human-readable status line (`✓ Development environment is up` / `✗ Development environment is down`).
- Exits **0** when up and **1** when down, so it works in scripts, CI, and health checks.
- For non-Docker environments (local / symfony-cli) it reports that there is no managed environment to check.

## How

- Adds `EnvironmentStatus(ctx) (bool, error)` to the `Executor` interface.
- Docker reuses the existing `docker compose ps --status=running -q` check (same definition the dev TUI uses).
- Local and symfony-cli executors return `ErrNotSupported`, mirroring their `Start/StopEnvironment`.
- A sentinel `ErrEnvironmentDown` drives the exit-1-without-error-noise behavior in `cmd/root.go`; the command sets `SilenceUsage` so a status of "down" doesn't print usage.

## Test plan

- `go test ./...`
- Added unit tests asserting local and symfony-cli executors return `ErrNotSupported` from `EnvironmentStatus`.