### PR TITLE
fix: prevent snippet merge from overwriting root locale files

### DIFF
--- a/internal/extension/cleanup_ci.go
+++ b/internal/extension/cleanup_ci.go
@@ -64,14 +64,26 @@ func CleanupAdministrationFiles(ctx context.Context, folder string) error {
 		return err
 	}
 
+	var tmpSnippetFolder string
+
+	if len(snippetFiles) > 0 {
+		tmpSnippetFolder, err = os.MkdirTemp(folder, ".shopware-admin-snippets-*")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = os.RemoveAll(tmpSnippetFolder) }()
+	}
+
 	for language, files := range snippetFiles {
+		tmpSnippetPath := filepath.Join(tmpSnippetFolder, language+".json")
+
 		if len(files) == 1 {
 			data, err := os.ReadFile(files[0])
 			if err != nil {
 				return err
 			}
 
-			if err := os.WriteFile(filepath.Join(folder, language), data, 0o644); err != nil {
+			if err := os.WriteFile(tmpSnippetPath, data, 0o644); err != nil {
 				return err
 			}
 
@@ -102,7 +114,7 @@ func CleanupAdministrationFiles(ctx context.Context, folder string) error {
 			return err
 		}
 
-		if err := os.WriteFile(filepath.Join(folder, language), mergedData, 0o644); err != nil {
+		if err := os.WriteFile(tmpSnippetPath, mergedData, 0o644); err != nil {
 			return err
 		}
 	}
@@ -121,7 +133,7 @@ func CleanupAdministrationFiles(ctx context.Context, folder string) error {
 	}
 
 	for language := range snippetFiles {
-		if err := os.Rename(filepath.Join(folder, language), filepath.Join(snippetFolder, language+".json")); err != nil {
+		if err := os.Rename(filepath.Join(tmpSnippetFolder, language+".json"), filepath.Join(snippetFolder, language+".json")); err != nil {
 			return err
 		}
 	}

--- a/internal/extension/cleanup_ci_test.go
+++ b/internal/extension/cleanup_ci_test.go
@@ -71,6 +71,33 @@ func TestCleanupAdministrationFiles_MergesSnippetFiles(t *testing.T) {
 	assert.Equal(t, "value2", merged["key2"])
 }
 
+func TestCleanupAdministrationFiles_DoesNotOverwriteRootLocaleFileWhenMergingSnippets(t *testing.T) {
+	tmpDir := t.TempDir()
+	adminDir := filepath.Join(tmpDir, "Resources", "app", "administration")
+
+	snippetDir1 := filepath.Join(adminDir, "src", "app", "snippet")
+	snippetDir2 := filepath.Join(adminDir, "src", "module", "test", "snippet")
+
+	require.NoError(t, os.MkdirAll(snippetDir1, 0755))
+	require.NoError(t, os.MkdirAll(snippetDir2, 0755))
+
+	rootLocalePath := filepath.Join(tmpDir, "en-GB")
+	require.NoError(t, os.WriteFile(rootLocalePath, []byte("keep me"), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(snippetDir1, "en-GB.json"), []byte(`{"key1":"value1"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(snippetDir2, "en-GB.json"), []byte(`{"key2":"value2"}`), 0644))
+
+	err := CleanupAdministrationFiles(context.Background(), tmpDir)
+	require.NoError(t, err)
+
+	rootLocaleContent, err := os.ReadFile(rootLocalePath)
+	require.NoError(t, err)
+	assert.Equal(t, "keep me", string(rootLocaleContent))
+
+	assert.FileExists(t, filepath.Join(snippetDir1, "en-GB.json"))
+	assert.NoFileExists(t, filepath.Join(snippetDir1, "en-GB"))
+}
+
 func TestCleanupAdministrationFiles_NoAdminFolder(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Problem

When merging snippet files during admin cleanup, intermediate files were written directly into the extension root folder using the language name (e.g. ). If a locale file with the same name already existed at the root level, it would be silently overwritten.

## Solution

Write merged snippet files to a temporary directory () inside the extension folder instead. The final files are then renamed from the temp directory to the snippet output location.

## Changes

- Create a temp directory for intermediate snippet files
- Write single-file and merged snippet outputs to the temp dir instead of the root
- Rename from temp dir to final snippet location
- Added regression test verifying root locale files are preserved

## Testing

- All existing tests pass
- New test  validates the fix