### PR TITLE
fix(project): run docker as host user with project dir group

### DIFF
--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -110,6 +110,8 @@ func runComposerInstall(ctx context.Context, projectFolder string, useDocker boo
 			"-v", fmt.Sprintf("%s:/app", absProjectFolder),
 			"-w", "/app"}
 
+		dockerArgs = append(dockerArgs, system.DockerRunUserArgs(absProjectFolder)...)
+
 		if system.IsDockerMountable() {
 			homeDir, err := os.UserHomeDir()
 			if err == nil {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/shopware/shopware-cli/internal/packagist"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/system"
 )
 
 const nodeVersion = "24"
@@ -37,6 +38,10 @@ type ComposeOptions struct {
 	BlackfireServerID    string
 	BlackfireServerToken string
 	TidewaysAPIKey       string
+	// User is the "uid:gid" the web container should run as so that
+	// writes to the bind-mounted project (var/, files/, public/, ...)
+	// are owned by the host user. Empty means: use the image default.
+	User string
 }
 
 func (o *ComposeOptions) phpVersion() string {
@@ -80,6 +85,13 @@ func GenerateComposeFile(lock *packagist.ComposerLock, opts *ComposeOptions) ([]
 }
 
 func WriteComposeFile(projectFolder string, opts *ComposeOptions) error {
+	if opts == nil {
+		opts = &ComposeOptions{}
+	}
+	if opts.User == "" {
+		opts.User = system.ProjectUserSpec(projectFolder)
+	}
+
 	lock, err := packagist.ReadComposerLock(filepath.Join(projectFolder, "composer.lock"))
 	if err != nil {
 		return fmt.Errorf("failed to read composer.lock: %w", err)
@@ -132,6 +144,9 @@ func buildCompose(hasAMQP, hasElasticsearch bool, opts *ComposeOptions) yaml.Nod
 
 	web := newMappingNode()
 	addKeyValue(web, "image", fmt.Sprintf("ghcr.io/shopware/docker-dev:php%s-node%s-caddy", opts.phpVersion(), nodeVersion))
+	if opts != nil && opts.User != "" {
+		addKeyValue(web, "user", opts.User)
+	}
 	addKeyValueNode(web, "ports", newSequenceNode(
 		"8000:8000", "8080:8080", "9999:9999", "9998:9998", "5173:5173", "5773:5773",
 	))

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -249,4 +249,35 @@ func TestGenerateComposeFile(t *testing.T) {
 		assert.Contains(t, compose, "MESSENGER_TRANSPORT_DSN")
 		assert.Contains(t, compose, "OPENSEARCH_URL")
 	})
+
+	t.Run("emits user when set", func(t *testing.T) {
+		t.Parallel()
+		lock := &packagist.ComposerLock{
+			Packages: []packagist.ComposerLockPackage{
+				{Name: "shopware/core", Version: "6.6.0.0"},
+			},
+		}
+
+		result, err := GenerateComposeFile(lock, &ComposeOptions{User: "1001:46"})
+		assert.NoError(t, err)
+
+		compose := string(result)
+		assert.Contains(t, compose, "user:")
+		assert.Contains(t, compose, "1001:46")
+	})
+
+	t.Run("no user key without User", func(t *testing.T) {
+		t.Parallel()
+		lock := &packagist.ComposerLock{
+			Packages: []packagist.ComposerLockPackage{
+				{Name: "shopware/core", Version: "6.6.0.0"},
+			},
+		}
+
+		result, err := GenerateComposeFile(lock, nil)
+		assert.NoError(t, err)
+
+		compose := string(result)
+		assert.NotContains(t, compose, "user:")
+	})
 }

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -10,6 +10,7 @@ import (
 
 	adminSdk "github.com/shopware/shopware-cli/internal/admin-api"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/system"
 )
 
 type DockerExecutor struct {
@@ -173,6 +174,15 @@ func (d *DockerExecutor) baseArgs() []string {
 	args := []string{"compose", "exec"}
 
 	args = append(args, "-T")
+
+	// When the web service runs as the mapped host user (see the compose
+	// user: directive derived from system.ProjectUserSpec), that UID has no
+	// passwd entry inside the image, so HOME is unset and tools like npm and
+	// composer fall back to / and fail with EACCES. Point HOME at a writable
+	// path, mirroring system.DockerRunUserArgs for the raw composer run.
+	if system.ProjectUserSpec(d.projectRoot) != "" {
+		args = append(args, "-e", "HOME=/tmp")
+	}
 
 	for k, v := range d.env {
 		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -201,6 +202,26 @@ func TestDockerExecutorNPMCommand(t *testing.T) {
 	assert.Contains(t, p.Cmd.Args, "npm")
 	assert.Contains(t, p.Cmd.Args, "run")
 	assert.Contains(t, p.Cmd.Args, "dev")
+}
+
+func TestDockerExecutorSetsHomeForMappedUser(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the user mapping and HOME redirect are Linux-only")
+	}
+
+	exec := &DockerExecutor{projectRoot: "/project"}
+
+	// Every container command must carry HOME=/tmp so that npm (install,
+	// run, exec) and composer do not fall back to / when the container runs
+	// as the mapped host UID with no passwd entry.
+	for _, p := range []*Process{
+		exec.NPMCommand(t.Context(), "install"),
+		exec.NPMCommand(t.Context(), "run", "build"),
+		exec.ComposerCommand(t.Context(), "install"),
+		exec.ConsoleCommand(t.Context(), "cache:clear"),
+	} {
+		assert.Contains(t, p.Cmd.Args, "HOME=/tmp")
+	}
 }
 
 func TestSymfonyCLIExecutorNPMCommand(t *testing.T) {

--- a/internal/system/docker_unix.go
+++ b/internal/system/docker_unix.go
@@ -4,9 +4,11 @@ package system
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 )
 
 func IsDockerMountable() bool {
@@ -14,11 +16,56 @@ func IsDockerMountable() bool {
 		return true
 	}
 
-	if runtime.GOOS == "linux" {
-		return os.Getuid() == 1000
+	// On Linux we always pass --user with the host UID/GID (see
+	// DockerRunUserArgs), so bind mounts are writable for any host user,
+	// not only UID 1000.
+	return runtime.GOOS == "linux"
+}
+
+// ProjectUserSpec returns the "uid:gid" the container should run as for
+// the given project directory: the calling user's UID combined with the
+// directory's owning group. Using the directory's group makes shared
+// setups work (e.g. a projects dir owned by a dev group with the setgid
+// bit): files created by the container belong to the shared group, so
+// other members can collaborate. Falls back to the caller's primary GID
+// when the directory cannot be inspected. Returns "" on non-Linux
+// platforms: only there do bind mounts expose raw host UIDs; Docker
+// Desktop's VM handles ownership mapping on macOS and Windows.
+func ProjectUserSpec(dir string) string {
+	if runtime.GOOS != "linux" {
+		return ""
 	}
 
-	return false
+	uid := os.Getuid()
+	gid := os.Getgid()
+	if uid < 0 || gid < 0 {
+		return ""
+	}
+
+	if fi, err := os.Stat(dir); err == nil {
+		if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+			gid = int(st.Gid)
+		}
+	}
+
+	return fmt.Sprintf("%d:%d", uid, gid)
+}
+
+// DockerRunUserArgs returns the arguments for a raw `docker run` so that
+// the container process runs as the host user with the project
+// directory's group. An arbitrary UID has no passwd entry inside the
+// image, which would leave HOME unset/unwritable, so HOME and
+// COMPOSER_HOME are pointed at a writable location.
+func DockerRunUserArgs(projectDir string) []string {
+	spec := ProjectUserSpec(projectDir)
+	if spec == "" {
+		return nil
+	}
+	return []string{
+		"--user", spec,
+		"-e", "HOME=/tmp",
+		"-e", "COMPOSER_HOME=/tmp/composer",
+	}
 }
 
 type dockerSettings struct {

--- a/internal/system/docker_windows.go
+++ b/internal/system/docker_windows.go
@@ -6,6 +6,17 @@ func IsDockerMountable() bool {
 	return false
 }
 
+// ProjectUserSpec returns "" on Windows: containers run via Docker
+// Desktop's VM and there is no host UID/GID to map.
+func ProjectUserSpec(dir string) string {
+	return ""
+}
+
+// DockerRunUserArgs returns nil on Windows (no UID mapping needed).
+func DockerRunUserArgs(projectDir string) []string {
+	return nil
+}
+
 func IsDockerUsingLibkrun() bool {
 	return false
 }


### PR DESCRIPTION
Fixes #1096
Refs shopware/shopware#15896

### Problem

`project create --docker` and `project dev` fail with **"Permission denied"** for any host user whose UID is not `1000` (composer cannot write `composer.lock` during create; `system:install` cannot write `var/log` during dev). The `ghcr.io/shopware/docker-dev` image runs as UID 1000, and on Linux bind mounts expose raw host ownership, so the containers cannot write into a project directory owned by any other user. See #1096 for full details.

### Approach

Run the containers as the calling host user (Linux only):

- **`internal/system/docker_unix.go`**: `IsDockerMountable()` no longer hard-codes `os.Getuid() == 1000` — with user mapping in place, bind mounts are writable for any host user. New helpers: `ProjectUserSpec(dir)` returns the `uid:gid` spec (caller's UID + the project directory's owning group), `DockerRunUserArgs(projectDir)` returns the `docker run` arguments (`--user` plus `HOME`/`COMPOSER_HOME` pointed at a writable location, since an arbitrary UID has no passwd entry inside the image).
- **`cmd/project/project_create_install.go`**: the composer `docker run` gets those user arguments.
- **`internal/docker/compose.go`**: `ComposeOptions` gains a `User` field, emitted as `user:` on the `web` service; `WriteComposeFile` defaults it to `ProjectUserSpec(projectFolder)`. All existing `WriteComposeFile` callers (`project create`, `project dev`, dev TUI) pick this up automatically.

Using the project directory's owning group as the GID keeps shared, group-owned multi-user dev directories working (e.g. a setgid projects dir owned by a dev group): files created by the container stay writable for the whole group.

The mapping is deliberately **Linux-only** (`ProjectUserSpec` returns `""` elsewhere): on macOS and Windows, Docker Desktop's VM handles bind-mount ownership, so the containers keep running with the image default user there and existing behavior is unchanged.

### Testing

- Two new sub-tests in `internal/docker/compose_test.go` cover the `user:` key emission (set vs. unset).
- `gofmt`, `go build ./...`, `golangci-lint run --timeout 4m` and the test suites for `internal/docker`, `internal/system` and `cmd/project` all pass locally.
- Verified locally against `0.16.0-alpha-3` on Ubuntu (host UID 1001).

### Open question for review

Whether the `docker-dev` image entrypoint starts cleanly as an arbitrary `uid:gid` (no passwd entry inside the container) — I will post the result of the first `docker compose up` with the generated `user:` key in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
