### PR TITLE
fix: use array for COVER_FLAGS to safely handle empty case

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f1eff485-16cd-4641-950b-79e0a0a10769","pid":68060,"procStart":"Tue May 26 12:24:31 2026","acquiredAt":1779799762311}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f1eff485-16cd-4641-950b-79e0a0a10769","pid":68060,"procStart":"Tue May 26 12:24:31 2026","acquiredAt":1779799762311}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ devenv.local.nix
 /.gomodcache
 /.gopath
 .soulforge
+.claude/scheduled_tasks.lock

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -430,6 +430,39 @@ func TestConfigDump_EnableClean(t *testing.T) {
 		assert.Len(t, config.NoData, 19)
 	})
 
+	t.Run("no duplicates when pre-existing entry overlaps with defaults", func(t *testing.T) {
+		config := &ConfigDump{
+			NoData: []string{"my_custom_table", "cart", "version"},
+		}
+
+		config.EnableClean()
+
+		// Should not introduce duplicates for 'cart' and 'version'
+		count := 0
+		for _, table := range config.NoData {
+			if table == "cart" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "cart should appear exactly once")
+
+		count = 0
+		for _, table := range config.NoData {
+			if table == "version" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "version should appear exactly once")
+
+		// Total should be custom tables (3) + remaining clean tables (15)
+		assert.Len(t, config.NoData, 18)
+
+		// Pre-existing tables should be preserved in their original positions
+		assert.Equal(t, "my_custom_table", config.NoData[0])
+		assert.Equal(t, "cart", config.NoData[1])
+		assert.Equal(t, "version", config.NoData[2])
+	})
+
 	t.Run("verify all expected tables", func(t *testing.T) {
 		config := &ConfigDump{}
 		config.EnableClean()

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -60,8 +60,8 @@ case "$(uname -s)" in
                 echo "error: need either ip (iproute2) or ifconfig to bring up loopback" >&2
                 exit 1
             fi
-            exec go test '"${COVER_FLAGS[@]}"' "$@"
-        ' bash "$@"
+            exec go test "$@"
+        ' bash "${COVER_FLAGS[@]}" "$@"
         ;;
     *)
         echo "error: unsupported OS: $(uname -s)" >&2

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -30,9 +30,9 @@ export GOPROXY=off
 # binaries or dart-sass) to skip themselves instead of failing on DNS.
 export SHOPWARE_CLI_NO_NETWORK=1
 
-COVER_FLAG=""
+COVER_FLAGS=()
 if [ -n "$COVERPROFILE" ]; then
-    COVER_FLAG="-coverprofile=$COVERPROFILE"
+    COVER_FLAGS=("-coverprofile=$COVERPROFILE")
 fi
 
 case "$(uname -s)" in
@@ -41,7 +41,7 @@ case "$(uname -s)" in
             echo "error: sandbox-exec not found" >&2
             exit 1
         fi
-        sandbox-exec -f "$REPO_DIR/sandbox-no-network.sb" go test $COVER_FLAG "$@"
+        sandbox-exec -f "$REPO_DIR/sandbox-no-network.sb" go test "${COVER_FLAGS[@]}" "$@"
         ;;
     Linux)
         if ! command -v unshare >/dev/null 2>&1; then
@@ -60,7 +60,7 @@ case "$(uname -s)" in
                 echo "error: need either ip (iproute2) or ifconfig to bring up loopback" >&2
                 exit 1
             fi
-            exec go test '"$COVER_FLAG"' "$@"
+            exec go test "${COVER_FLAGS[@]}" "$@"
         ' bash "$@"
         ;;
     *)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -60,7 +60,7 @@ case "$(uname -s)" in
                 echo "error: need either ip (iproute2) or ifconfig to bring up loopback" >&2
                 exit 1
             fi
-            exec go test "${COVER_FLAGS[@]}" "$@"
+            exec go test '"${COVER_FLAGS[@]}"' "$@"
         ' bash "$@"
         ;;
     *)


### PR DESCRIPTION
Replace unquoted `` string variable with a bash array `COVER_FLAGS=()` so that when coverage is not requested, the empty array expands to nothing instead of an empty-string argument to `go test`.

This prevents a potential unexpected argument error when `COVERAGE_FILE` is not set.