### PR TITLE
fix(project): guard project ci on dirty local worktrees

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,10 +14,12 @@ import (
 
 	"github.com/shopware/shopware-cli/internal/ci"
 	"github.com/shopware/shopware-cli/internal/extension"
+	internalgit "github.com/shopware/shopware-cli/internal/git"
 	"github.com/shopware/shopware-cli/internal/mjml"
 	"github.com/shopware/shopware-cli/internal/packagist"
 	"github.com/shopware/shopware-cli/internal/phpexec"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -372,11 +373,11 @@ func init() {
 }
 
 func projectCISafetyCheck(ctx context.Context, root string, force bool, getenv func(string) string) error {
-	if force || isCIEnvironment(getenv) {
+	if force || system.IsCIEnvironment(getenv) {
 		return nil
 	}
 
-	dirty, isGitRepository, err := isGitWorkingTreeDirty(ctx, root)
+	dirty, isGitRepository, err := internalgit.IsWorkingTreeDirty(ctx, root)
 	if err != nil {
 		return err
 	}
@@ -393,56 +394,6 @@ func projectCISafetyCheck(ctx context.Context, root string, force bool, getenv f
 	logging.FromContext(ctx).Warnf("Running project ci outside a CI environment; this command removes source files and should usually only be used in CI")
 
 	return nil
-}
-
-func isCIEnvironment(getenv func(string) string) bool {
-	if strings.EqualFold(getenv("CI"), "true") {
-		return true
-	}
-
-	ciEnvVars := []string{
-		"GITHUB_ACTIONS",
-		"GITLAB_CI",
-		"JENKINS_URL",
-		"BUILDKITE",
-		"CIRCLECI",
-		"DRONE",
-		"TEAMCITY_VERSION",
-		"TF_BUILD",
-	}
-
-	for _, envVar := range ciEnvVars {
-		if getenv(envVar) != "" {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isGitWorkingTreeDirty(ctx context.Context, root string) (bool, bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--is-inside-work-tree") //nolint:gosec
-	output, err := cmd.Output()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return false, false, nil
-		}
-
-		return false, false, fmt.Errorf("checking git repository: %w", err)
-	}
-
-	if strings.TrimSpace(string(output)) != "true" {
-		return false, false, nil
-	}
-
-	statusCmd := exec.CommandContext(ctx, "git", "-C", root, "status", "--porcelain", "--untracked-files=all") //nolint:gosec
-	status, err := statusCmd.Output()
-	if err != nil {
-		return false, true, fmt.Errorf("checking git working tree status: %w", err)
-	}
-
-	return strings.TrimSpace(string(status)) != "", true, nil
 }
 
 func commandWithRoot(cmd *exec.Cmd, root string) *exec.Cmd {

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -44,6 +44,15 @@ var projectCI = &cobra.Command{
 			return err
 		}
 
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
+		if err := projectCISafetyCheck(cmd.Context(), args[0], force, os.Getenv); err != nil {
+			return err
+		}
+
 		if os.Getenv("APP_ENV") == "" {
 			if err := os.Setenv("APP_ENV", "prod"); err != nil {
 				return err
@@ -358,6 +367,76 @@ func prepareComposerAuth(ctx context.Context, root string) (string, error) {
 func init() {
 	projectRootCmd.AddCommand(projectCI)
 	projectCI.PersistentFlags().Bool("with-dev-dependencies", false, "Install dev dependencies")
+	projectCI.PersistentFlags().Bool("force", false, "Run project ci outside CI even when the git working tree has local changes")
+}
+
+func projectCISafetyCheck(ctx context.Context, root string, force bool, getenv func(string) string) error {
+	if force || isCIEnvironment(getenv) {
+		return nil
+	}
+
+	dirty, isGitRepository, err := isGitWorkingTreeDirty(ctx, root)
+	if err != nil {
+		return err
+	}
+
+	if !isGitRepository {
+		logging.FromContext(ctx).Warnf("Running project ci outside a CI environment; this command removes source files and should usually only be used in CI")
+		return nil
+	}
+
+	if dirty {
+		return fmt.Errorf("project ci removes source files and creates build stubs; refusing to run outside CI with a dirty git working tree. Commit, stash, or clean local changes, or pass --force if you intentionally want to run it")
+	}
+
+	logging.FromContext(ctx).Warnf("Running project ci outside a CI environment; this command removes source files and should usually only be used in CI")
+
+	return nil
+}
+
+func isCIEnvironment(getenv func(string) string) bool {
+	if strings.EqualFold(getenv("CI"), "true") {
+		return true
+	}
+
+	ciEnvVars := []string{
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"JENKINS_URL",
+		"BUILDKITE",
+		"CIRCLECI",
+		"DRONE",
+		"TEAMCITY_VERSION",
+		"TF_BUILD",
+	}
+
+	for _, envVar := range ciEnvVars {
+		if getenv(envVar) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isGitWorkingTreeDirty(ctx context.Context, root string) (bool, bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--is-inside-work-tree") //nolint:gosec
+	output, err := cmd.Output()
+	if err != nil {
+		return false, false, nil
+	}
+
+	if strings.TrimSpace(string(output)) != "true" {
+		return false, false, nil
+	}
+
+	statusCmd := exec.CommandContext(ctx, "git", "-C", root, "status", "--porcelain", "--untracked-files=all") //nolint:gosec
+	status, err := statusCmd.Output()
+	if err != nil {
+		return false, true, fmt.Errorf("checking git working tree status: %w", err)
+	}
+
+	return strings.TrimSpace(string(status)) != "", true, nil
 }
 
 func commandWithRoot(cmd *exec.Cmd, root string) *exec.Cmd {

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -423,7 +424,12 @@ func isGitWorkingTreeDirty(ctx context.Context, root string) (bool, bool, error)
 	cmd := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--is-inside-work-tree") //nolint:gosec
 	output, err := cmd.Output()
 	if err != nil {
-		return false, false, nil
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, false, nil
+		}
+
+		return false, false, fmt.Errorf("checking git repository: %w", err)
 	}
 
 	if strings.TrimSpace(string(output)) != "true" {

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -87,7 +87,7 @@ func newCleanGitRepository(t *testing.T) string {
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "git %v failed: %s", args, output)

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -1,0 +1,100 @@
+package project
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectCISafetyCheck(t *testing.T) {
+	t.Run("allows dirty git working tree in CI", func(t *testing.T) {
+		root := newDirtyGitRepository(t)
+
+		err := projectCISafetyCheck(t.Context(), root, false, mapGetenv(map[string]string{"CI": "true"}))
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows dirty git working tree with force", func(t *testing.T) {
+		root := newDirtyGitRepository(t)
+
+		err := projectCISafetyCheck(t.Context(), root, true, mapGetenv(nil))
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects dirty git working tree outside CI without force", func(t *testing.T) {
+		root := newDirtyGitRepository(t)
+
+		err := projectCISafetyCheck(t.Context(), root, false, mapGetenv(nil))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project ci removes source files")
+		assert.Contains(t, err.Error(), "--force")
+	})
+
+	t.Run("allows clean git working tree outside CI without force", func(t *testing.T) {
+		root := newCleanGitRepository(t)
+
+		err := projectCISafetyCheck(t.Context(), root, false, mapGetenv(nil))
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestIsCIEnvironment(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{name: "CI true", env: map[string]string{"CI": "true"}, want: true},
+		{name: "GitHub Actions", env: map[string]string{"GITHUB_ACTIONS": "true"}, want: true},
+		{name: "GitLab CI", env: map[string]string{"GITLAB_CI": "true"}, want: true},
+		{name: "Jenkins", env: map[string]string{"JENKINS_URL": "https://jenkins.example"}, want: true},
+		{name: "no CI", env: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCIEnvironment(mapGetenv(tt.env)))
+		})
+	}
+}
+
+func newDirtyGitRepository(t *testing.T) string {
+	t.Helper()
+
+	root := newCleanGitRepository(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "untracked.txt"), []byte("local work"), 0o644))
+
+	return root
+}
+
+func newCleanGitRepository(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	runGit(t, root, "init")
+
+	return root
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v failed: %s", args, output)
+}
+
+func mapGetenv(env map[string]string) func(string) string {
+	return func(key string) string {
+		return env[key]
+	}
+}

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -46,26 +46,6 @@ func TestProjectCISafetyCheck(t *testing.T) {
 	})
 }
 
-func TestIsCIEnvironment(t *testing.T) {
-	tests := []struct {
-		name string
-		env  map[string]string
-		want bool
-	}{
-		{name: "CI true", env: map[string]string{"CI": "true"}, want: true},
-		{name: "GitHub Actions", env: map[string]string{"GITHUB_ACTIONS": "true"}, want: true},
-		{name: "GitLab CI", env: map[string]string{"GITLAB_CI": "true"}, want: true},
-		{name: "Jenkins", env: map[string]string{"JENKINS_URL": "https://jenkins.example"}, want: true},
-		{name: "no CI", env: nil, want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isCIEnvironment(mapGetenv(tt.env)))
-		})
-	}
-}
-
 func newDirtyGitRepository(t *testing.T) string {
 	t.Helper()
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -194,6 +195,31 @@ func unshallowRepository(ctx context.Context, repo string) error {
 	_, err := runGit(ctx, repo, "fetch", "--unshallow")
 
 	return err
+}
+
+func IsWorkingTreeDirty(ctx context.Context, repo string) (bool, bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "rev-parse", "--is-inside-work-tree") //nolint:gosec
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, false, nil
+		}
+
+		return false, false, fmt.Errorf("checking git repository: %w", err)
+	}
+
+	if strings.TrimSpace(string(output)) != "true" {
+		return false, false, nil
+	}
+
+	statusCmd := exec.CommandContext(ctx, "git", "-C", repo, "status", "--porcelain", "--untracked-files=all") //nolint:gosec
+	status, err := statusCmd.Output()
+	if err != nil {
+		return false, true, fmt.Errorf("checking git working tree status: %w", err)
+	}
+
+	return strings.TrimSpace(string(status)) != "", true, nil
 }
 
 func Init(ctx context.Context, repo string) error {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -94,6 +94,39 @@ func TestGetPublicVCSURL(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestIsWorkingTreeDirty(t *testing.T) {
+	t.Run("clean git working tree", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		prepareRepository(t, tmpDir)
+
+		dirty, isGitRepository, err := IsWorkingTreeDirty(t.Context(), tmpDir)
+
+		assert.NoError(t, err)
+		assert.True(t, isGitRepository)
+		assert.False(t, dirty)
+	})
+
+	t.Run("dirty git working tree", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		prepareRepository(t, tmpDir)
+		assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, "untracked.txt"), []byte("local work"), 0o644))
+
+		dirty, isGitRepository, err := IsWorkingTreeDirty(t.Context(), tmpDir)
+
+		assert.NoError(t, err)
+		assert.True(t, isGitRepository)
+		assert.True(t, dirty)
+	})
+
+	t.Run("not a git repository", func(t *testing.T) {
+		dirty, isGitRepository, err := IsWorkingTreeDirty(t.Context(), t.TempDir())
+
+		assert.NoError(t, err)
+		assert.False(t, isGitRepository)
+		assert.False(t, dirty)
+	})
+}
+
 func runCommand(t *testing.T, tmpDir string, args ...string) {
 	t.Helper()
 

--- a/internal/system/ci.go
+++ b/internal/system/ci.go
@@ -1,0 +1,28 @@
+package system
+
+import "strings"
+
+func IsCIEnvironment(getenv func(string) string) bool {
+	if strings.EqualFold(getenv("CI"), "true") {
+		return true
+	}
+
+	ciEnvVars := []string{
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"JENKINS_URL",
+		"BUILDKITE",
+		"CIRCLECI",
+		"DRONE",
+		"TEAMCITY_VERSION",
+		"TF_BUILD",
+	}
+
+	for _, envVar := range ciEnvVars {
+		if getenv(envVar) != "" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/system/ci_test.go
+++ b/internal/system/ci_test.go
@@ -1,0 +1,33 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCIEnvironment(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{name: "CI true", env: map[string]string{"CI": "true"}, want: true},
+		{name: "GitHub Actions", env: map[string]string{"GITHUB_ACTIONS": "true"}, want: true},
+		{name: "GitLab CI", env: map[string]string{"GITLAB_CI": "true"}, want: true},
+		{name: "Jenkins", env: map[string]string{"JENKINS_URL": "https://jenkins.example"}, want: true},
+		{name: "no CI", env: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsCIEnvironment(mapGetenv(tt.env)))
+		})
+	}
+}
+
+func mapGetenv(env map[string]string) func(string) string {
+	return func(key string) string {
+		return env[key]
+	}
+}


### PR DESCRIPTION
## Summary
- Add a `--force` flag to `project ci` for intentional local execution
- Detect common CI environments and preserve existing CI behavior
- Refuse to run outside CI when the target project has a dirty git working tree, with an explicit warning about destructive cleanup
- Add regression coverage for CI, force, dirty, and clean worktree cases

Closes #1071

## Test Plan
- `go test ./cmd/project -count=1`
- `go test ./...`
- `go vet ./...`
- Built local binary and verified `project ci` rejects a dirty git worktree before continuing