### PR TITLE
fix(project): validate admin password length in dev setup wizards

### DIFF
--- a/internal/devtui/install_wizard.go
+++ b/internal/devtui/install_wizard.go
@@ -1,6 +1,7 @@
 package devtui
 
 import (
+	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/progress"
@@ -11,6 +12,20 @@ import (
 
 	"github.com/shopware/shopware-cli/internal/tui"
 )
+
+// minAdminPasswordLength is the minimum admin password length enforced by the
+// Shopware core (user:create / system:install). Validating it here lets the
+// wizard reject too-short passwords up front instead of failing late during the
+// deployment-helper run.
+const minAdminPasswordLength = 8
+
+// validateAdminPassword mirrors the Shopware core password length requirement.
+func validateAdminPassword(password string) error {
+	if len([]rune(password)) < minAdminPasswordLength {
+		return fmt.Errorf("password must be at least %d characters long", minAdminPasswordLength)
+	}
+	return nil
+}
 
 type installStep int
 
@@ -55,6 +70,7 @@ type installWizard struct {
 	username        textinput.Model
 	password        textinput.Model
 	checkboxFocused bool
+	passwordErr     string
 }
 
 type installProgress struct {
@@ -191,6 +207,7 @@ func (m Model) updateInstallStepPassword(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	if m.install.checkboxFocused {
 		return m, nil
 	}
+	m.install.passwordErr = ""
 	var cmd tea.Cmd
 	m.install.password, cmd = m.install.password.Update(msg)
 	return m, cmd
@@ -205,6 +222,11 @@ func (m Model) handleInstallPasswordEnter() (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+	if err := validateAdminPassword(m.install.password.Value()); err != nil {
+		m.install.passwordErr = err.Error()
+		return m, nil
+	}
+	m.install.passwordErr = ""
 	m.install.password.Blur()
 	m.phase = phaseInstalling
 	m.overlayLines = nil
@@ -260,6 +282,10 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 		b.WriteString(tui.DimStyle.Render("Enter the password for the admin account (default: shopware)"))
 		b.WriteString("\n\n")
 		b.WriteString(m.install.password.View())
+		if m.install.passwordErr != "" {
+			b.WriteString("\n")
+			b.WriteString(errorStyle.Render(m.install.passwordErr))
+		}
 		b.WriteString("\n\n")
 		b.WriteString(renderShowPasswordCheckbox(m.install.password.EchoMode == textinput.EchoNormal, m.install.checkboxFocused))
 	}

--- a/internal/devtui/install_wizard_test.go
+++ b/internal/devtui/install_wizard_test.go
@@ -243,6 +243,62 @@ func TestInstallStepPassword_CheckboxFocusedSwallowsTypedKeys(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
+func TestValidateAdminPassword(t *testing.T) {
+	assert.NoError(t, validateAdminPassword("shopware"))
+	assert.NoError(t, validateAdminPassword("12345678"))
+	assert.Error(t, validateAdminPassword("shopwar"))
+	assert.Error(t, validateAdminPassword(""))
+	// Length is counted in runes, not bytes.
+	assert.Error(t, validateAdminPassword("äöü"))
+}
+
+func TestInstallStepPassword_EnterWithShortPasswordBlocks(t *testing.T) {
+	m := newTestInstallModel()
+	m.install.step = installStepPassword
+	m.install.password.SetValue("shopwar")
+	m.install.password.Focus()
+
+	updated, cmd := m.updateInstallPrompt(enterKey())
+	mm := updated.(Model)
+	assert.Equal(t, installStepPassword, mm.install.step, "should stay on the password step")
+	assert.Equal(t, phaseInstallPrompt, mm.phase, "should not start installing")
+	assert.NotEmpty(t, mm.install.passwordErr, "should set a validation error")
+	assert.Nil(t, cmd)
+}
+
+func TestInstallStepPassword_EnterWithValidPasswordStartsInstall(t *testing.T) {
+	m := newTestInstallModel()
+	m.install.step = installStepPassword
+	m.install.password.SetValue("shopware")
+	m.install.password.Focus()
+
+	updated, cmd := m.updateInstallPrompt(enterKey())
+	mm := updated.(Model)
+	assert.Equal(t, phaseInstalling, mm.phase)
+	assert.Empty(t, mm.install.passwordErr)
+	assert.NotNil(t, cmd)
+}
+
+func TestInstallStepPassword_TypingClearsError(t *testing.T) {
+	m := newTestInstallModel()
+	m.install.step = installStepPassword
+	m.install.passwordErr = "password must be at least 8 characters long"
+	m.install.password.Focus()
+
+	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
+	assert.Empty(t, updated.(Model).install.passwordErr)
+}
+
+func TestRenderInstallPrompt_PasswordErrorShown(t *testing.T) {
+	m := newTestInstallModel()
+	m.install.step = installStepPassword
+	m.install.passwordErr = "password must be at least 8 characters long"
+
+	var b strings.Builder
+	m.renderInstallPrompt(&b)
+	assert.Contains(t, b.String(), "at least 8 characters")
+}
+
 func TestRenderInstallPrompt_AllStepsDoNotPanic(t *testing.T) {
 	m := newTestInstallModel()
 

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -40,6 +40,7 @@ type setupGuide struct {
 	url                   textinput.Model
 	username              textinput.Model
 	password              textinput.Model
+	passwordErr           string
 	showPassword          bool
 	blackfireServerID     textinput.Model
 	blackfireServerToken  textinput.Model
@@ -222,6 +223,11 @@ func (sg *setupGuide) updateAdminUser(msg tea.KeyPressMsg) (setupGuide, tea.Cmd)
 func (sg *setupGuide) updateAdminPassword(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
 	switch msg.String() {
 	case keyEnter:
+		if err := validateAdminPassword(sg.password.Value()); err != nil {
+			sg.passwordErr = err.Error()
+			return *sg, nil
+		}
+		sg.passwordErr = ""
 		sg.password.Blur()
 		sg.step = setupStepDockerPHP
 		return *sg, nil
@@ -234,6 +240,7 @@ func (sg *setupGuide) updateAdminPassword(msg tea.KeyPressMsg) (setupGuide, tea.
 		}
 		return *sg, nil
 	}
+	sg.passwordErr = ""
 	var cmd tea.Cmd
 	sg.password, cmd = sg.password.Update(msg)
 	return *sg, cmd

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -46,6 +46,35 @@ func TestResolvePHPVersions_NoMatchingVersionsFallsBackToAll(t *testing.T) {
 	assert.Equal(t, "^9.0", constraint)
 }
 
+func TestSetupGuideAdminPassword_ShortPasswordBlocksAdvance(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepAdminPassword
+	sg.password.SetValue("shopwar")
+
+	out, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, setupStepAdminPassword, out.step, "should stay on the admin password step")
+	assert.NotEmpty(t, out.passwordErr, "should set a validation error")
+}
+
+func TestSetupGuideAdminPassword_ValidPasswordAdvances(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepAdminPassword
+	sg.password.SetValue("shopware")
+
+	out, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, setupStepDockerPHP, out.step)
+	assert.Empty(t, out.passwordErr)
+}
+
+func TestSetupGuideAdminPassword_TypingClearsError(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepAdminPassword
+	sg.passwordErr = "password must be at least 8 characters long"
+
+	out, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
+	assert.Empty(t, out.passwordErr)
+}
+
 func TestSetupGuideReview_QuitButtonQuits(t *testing.T) {
 	sg := newSetupGuide("")
 	sg.step = setupStepReview

--- a/internal/devtui/setup_guide_view.go
+++ b/internal/devtui/setup_guide_view.go
@@ -132,6 +132,10 @@ func (sg setupGuide) viewAdminPassword() string {
 	b.WriteString(tui.DimStyle.Render("Password for the Shopware admin panel and API access."))
 	b.WriteString("\n\n")
 	b.WriteString(sg.password.View())
+	if sg.passwordErr != "" {
+		b.WriteString("\n")
+		b.WriteString(errorStyle.Render(sg.passwordErr))
+	}
 	b.WriteString("\n\n")
 	b.WriteString(renderShowPasswordCheckbox(sg.showPassword, false))
 	b.WriteString("\n\n")


### PR DESCRIPTION
## Problem

The interactive `shopware-cli project dev` setup wizard accepted admin passwords shorter than 8 characters without any validation. The password is passed to the deployment-helper as `INSTALL_ADMIN_PASSWORD` and consumed by `bin/console user:create`, where the Shopware core enforces a minimum length of 8 characters.

As a result, a too-short password (e.g. `shopwar`) was accepted at input time but failed *late* during the deployment phase:

```
In MaintenanceException.php line 144:
  The password must have at least 8 characters.
[deployment-helper] Installation failed: exit status 1
```

## Fix

Validate the admin password length up front in both wizards that collect it:

- **Install wizard** (`internal/devtui/install_wizard.go`) — pressing Enter on a too-short password now shows an inline error and keeps the user on the password step instead of starting the installation.
- **Docker setup guide** (`internal/devtui/setup_guide.go`) — the admin password step blocks advancing with the same validation and inline error.

<img width="889" height="613" alt="image" src="https://github.com/user-attachments/assets/9f4c31da-43df-4881-8321-409fa1cc611c" />

A shared `validateAdminPassword` helper mirrors the core's requirement (`minAdminPasswordLength = 8`). The length is counted in runes, matching the core's `mb_strlen` check. The error clears as soon as the user edits the field.

## Tests

Added unit tests covering: too-short password blocks, valid password proceeds, error clears on typing, rune-based counting, and error rendering — for both wizards.

`go build ./...`, `go test ./internal/devtui/`, `go vet` and `gofmt` are clean.

## Manual verification

Created a fresh Docker project via `project create --docker`, ran `project dev`, and confirmed that entering a <8-character password at step 4/4 now shows the validation error instead of proceeding to "Installing Shopware".

Fixes #1095