### PR TITLE
fix(devtui): show output when clearing cache

### DIFF
--- a/internal/devtui/task_runner.go
+++ b/internal/devtui/task_runner.go
@@ -58,9 +58,7 @@ func (m *Model) runSelfCommand(title string, args ...string) tea.Cmd {
 
 func (m *Model) runCacheClear() tea.Cmd {
 	e := m.executor
-	return func() tea.Msg {
-		cmd := e.ConsoleCommand(context.Background(), "cache:clear")
-		_ = cmd.Run()
-		return nil
-	}
+	return m.runTask("Clearing Cache...", func() (*exec.Cmd, error) {
+		return e.ConsoleCommand(context.Background(), "cache:clear").Cmd, nil
+	})
 }


### PR DESCRIPTION
## Summary
- The "Clear Cache" command in devtui ran `cache:clear` synchronously, discarded the result, and returned `nil` — giving the user no feedback that anything happened.
- Route it through the existing `runTask` infrastructure (same as the build actions) so it switches to the task view, streams output under a "Clearing Cache..." header, and reports completion/error.

<img width="778" height="228" alt="image" src="https://github.com/user-attachments/assets/9f6d6070-23b7-4ab1-b03f-91cf6f95e9d1" />
