### PR TITLE
Declare missing typescript dependency

### DIFF
--- a/internal/verifier/js/package.json
+++ b/internal/verifier/js/package.json
@@ -23,6 +23,7 @@
 		"stylelint-config-recommended-scss": "^17.0.0",
 		"stylelint-config-standard": "^40.0.0",
 		"stylelint-scss": "^7.0.0",
+		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.56.0",
 		"vitest": "^4.0.6",
 		"vue-eslint-parser": "^10.1.1"


### PR DESCRIPTION
## Summary
Declares the missing `typescript` dependency.

## Problem reproduction
The candidate reports a missing-module failure. Running `npm test -- --runInBand` reproduced or confirmed the missing `typescript` dependency path.

## Fix
Added `typescript` to devDependencies with the current npm version.

## Validation
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `npm test -- --runInBand`

## Known limitations
None for the scoped fix.

## Safety
This change uses only public repository/package metadata, public source files, and local validation commands.