### PR TITLE
Add timeout to interactive OAuth2 login flow

### DIFF
--- a/internal/account-api/oauth2.go
+++ b/internal/account-api/oauth2.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/oauth2"
 
@@ -18,6 +19,10 @@ import (
 	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/logging"
 )
+
+// interactiveLoginTimeout is the maximum time we wait for the user to complete
+// the browser-based login before giving up, so the command does not hang forever.
+const interactiveLoginTimeout = 5 * time.Minute
 
 func InteractiveLogin(ctx context.Context) (*oauth2.Token, error) {
 	client := &oauth2.Config{
@@ -107,10 +112,15 @@ func InteractiveLogin(ctx context.Context) (*oauth2.Token, error) {
 		close(enterPressed)
 	}()
 
+	timeout := time.NewTimer(interactiveLoginTimeout)
+	defer timeout.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		case <-timeout.C:
+			return nil, fmt.Errorf("timed out after %s waiting for login to complete", interactiveLoginTimeout)
 		case <-enterPressed:
 			enterPressed = nil
 			if err := system.OpenURL(ctx, u); err != nil {


### PR DESCRIPTION
## Summary
Adds a 5-minute timeout to the interactive OAuth2 login flow to prevent the command from hanging indefinitely if the user fails to complete the browser-based login.

## Changes
- Added `time` package import
- Introduced `interactiveLoginTimeout` constant (5 minutes) with documentation
- Implemented timeout mechanism using `time.NewTimer` in the `InteractiveLogin` function
- Added timeout case to the select statement that returns an error if the timeout is exceeded before login completion

## Implementation Details
The timeout is enforced via a timer that runs concurrently with the login flow. If the user doesn't complete the login within 5 minutes, the function returns a descriptive error message indicating the timeout duration. The timer is properly cleaned up using `defer timeout.Stop()` to prevent resource leaks.

https://claude.ai/code/session_01MFardjVLPmUUKkBhTnFtWd