### PR TITLE
Validate project names for Docker Compose compatibility

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -45,6 +45,15 @@ var gitlabCITemplate string
 
 const versionLatest = "latest"
 
+const (
+	// projectNameHelp is the help text shown under the project name input.
+	projectNameHelp = "The name of the project directory to create"
+	// projectNameRule describes which characters are allowed in a project name.
+	// It is shared between the up-front validation error and the live form hint
+	// so both stay in sync.
+	projectNameRule = "only lowercase letters, digits, dashes (-) and underscores (_) are allowed, and it must start with a lowercase letter or digit"
+)
+
 // composeProjectNameRegexp matches names that are valid as a Docker Compose
 // project name. Docker Compose only allows lowercase letters, digits, dashes
 // and underscores, and the name must start with a lowercase letter or digit.
@@ -60,10 +69,24 @@ func validateProjectName(name string) error {
 	base := filepath.Base(name)
 
 	if !composeProjectNameRegexp.MatchString(base) {
-		return fmt.Errorf("invalid project name %q: a project name may only contain lowercase letters, digits, dashes (-) and underscores (_), and must start with a lowercase letter or digit so it can be used as a Docker Compose project name", base)
+		return fmt.Errorf("invalid project name %q: %s, so it can be used as a Docker Compose project name", base, projectNameRule)
 	}
 
 	return nil
+}
+
+// projectNameFieldDescription returns the description shown under the project
+// name input in the interactive form. While the typed name is invalid it
+// returns the rule highlighted in red, validating the input live; otherwise it
+// returns the regular help text.
+func projectNameFieldDescription(name string) string {
+	if name != "" {
+		if err := validateProjectName(name); err != nil {
+			return tui.RedText.Render(projectNameRule)
+		}
+	}
+
+	return projectNameHelp
 }
 
 var projectCreateCmd = &cobra.Command{
@@ -242,7 +265,9 @@ var projectCreateCmd = &cobra.Command{
 					formGroups = append(formGroups, huh.NewGroup(
 						huh.NewInput().
 							Title("Project Name").
-							Description("The name of the project directory to create").
+							DescriptionFunc(func() string {
+								return projectNameFieldDescription(projectFolder)
+							}, &projectFolder).
 							Placeholder("my-shopware-project").
 							Value(&projectFolder).
 							Validate(func(s string) error {

--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -43,6 +44,27 @@ var githubDeployTemplate string
 var gitlabCITemplate string
 
 const versionLatest = "latest"
+
+// composeProjectNameRegexp matches names that are valid as a Docker Compose
+// project name. Docker Compose derives the project name from the project
+// directory and only allows alphanumeric characters, dashes and underscores,
+// and the name must start with a letter or digit. Anything else (umlauts,
+// spaces, dots, …) gets silently stripped or rejected by Docker Compose, so we
+// reject such project names up front.
+var composeProjectNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+// validateProjectName ensures the project folder name can be used as a Docker
+// Compose project name. Only the final path element is relevant, as that is
+// what Docker Compose uses to derive the project name.
+func validateProjectName(name string) error {
+	base := filepath.Base(name)
+
+	if !composeProjectNameRegexp.MatchString(base) {
+		return fmt.Errorf("invalid project name %q: a project name may only contain letters, digits, dashes (-) and underscores (_), and must start with a letter or digit so it can be used as a Docker Compose project name", base)
+	}
+
+	return nil
+}
 
 var projectCreateCmd = &cobra.Command{
 	Use:   "create [name] [version]",
@@ -227,6 +249,9 @@ var projectCreateCmd = &cobra.Command{
 								if s == "" {
 									return fmt.Errorf("project name is required")
 								}
+								if err := validateProjectName(s); err != nil {
+									return err
+								}
 								if info, err := os.Stat(s); err == nil && info.IsDir() {
 									empty, err := system.IsDirEmpty(s)
 									if err != nil {
@@ -400,6 +425,10 @@ var projectCreateCmd = &cobra.Command{
 					return fmt.Errorf("project creation cancelled")
 				}
 			}
+		}
+
+		if err := validateProjectName(projectFolder); err != nil {
+			return err
 		}
 
 		missingDeps := system.CheckProjectDependencies(cmd.Context(), useDocker)

--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -46,12 +46,12 @@ var gitlabCITemplate string
 const versionLatest = "latest"
 
 // composeProjectNameRegexp matches names that are valid as a Docker Compose
-// project name. Docker Compose derives the project name from the project
-// directory and only allows alphanumeric characters, dashes and underscores,
-// and the name must start with a letter or digit. Anything else (umlauts,
-// spaces, dots, …) gets silently stripped or rejected by Docker Compose, so we
-// reject such project names up front.
-var composeProjectNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+// project name. Docker Compose only allows lowercase letters, digits, dashes
+// and underscores, and the name must start with a lowercase letter or digit.
+// Anything else (uppercase letters, umlauts, spaces, dots, …) is rejected by
+// Docker Compose once the generated Docker setup runs from the project
+// directory, so we reject such project names up front.
+var composeProjectNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 
 // validateProjectName ensures the project folder name can be used as a Docker
 // Compose project name. Only the final path element is relevant, as that is
@@ -60,7 +60,7 @@ func validateProjectName(name string) error {
 	base := filepath.Base(name)
 
 	if !composeProjectNameRegexp.MatchString(base) {
-		return fmt.Errorf("invalid project name %q: a project name may only contain letters, digits, dashes (-) and underscores (_), and must start with a letter or digit so it can be used as a Docker Compose project name", base)
+		return fmt.Errorf("invalid project name %q: a project name may only contain lowercase letters, digits, dashes (-) and underscores (_), and must start with a lowercase letter or digit so it can be used as a Docker Compose project name", base)
 	}
 
 	return nil

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -117,6 +117,34 @@ func TestValidateProjectName(t *testing.T) {
 	}
 }
 
+func TestProjectNameFieldDescription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty shows help text", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, projectNameHelp, projectNameFieldDescription(""))
+	})
+
+	t.Run("valid name shows help text", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, projectNameHelp, projectNameFieldDescription("my-shop"))
+	})
+
+	t.Run("uppercase name shows the rule", func(t *testing.T) {
+		t.Parallel()
+		desc := projectNameFieldDescription("MyShop")
+		assert.NotEqual(t, projectNameHelp, desc)
+		assert.Contains(t, desc, projectNameRule)
+	})
+
+	t.Run("umlaut name shows the rule", func(t *testing.T) {
+		t.Parallel()
+		desc := projectNameFieldDescription("müller")
+		assert.NotEqual(t, projectNameHelp, desc)
+		assert.Contains(t, desc, projectNameRule)
+	})
+}
+
 func TestSetupDeployment(t *testing.T) {
 	t.Parallel()
 	t.Run("none creates no files", func(t *testing.T) {

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -67,6 +67,53 @@ func TestResolveVersion(t *testing.T) {
 	})
 }
 
+func TestValidateProjectName(t *testing.T) {
+	t.Parallel()
+
+	validNames := []string{
+		"my-shopware-project",
+		"myshop",
+		"my_shop",
+		"shop123",
+		"123shop",
+		"MyShop",
+		"a",
+		"path/to/my-shop",
+	}
+
+	for _, name := range validNames {
+		t.Run("valid: "+name, func(t *testing.T) {
+			t.Parallel()
+			assert.NoError(t, validateProjectName(name))
+		})
+	}
+
+	invalidNames := []string{
+		"müller",
+		"über-shop",
+		"Müller-Shop",
+		"café",
+		"straße",
+		"my shop",
+		"my.shop",
+		"shop!",
+		"-shop",
+		"_shop",
+		"ä",
+		"",
+		"path/to/müller",
+	}
+
+	for _, name := range invalidNames {
+		t.Run("invalid: "+name, func(t *testing.T) {
+			t.Parallel()
+			err := validateProjectName(name)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid project name")
+		})
+	}
+}
+
 func TestSetupDeployment(t *testing.T) {
 	t.Parallel()
 	t.Run("none creates no files", func(t *testing.T) {

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -76,7 +76,6 @@ func TestValidateProjectName(t *testing.T) {
 		"my_shop",
 		"shop123",
 		"123shop",
-		"MyShop",
 		"a",
 		"path/to/my-shop",
 	}
@@ -89,6 +88,9 @@ func TestValidateProjectName(t *testing.T) {
 	}
 
 	invalidNames := []string{
+		"MyShop",
+		"myShop",
+		"SHOP",
 		"müller",
 		"über-shop",
 		"Müller-Shop",
@@ -102,6 +104,7 @@ func TestValidateProjectName(t *testing.T) {
 		"ä",
 		"",
 		"path/to/müller",
+		"path/to/MyShop",
 	}
 
 	for _, name := range invalidNames {


### PR DESCRIPTION
## Summary
Add validation for project names to ensure they are compatible with Docker Compose's project naming requirements. Project names can only contain alphanumeric characters, dashes, and underscores, and must start with a letter or digit.

## Changes
- **Added `validateProjectName()` function** in `cmd/project/project_create.go` that validates project folder names against Docker Compose naming constraints using a regex pattern
- **Added `composeProjectNameRegexp`** regex pattern that matches valid Docker Compose project names: `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`
- **Integrated validation** at two points in the project creation flow:
  - In the interactive prompt when asking for project name
  - Before dependency checks in the main command execution
- **Added comprehensive test coverage** in `cmd/project/project_create_test.go` with `TestValidateProjectName()` that validates:
  - Valid names: alphanumeric, dashes, underscores, paths with valid segments
  - Invalid names: umlauts, spaces, dots, special characters, names starting with dash/underscore, empty strings

## Implementation Details
- Validation only checks the final path element (via `filepath.Base()`) since Docker Compose derives the project name from the directory name
- Error messages clearly explain the naming constraints to users
- Validation happens early in the flow to provide immediate feedback before any project setup occurs

https://claude.ai/code/session_012ynH2shX6TQgW983qJztYu