### PR TITLE
Add interactive multi-select picker for extension filtering

### DIFF
--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/extension"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/logging"
 )
 
@@ -86,6 +87,15 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 	skipExtensions, _ := cmd.PersistentFlags().GetString("skip-extensions")
 	onlyCustomStatic, _ := cmd.PersistentFlags().GetBool("only-custom-static-extensions")
 
+	// When --only-extensions is passed without a value, present an interactive
+	// multi-select picker instead of requiring the names upfront.
+	if cmd.PersistentFlags().Changed("only-extensions") && strings.TrimSpace(onlyExtensions) == "" {
+		onlyExtensions, err = selectExtensionsInteractively(cmd, sources)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if onlyExtensions != "" && skipExtensions != "" {
 		return nil, fmt.Errorf("only-extensions and skip-extensions cannot be used together")
 	}
@@ -155,4 +165,36 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 	}
 
 	return sources, nil
+}
+
+// selectExtensionsInteractively presents a filterable multi-select picker of
+// all available extensions and returns the chosen names as a comma-separated
+// string suitable for the --only-extensions filter. The Storefront bundle is
+// omitted from the list as it is always kept by the filter.
+func selectExtensionsInteractively(cmd *cobra.Command, sources []asset.Source) (string, error) {
+	items := make([]tui.FilterMultiSelectItem, 0, len(sources))
+	for _, s := range sources {
+		if s.Name == storefrontBundleName {
+			continue
+		}
+		items = append(items, tui.FilterMultiSelectItem{Label: s.Name, Detail: s.Path, Value: s.Name})
+	}
+
+	if len(items) == 0 {
+		return "", fmt.Errorf("no extensions available to select")
+	}
+
+	selected, err := tui.FilterMultiSelect(cmd.Context(),
+		"Which extensions should be included?",
+		"Type to filter, space to toggle, enter to confirm.",
+		items)
+	if err != nil {
+		return "", err
+	}
+
+	if len(selected) == 0 {
+		return "", fmt.Errorf("no extensions selected")
+	}
+
+	return strings.Join(selected, ","), nil
 }

--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -83,7 +83,8 @@ func init() {
 	projectRootCmd.AddCommand(projectAdminBuildCmd)
 	projectAdminBuildCmd.PersistentFlags().Bool("skip-assets-install", false, "Skips the assets installation")
 	projectAdminBuildCmd.PersistentFlags().Bool("force-install-dependencies", false, "Force install NPM dependencies")
-	projectAdminBuildCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
+	projectAdminBuildCmd.PersistentFlags().String("only-extensions", "", "Only build the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
+	projectAdminBuildCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
 	projectAdminBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectAdminBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }

--- a/cmd/project/project_admin_watch.go
+++ b/cmd/project/project_admin_watch.go
@@ -61,7 +61,8 @@ var projectAdminWatchCmd = &cobra.Command{
 
 func init() {
 	projectRootCmd.AddCommand(projectAdminWatchCmd)
-	projectAdminWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
+	projectAdminWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
+	projectAdminWatchCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
 	projectAdminWatchCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectAdminWatchCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -90,7 +90,8 @@ func init() {
 	projectStorefrontBuildCmd.PersistentFlags().Bool("skip-assets-install", false, "Skips the assets installation")
 	projectStorefrontBuildCmd.PersistentFlags().Bool("skip-theme-compile", false, "Skip theme compilation")
 	projectStorefrontBuildCmd.PersistentFlags().Bool("force-install-dependencies", false, "Force install NPM dependencies")
-	projectStorefrontBuildCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
+	projectStorefrontBuildCmd.PersistentFlags().String("only-extensions", "", "Only build the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
+	projectStorefrontBuildCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
 	projectStorefrontBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectStorefrontBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }

--- a/cmd/project/project_storefront_watch.go
+++ b/cmd/project/project_storefront_watch.go
@@ -75,7 +75,8 @@ var projectStorefrontWatchCmd = &cobra.Command{
 
 func init() {
 	projectRootCmd.AddCommand(projectStorefrontWatchCmd)
-	projectStorefrontWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
+	projectStorefrontWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
+	projectStorefrontWatchCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
 	projectStorefrontWatchCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectStorefrontWatchCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 	projectStorefrontWatchCmd.PersistentFlags().String("sales-channel", "", "Sales channel ID to target with theme:dump. Pass without a value (--sales-channel) to pick interactively. Omit the flag entirely to keep the legacy theme:dump behavior")

--- a/internal/tui/filter_multi_select.go
+++ b/internal/tui/filter_multi_select.go
@@ -1,0 +1,251 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// FilterMultiSelectItem is a single row presented by FilterMultiSelect. Label
+// is the primary text, Detail is an optional secondary line (e.g. a path).
+// Both are matched against the filter query. Value is the string returned when
+// the user selects this item.
+type FilterMultiSelectItem struct {
+	Label  string
+	Detail string
+	Value  string
+}
+
+// FilterMultiSelect renders an interactive picker with a type-to-filter input
+// and a windowed list that allows toggling multiple items. It returns the
+// chosen Values in the original item order, or ErrFilterSelectCancelled if the
+// user dismisses the prompt.
+//
+// Use it from CLI commands that need to pick several entries from a list that
+// may be small or huge. For single selection use FilterSelect instead.
+func FilterMultiSelect(ctx context.Context, title, help string, items []FilterMultiSelectItem) ([]string, error) {
+	if len(items) == 0 {
+		return nil, errors.New("no items to choose from")
+	}
+
+	ti := textinput.New()
+	ti.Prompt = lipgloss.NewStyle().Foreground(BrandColor).Render("> ")
+	ti.Placeholder = "Type to filter"
+	ti.CharLimit = 64
+	ti.Focus()
+
+	m := &filterMultiSelectModel{
+		title:    title,
+		help:     help,
+		items:    items,
+		filter:   ti,
+		pageSize: filterSelectPageSize,
+		selected: make(map[int]bool, len(items)),
+	}
+	m.applyFilter()
+
+	p := tea.NewProgram(m, tea.WithContext(ctx))
+	final, err := p.Run()
+	if err != nil {
+		return nil, err
+	}
+	res := final.(*filterMultiSelectModel)
+	if res.cancelled {
+		return nil, ErrFilterSelectCancelled
+	}
+
+	chosen := make([]string, 0, len(res.selected))
+	for i, it := range res.items {
+		if res.selected[i] {
+			chosen = append(chosen, it.Value)
+		}
+	}
+	return chosen, nil
+}
+
+type filterMultiSelectModel struct {
+	title    string
+	help     string
+	items    []FilterMultiSelectItem
+	filter   textinput.Model
+	filtered []int
+	selected map[int]bool
+	cursor   int
+	scroll   int
+	pageSize int
+
+	cancelled bool
+	width     int
+}
+
+func (m *filterMultiSelectModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m *filterMultiSelectModel) applyFilter() {
+	query := strings.ToLower(m.filter.Value())
+	m.filtered = m.filtered[:0]
+	for i, it := range m.items {
+		if query == "" ||
+			strings.Contains(strings.ToLower(it.Label), query) ||
+			strings.Contains(strings.ToLower(it.Detail), query) {
+			m.filtered = append(m.filtered, i)
+		}
+	}
+	if m.cursor >= len(m.filtered) {
+		m.cursor = max(len(m.filtered)-1, 0)
+	}
+	m.clampScroll()
+}
+
+func (m *filterMultiSelectModel) clampScroll() {
+	if m.cursor < m.scroll {
+		m.scroll = m.cursor
+	}
+	if m.cursor >= m.scroll+m.pageSize {
+		m.scroll = m.cursor - m.pageSize + 1
+	}
+	if m.scroll < 0 {
+		m.scroll = 0
+	}
+}
+
+func (m *filterMultiSelectModel) toggle() {
+	if len(m.filtered) == 0 {
+		return
+	}
+	idx := m.filtered[m.cursor]
+	if m.selected[idx] {
+		delete(m.selected, idx)
+	} else {
+		m.selected[idx] = true
+	}
+}
+
+func (m *filterMultiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "esc", "ctrl+c":
+			m.cancelled = true
+			return m, tea.Quit
+		case "enter":
+			return m, tea.Quit
+		case "space", " ":
+			m.toggle()
+			return m, nil
+		case "up":
+			if m.cursor > 0 {
+				m.cursor--
+				m.clampScroll()
+			}
+			return m, nil
+		case "down":
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+				m.clampScroll()
+			}
+			return m, nil
+		}
+
+		var cmd tea.Cmd
+		m.filter, cmd = m.filter.Update(msg)
+		m.applyFilter()
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *filterMultiSelectModel) View() tea.View {
+	return tea.NewView(m.render())
+}
+
+func (m *filterMultiSelectModel) render() string {
+	innerWidth := m.width - 6
+	if innerWidth < 30 {
+		innerWidth = 60
+	}
+	if innerWidth > 100 {
+		innerWidth = 100
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(BrandColor)
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(m.title))
+	b.WriteString("\n")
+	if m.help != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(MutedColor).Render(m.help))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(m.filter.View())
+	b.WriteString("\n\n")
+
+	selectedStyle := lipgloss.NewStyle().
+		Foreground(BrandColor).
+		Background(SelectedBgColor).
+		Bold(true).
+		Width(innerWidth)
+	normalStyle := lipgloss.NewStyle().
+		Foreground(TextColor).
+		Width(innerWidth)
+	detailStyle := lipgloss.NewStyle().Foreground(MutedColor)
+	selectedDetailStyle := lipgloss.NewStyle().
+		Foreground(MutedColor).
+		Background(SelectedBgColor)
+
+	end := m.scroll + m.pageSize
+	if end > len(m.filtered) {
+		end = len(m.filtered)
+	}
+	for i := m.scroll; i < end; i++ {
+		idx := m.filtered[i]
+		item := m.items[idx]
+		rowStyle, dStyle := normalStyle, detailStyle
+		if i == m.cursor {
+			rowStyle, dStyle = selectedStyle, selectedDetailStyle
+		}
+		check := "[ ] "
+		if m.selected[idx] {
+			check = "[x] "
+		}
+		label := check + item.Label
+		if item.Detail != "" {
+			gap := max(innerWidth-lipgloss.Width(label)-lipgloss.Width(item.Detail), 1)
+			b.WriteString(rowStyle.Render(label + strings.Repeat(" ", gap) + dStyle.Render(item.Detail)))
+		} else {
+			b.WriteString(rowStyle.Render(label))
+		}
+		b.WriteString("\n")
+	}
+	if len(m.filtered) == 0 {
+		b.WriteString(detailStyle.Render("No matching items"))
+		b.WriteString("\n")
+	} else if len(m.filtered) > m.pageSize {
+		b.WriteString(detailStyle.Render("Showing " + strconv.Itoa(m.scroll+1) + "–" + strconv.Itoa(end) + " of " + strconv.Itoa(len(m.filtered))))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(detailStyle.Render(strconv.Itoa(len(m.selected)) + " selected"))
+	b.WriteString("\n")
+
+	b.WriteString("\n")
+	b.WriteString(ShortcutBar(
+		Shortcut{Key: "↑/↓", Label: "Move"},
+		Shortcut{Key: "space", Label: "Toggle"},
+		Shortcut{Key: "enter", Label: "Confirm"},
+		Shortcut{Key: "esc", Label: "Cancel"},
+	))
+
+	return b.String()
+}

--- a/internal/tui/filter_multi_select_test.go
+++ b/internal/tui/filter_multi_select_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestMultiModel(items []FilterMultiSelectItem) *filterMultiSelectModel {
+	ti := textinput.New()
+	ti.Focus()
+	m := &filterMultiSelectModel{items: items, filter: ti, pageSize: 10, selected: map[int]bool{}}
+	m.applyFilter()
+	return m
+}
+
+func TestFilterMultiSelect_FilterMatchesLabelAndDetail(t *testing.T) {
+	m := newTestMultiModel([]FilterMultiSelectItem{
+		{Label: "MyPlugin", Detail: "custom/plugins/MyPlugin", Value: "MyPlugin"},
+		{Label: "OtherPlugin", Detail: "custom/static-plugins/OtherPlugin", Value: "OtherPlugin"},
+		{Label: "Swag", Detail: "custom/plugins/Swag", Value: "Swag"},
+	})
+
+	m.filter.SetValue("static")
+	m.applyFilter()
+	assert.Len(t, m.filtered, 1, "filter should match Detail (path)")
+	assert.Equal(t, 1, m.filtered[0])
+
+	m.filter.SetValue("swag")
+	m.applyFilter()
+	assert.Len(t, m.filtered, 1, "filter should match Label")
+	assert.Equal(t, 2, m.filtered[0])
+
+	m.filter.SetValue("")
+	m.applyFilter()
+	assert.Len(t, m.filtered, 3, "empty filter keeps all items")
+}
+
+func TestFilterMultiSelect_SpaceTogglesSelection(t *testing.T) {
+	m := newTestMultiModel([]FilterMultiSelectItem{
+		{Label: "A", Value: "a"},
+		{Label: "B", Value: "b"},
+		{Label: "C", Value: "c"},
+	})
+
+	// Toggle first item.
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
+	assert.True(t, m.selected[0])
+
+	// Move to third item and toggle it.
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
+	assert.True(t, m.selected[2])
+
+	// Toggle first item off again.
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
+	assert.False(t, m.selected[0])
+
+	assert.Len(t, m.selected, 1)
+}
+
+func TestFilterMultiSelect_SelectionSurvivesFiltering(t *testing.T) {
+	m := newTestMultiModel([]FilterMultiSelectItem{
+		{Label: "MyPlugin", Value: "MyPlugin"},
+		{Label: "OtherPlugin", Value: "OtherPlugin"},
+	})
+
+	// Select first item.
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
+	assert.True(t, m.selected[0])
+
+	// Filter to hide it, then clear the filter — selection must persist.
+	m.filter.SetValue("Other")
+	m.applyFilter()
+	assert.Len(t, m.filtered, 1)
+	m.filter.SetValue("")
+	m.applyFilter()
+	assert.True(t, m.selected[0], "selection should survive filtering")
+}
+
+func TestFilterMultiSelect_EnterConfirms(t *testing.T) {
+	m := newTestMultiModel([]FilterMultiSelectItem{{Label: "Only", Value: "only"}})
+
+	_, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace}))
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.NotNil(t, cmd, "enter should produce a Quit cmd")
+	assert.False(t, m.cancelled)
+	assert.True(t, m.selected[0])
+}
+
+func TestFilterMultiSelect_EscCancels(t *testing.T) {
+	m := newTestMultiModel([]FilterMultiSelectItem{{Label: "Only", Value: "only"}})
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
+	assert.NotNil(t, cmd)
+	assert.True(t, m.cancelled)
+}


### PR DESCRIPTION
## Summary
Adds a new interactive terminal UI component for selecting multiple extensions, allowing users to filter and toggle extensions interactively instead of requiring comma-separated names upfront.

## Key Changes
- **New TUI Component**: `FilterMultiSelect` in `internal/tui/filter_multi_select.go`
  - Renders a filterable, windowed list with checkbox-style selection
  - Supports type-to-filter matching against both label and detail fields
  - Keyboard navigation (↑/↓ to move, space to toggle, enter to confirm, esc to cancel)
  - Displays selection count and pagination info
  - Maintains selections across filter changes

- **Comprehensive Tests**: `internal/tui/filter_multi_select_test.go`
  - Filter matching against label and detail fields
  - Space-based toggle selection
  - Selection persistence through filtering
  - Enter/Esc confirmation and cancellation

- **Integration with Project Commands**: `cmd/project/platform.go`
  - New `selectExtensionsInteractively()` function that presents the picker when `--only-extensions` flag is passed without a value
  - Converts selected extensions to comma-separated format for existing filter logic
  - Omits Storefront bundle from selection (always kept by filter)

- **Flag Documentation Updates**: Updated `--only-extensions` flag descriptions in:
  - `project_admin_build.go`
  - `project_admin_watch.go`
  - `project_storefront_build.go`
  - `project_storefront_watch.go`

## Implementation Details
- Uses Bubble Tea for TUI rendering with Lipgloss for styling
- Maintains original item order when returning selected values
- Gracefully handles empty item lists and no matches
- Integrates seamlessly with existing extension filtering logic

https://claude.ai/code/session_01SN9rEofkYtKfDioG9RLYoV