### PR TITLE
Add glob wildcard support to NoData and Ignore table filters

### DIFF
--- a/internal/mysqldump/mysql.go
+++ b/internal/mysqldump/mysql.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"regexp"
 	"slices"
 	"strings"
@@ -22,9 +23,9 @@ type Dumper struct {
 	SelectMap map[string]map[string]string
 	// WhereMap contains WHERE clauses per table (table -> WHERE clause)
 	WhereMap map[string]string
-	// NoData contains list of tables to dump structure only (no data)
+	// NoData contains list of tables to dump structure only (no data), supports glob wildcards (e.g. "cart*")
 	NoData []string
-	// Ignore contains list of tables to skip entirely
+	// Ignore contains list of tables to skip entirely, supports glob wildcards (e.g. "cart*")
 	Ignore    []string
 	filterMap map[string]string
 	// LockTables controls whether to lock tables during dump (default: true)
@@ -77,12 +78,9 @@ func (d *Dumper) Dump(ctx context.Context, w io.Writer) error {
 		return err
 	}
 
-	d.filterMap = make(map[string]string)
-	for _, table := range d.NoData {
-		d.filterMap[strings.ToLower(table)] = NoDataMapPlacement
-	}
-	for _, table := range d.Ignore {
-		d.filterMap[strings.ToLower(table)] = IgnoreMapPlacement
+	d.filterMap, err = buildFilterMap(tables, d.NoData, d.Ignore)
+	if err != nil {
+		return err
 	}
 
 	tablesToDump := make([]string, 0, len(tables))
@@ -121,6 +119,62 @@ func (d *Dumper) Dump(ctx context.Context, w io.Writer) error {
 	}
 
 	return err
+}
+
+// buildFilterMap maps lowercased table names to their placement (nodata or
+// ignore). Entries may contain glob wildcards ('*', '?', '[...]'), which are
+// expanded against the actual table list. Ignore wins over NoData when both
+// match a table.
+func buildFilterMap(tables, noData, ignore []string) (map[string]string, error) {
+	filterMap := make(map[string]string)
+
+	for _, pattern := range noData {
+		matches, err := expandTablePattern(pattern, tables)
+		if err != nil {
+			return nil, err
+		}
+		for _, table := range matches {
+			filterMap[table] = NoDataMapPlacement
+		}
+	}
+
+	for _, pattern := range ignore {
+		matches, err := expandTablePattern(pattern, tables)
+		if err != nil {
+			return nil, err
+		}
+		for _, table := range matches {
+			filterMap[table] = IgnoreMapPlacement
+		}
+	}
+
+	return filterMap, nil
+}
+
+// expandTablePattern returns the lowercased table names matching the given
+// glob pattern, case-insensitively. Patterns without wildcards are returned
+// verbatim so they don't have to exist in the table list.
+func expandTablePattern(pattern string, tables []string) ([]string, error) {
+	pattern = strings.ToLower(pattern)
+
+	if !strings.ContainsAny(pattern, "*?[") {
+		return []string{pattern}, nil
+	}
+
+	matches := make([]string, 0)
+	for _, table := range tables {
+		table = strings.ToLower(table)
+		ok, err := path.Match(pattern, table)
+		if err != nil {
+			return nil, fmt.Errorf("invalid table pattern %q: %w", pattern, err)
+		}
+
+		if ok {
+			matches = append(matches, table)
+		}
+	}
+
+	return matches, nil
 }
 
 func (d *Dumper) dumpTablesSequential(ctx context.Context, w io.Writer, tables []string) error {

--- a/internal/mysqldump/mysql_test.go
+++ b/internal/mysqldump/mysql_test.go
@@ -772,6 +772,177 @@ func Test_mySQL_ignoresTable(t *testing.T) {
 	}
 }
 
+func Test_expandTablePattern(t *testing.T) {
+	tables := []string{"cart", "customer", "customer_address", "OLD_table", "order_customer"}
+
+	tests := []struct {
+		name    string
+		pattern string
+		want    []string
+		wantErr bool
+	}{
+		{"exact name", "cart", []string{"cart"}, false},
+		{"exact name not in table list", "not_existing", []string{"not_existing"}, false},
+		{"exact name is case-insensitive", "old_TABLE", []string{"old_table"}, false},
+		{"prefix wildcard", "customer*", []string{"customer", "customer_address"}, false},
+		{"suffix wildcard", "*customer", []string{"customer", "order_customer"}, false},
+		{"wildcard is case-insensitive", "OLD_*", []string{"old_table"}, false},
+		{"wildcard without matches", "product*", []string{}, false},
+		{"single character wildcard", "car?", []string{"cart"}, false},
+		{"invalid pattern", "customer[", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandTablePattern(tt.pattern, tables)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+				return
+			}
+			assert.Nil(t, err)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func Test_buildFilterMap(t *testing.T) {
+	tables := []string{"cart", "customer", "customer_address", "order_customer"}
+
+	filterMap, err := buildFilterMap(tables, []string{"customer*"}, []string{"cart", "customer_address"})
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{
+		"cart":             IgnoreMapPlacement,
+		"customer":         NoDataMapPlacement,
+		"customer_address": IgnoreMapPlacement,
+	}, filterMap)
+}
+
+func Test_mySQL_ignoresTableWildcard(t *testing.T) {
+	db, mock := getDB(t)
+
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("OLD_table", "BASE TABLE").
+			AddRow("OLD_archive", "BASE TABLE"),
+	)
+
+	// Mock batch prefetch queries (all tables are ignored, so no schemas to prefetch)
+	mockPrefetchSchemas(mock)
+
+	// Expect SHOW FULL TABLES query for views
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}),
+	)
+
+	// Expect SHOW TRIGGERS query since triggers are dumped by default
+	mock.ExpectQuery("SHOW TRIGGERS").WillReturnRows(
+		sqlmock.NewRows([]string{"Trigger", "Event", "Table", "Statement", "Timing", "Created", "sql_mode", "Definer", "character_set_client", "collation_connection", "Database Collation"}),
+	)
+
+	dumper := getInternalMySQLInstance(db)
+
+	dumper.Ignore = []string{"old_*"}
+
+	b := new(strings.Builder)
+
+	err := dumper.Dump(t.Context(), b)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := "SET NAMES utf8mb4;\nSET FOREIGN_KEY_CHECKS = 0;\n\nSET FOREIGN_KEY_CHECKS = 1;\n"
+	if b.String() != expected {
+		t.Errorf("No tables should be dumped, expected:\n%s\ngot:\n%s", expected, b.String())
+	}
+}
+
+func Test_mySQL_noDataTableWildcard(t *testing.T) {
+	db, mock := getDB(t)
+
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("customer", "BASE TABLE").
+			AddRow("customer_address", "BASE TABLE"),
+	)
+
+	// Mock batch prefetch queries with both tables
+	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.TABLES.*TABLE_TYPE = 'BASE TABLE'").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME", "ENGINE", "TABLE_COLLATION", "TABLE_COMMENT", "ROW_FORMAT", "AUTO_INCREMENT"}).
+			AddRow("customer", "InnoDB", "utf8mb4_unicode_ci", "", "Dynamic", nil).
+			AddRow("customer_address", "InnoDB", "utf8mb4_unicode_ci", "", "Dynamic", nil))
+
+	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.COLUMNS.*WHERE TABLE_SCHEMA = DATABASE()").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_NAME", "COLUMN_NAME", "COLUMN_TYPE", "CHARACTER_SET_NAME", "IS_NULLABLE", "COLUMN_DEFAULT",
+			"EXTRA", "COLLATION_NAME", "COLUMN_COMMENT", "GENERATION_EXPRESSION",
+		}).
+			AddRow("customer", "id", "bigint(20)", nil, "NO", nil, "AUTO_INCREMENT", nil, "", nil).
+			AddRow("customer_address", "id", "bigint(20)", nil, "NO", nil, "AUTO_INCREMENT", nil, "", nil))
+
+	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.STATISTICS.*WHERE TABLE_SCHEMA = DATABASE()").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_NAME", "INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "INDEX_TYPE", "SUB_PART", "COLLATION", "INDEX_COMMENT", "SEQ_IN_INDEX",
+		}))
+
+	mock.ExpectQuery("SELECT COUNT.*KEY_COLUMN_USAGE.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+	mock.ExpectQuery("SELECT COUNT.*REFERENTIAL_CONSTRAINTS.*").
+		WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(0))
+
+	mock.ExpectQuery("SELECT DISTINCT.*FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE.*").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_NAME", "CONSTRAINT_NAME", "COLUMN_NAME", "REFERENCED_TABLE_NAME",
+			"REFERENCED_COLUMN_NAME", "UPDATE_RULE", "DELETE_RULE", "ORDINAL_POSITION",
+		}))
+
+	mock.ExpectQuery("SELECT.*FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS.*CHECK_CONSTRAINTS.*").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"TABLE_NAME", "CONSTRAINT_NAME", "CHECK_CLAUSE",
+		}))
+
+	// Expect SHOW FULL TABLES query for views
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}),
+	)
+
+	// Expect SHOW TRIGGERS query since triggers are dumped by default
+	mock.ExpectQuery("SHOW TRIGGERS").WillReturnRows(
+		sqlmock.NewRows([]string{"Trigger", "Event", "Table", "Statement", "Timing", "Created", "sql_mode", "Definer", "character_set_client", "collation_connection", "Database Collation"}),
+	)
+
+	dumper := getInternalMySQLInstance(db)
+
+	dumper.NoData = []string{"customer*"}
+
+	b := new(strings.Builder)
+
+	err := dumper.Dump(t.Context(), b)
+	assert.Nil(t, err)
+
+	assert.Contains(t, b.String(), "CREATE TABLE `customer`")
+	assert.Contains(t, b.String(), "CREATE TABLE `customer_address`")
+	assert.NotContains(t, b.String(), "INSERT INTO")
+	assert.NotContains(t, b.String(), "Data for table")
+}
+
+func Test_mySQL_invalidTablePattern(t *testing.T) {
+	db, mock := getDB(t)
+
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("customer", "BASE TABLE"),
+	)
+
+	dumper := getInternalMySQLInstance(db)
+
+	dumper.NoData = []string{"customer["}
+
+	err := dumper.Dump(t.Context(), new(strings.Builder))
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid table pattern")
+}
+
 func Test_mySQL_dumpsTriggers(t *testing.T) {
 	db, mock := getDB(t)
 

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -201,9 +201,9 @@ type ConfigAdminApi struct {
 type ConfigDump struct {
 	// Allows to rewrite single columns, perfect for GDPR compliance
 	Rewrite map[string]map[string]string `yaml:"rewrite,omitempty"`
-	// Only export the schema of these tables
+	// Only export the schema of these tables, supports glob wildcards (e.g. "customer*")
 	NoData []string `yaml:"nodata,omitempty"`
-	// Ignore these tables from export
+	// Ignore these tables from export, supports glob wildcards (e.g. "customer*")
 	Ignore []string `yaml:"ignore,omitempty"`
 	// Add an where condition to that table, schema is table name as key, and where statement as value
 	Where map[string]string `yaml:"where,omitempty"`

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -403,14 +403,14 @@
             "type": "string"
           },
           "type": "array",
-          "description": "Only export the schema of these tables"
+          "description": "Only export the schema of these tables, supports glob wildcards (e.g. \"customer*\")"
         },
         "ignore": {
           "items": {
             "type": "string"
           },
           "type": "array",
-          "description": "Ignore these tables from export"
+          "description": "Ignore these tables from export, supports glob wildcards (e.g. \"customer*\")"
         },
         "where": {
           "additionalProperties": {


### PR DESCRIPTION
## Summary
Adds support for glob wildcard patterns (e.g., `customer*`, `*_archive`, `old_?`) in the `NoData` and `Ignore` table filter lists for database dumps. This allows users to match multiple tables with a single pattern instead of listing each table individually.

## Key Changes
- **New `expandTablePattern()` function**: Expands glob patterns against the actual table list, supporting `*`, `?`, and `[...]` wildcards. Patterns without wildcards are returned verbatim to allow non-existent table names. Matching is case-insensitive.
- **New `buildFilterMap()` function**: Builds the filter map by expanding all patterns in `NoData` and `Ignore` lists. `Ignore` patterns take precedence when both match a table.
- **Updated `Dumper.Dump()` method**: Now uses `buildFilterMap()` to process patterns instead of simple string mapping.
- **Documentation updates**: Updated comments in `ConfigDump` struct and JSON schema to indicate wildcard support.

## Implementation Details
- Uses Go's `path.Match()` for glob pattern matching (standard library)
- All table names and patterns are normalized to lowercase for case-insensitive matching
- Invalid patterns (e.g., unclosed brackets) return an error with context
- Comprehensive test coverage including:
  - Pattern expansion with various wildcard types
  - Filter map building with overlapping patterns
  - Integration tests for wildcard-based ignore and nodata filters
  - Error handling for invalid patterns

https://claude.ai/code/session_012P9LW5x7MB5vS3jaUB4m6c