### PR TITLE
fix(project): support running shopware-cli inside the docker dev container

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,11 @@ func run(ctx context.Context) int {
 	ctx = logging.WithLogger(ctx, logging.NewLogger(verbose))
 	ctx = logging.WithVerbose(ctx, verbose)
 	ctx = system.WithInteraction(ctx, !slices.Contains(args, "--no-interaction") && !slices.Contains(args, "-n") && isatty.IsTerminal(os.Stdin.Fd()))
+
+	if dir := system.EnsureWritableHome(); dir != "" {
+		logging.FromContext(ctx).Debugf("HOME was unset or not writable; redirected to %s so child tools (npm/composer) can write their caches", dir)
+	}
+
 	tui.AppVersion = version
 	accountApi.SetUserAgent("shopware-cli/" + version)
 	rootCmd.SetArgs(args)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -37,6 +37,30 @@ func TestNewDockerExecutor(t *testing.T) {
 	assert.Equal(t, "docker", exec.Type())
 }
 
+func TestNewDockerExecutorFallsBackToLocalInContainer(t *testing.T) {
+	original := resolveDockerFallback
+	t.Cleanup(func() { resolveDockerFallback = original })
+
+	resolveDockerFallback = func() bool { return true }
+
+	cfg := &shop.EnvironmentConfig{Type: "docker"}
+	exec, err := New("/project", cfg, &shop.Config{})
+	assert.NoError(t, err)
+	assert.Equal(t, "local", exec.Type())
+}
+
+func TestNewDockerExecutorKeepsDockerWithoutFallback(t *testing.T) {
+	original := resolveDockerFallback
+	t.Cleanup(func() { resolveDockerFallback = original })
+
+	resolveDockerFallback = func() bool { return false }
+
+	cfg := &shop.EnvironmentConfig{Type: "docker"}
+	exec, err := New("/project", cfg, &shop.Config{})
+	assert.NoError(t, err)
+	assert.Equal(t, "docker", exec.Type())
+}
+
 func TestNewUnsupportedType(t *testing.T) {
 	cfg := &shop.EnvironmentConfig{Type: "unknown"}
 

--- a/internal/executor/factory.go
+++ b/internal/executor/factory.go
@@ -25,6 +25,14 @@ func New(projectRoot string, cfg *shop.EnvironmentConfig, shopCfg *shop.Config) 
 		}
 		return &SymfonyCLIExecutor{BinaryPath: path, projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
 	case TypeDocker:
+		if resolveDockerFallback() {
+			// Running inside a container that has no docker CLI (e.g. the
+			// docker-dev image itself): there is no daemon to `docker compose
+			// exec` into, so the commands run locally — this container *is* the
+			// target environment. The local execution is visible via the
+			// executor's exec logging under --verbose.
+			return NewLocalWithConfig(projectRoot, cfg, shopCfg), nil
+		}
 		return &DockerExecutor{projectRoot: projectRoot, shopCfg: shopCfg, envCfg: cfg}, nil
 	default:
 		return nil, fmt.Errorf("unsupported environment type: %s", cfg.Type)
@@ -51,4 +59,29 @@ var pathToSymfonyCLI = sync.OnceValue(func() string {
 
 func symfonyCliAllowed() bool {
 	return os.Getenv("SHOPWARE_CLI_NO_SYMFONY_CLI") != "1"
+}
+
+// resolveDockerFallback reports whether a type:docker environment should run
+// locally instead. True only when shopware-cli runs inside a container that has
+// no docker CLI: there is nothing to exec into, so the container itself is the
+// execution environment. A host without docker keeps the DockerExecutor so it
+// fails with a clear "docker not found" error instead of silently running on
+// the host. Overridable in tests.
+var resolveDockerFallback = func() bool {
+	return isInsideContainer() && !dockerBinaryAvailable()
+}
+
+func isInsideContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/run/.containerenv"); err == nil {
+		return true
+	}
+	return false
+}
+
+func dockerBinaryAvailable() bool {
+	_, err := exec.LookPath("docker")
+	return err == nil
 }

--- a/internal/system/home_linux.go
+++ b/internal/system/home_linux.go
@@ -1,0 +1,43 @@
+package system
+
+import (
+	"os"
+	"syscall"
+)
+
+// EnsureWritableHome points HOME at a writable directory when the current HOME
+// is unset or not writable. This happens when shopware-cli runs inside a
+// container as a mapped host UID with no passwd entry: HOME resolves to "/",
+// where tools like npm (cache ~/.npm) and composer (~/.composer) fail with
+// EACCES. On a normal host with a writable HOME it is a no-op. Returns the
+// directory HOME was redirected to, or "" when nothing was changed.
+//
+// Linux only: macOS and Windows do not expose this problem (Docker Desktop
+// handles bind-mount ownership) and use different home conventions; see the
+// no-op in home_other.go.
+func EnsureWritableHome() string {
+	if home := os.Getenv("HOME"); home != "" && isWritableDir(home) {
+		return ""
+	}
+
+	fallback := os.TempDir()
+	if !isWritableDir(fallback) {
+		// Nothing better to offer; let the original error surface instead of
+		// pointing HOME at another unwritable location.
+		return ""
+	}
+
+	if err := os.Setenv("HOME", fallback); err != nil {
+		return ""
+	}
+
+	return fallback
+}
+
+// isWritableDir reports whether the process can create entries in dir. It uses
+// access(2) so it performs no write and leaves no probe file behind (run() calls
+// EnsureWritableHome on every invocation, including shell completion).
+func isWritableDir(dir string) bool {
+	const writeOK = 0x2 // unix W_OK
+	return syscall.Access(dir, writeOK) == nil
+}

--- a/internal/system/home_other.go
+++ b/internal/system/home_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package system
+
+// EnsureWritableHome is a no-op outside Linux. macOS and Windows do not expose
+// the unwritable-HOME problem (Docker Desktop handles bind-mount ownership) and
+// use different home conventions. See home_linux.go for the Linux behavior.
+func EnsureWritableHome() string {
+	return ""
+}

--- a/internal/system/home_test.go
+++ b/internal/system/home_test.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureWritableHomeKeepsWritableHome(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("EnsureWritableHome only acts on Linux")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	assert.Equal(t, "", EnsureWritableHome())
+	assert.Equal(t, home, os.Getenv("HOME"))
+}
+
+func TestEnsureWritableHomeRedirectsUnsetHome(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("EnsureWritableHome only acts on Linux")
+	}
+
+	t.Setenv("HOME", "")
+
+	redirected := EnsureWritableHome()
+	assert.Equal(t, os.TempDir(), redirected)
+	assert.Equal(t, os.TempDir(), os.Getenv("HOME"))
+}
+
+func TestEnsureWritableHomeRedirectsUnwritableHome(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("EnsureWritableHome only acts on Linux")
+	}
+
+	// A path that does not exist is unwritable even for root, keeping the test
+	// deterministic in the root-mapped CI sandbox.
+	t.Setenv("HOME", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	redirected := EnsureWritableHome()
+	assert.Equal(t, os.TempDir(), redirected)
+	assert.Equal(t, os.TempDir(), os.Getenv("HOME"))
+}


### PR DESCRIPTION
Follow-up to #1097, which made `project create --docker` / `project dev` work for any host UID by running the containers as the calling user. This PR covers the remaining case: running `shopware-cli` itself **inside** the dev container (directly, via an alias such as `docker compose exec web shopware-cli ...`, or when the CLI is shipped in the `ghcr.io/shopware/docker-dev` image).

### Problem

Two issues surface when the CLI runs inside the container:

1. **No docker to exec into.** The `docker-dev` image ships no `docker` CLI, but a `type: docker` environment unconditionally builds a `DockerExecutor`. The first executor command (`project storefront-build` runs `feature:dump`) then fails with `docker: not found` — before any build step.
2. **Unwritable HOME.** Inside the container the CLI runs as the mapped host UID, which has no passwd entry, so `HOME` resolves to `/`. npm (`~/.npm`) and composer (`~/.composer`) then fail with `EACCES` (e.g. `mkdir /.npm`).

### Changes

- **`internal/executor/factory.go`** — a `type: docker` environment falls back to **local execution** when running inside a container that has no docker CLI (detected via `/.dockerenv` / `/run/.containerenv` + `docker` not on `PATH`). The container *is* the target environment, so commands run locally. A host without docker keeps the `DockerExecutor`, so it still fails with a clear error instead of silently running on the host; a container *with* docker (dind) is unaffected.
- **`internal/system/home_linux.go` + `cmd/root.go`** — at startup, when `HOME` is unset or not writable, it is redirected to a writable temp dir, so every child process (the executor's npm/composer/console **and** the verifier's direct npm/node calls, which all inherit the process env) can write its caches. The writability check uses `access(2)` (no probe file is written, so shell completion stays side-effect free). Linux only; a no-op when `HOME` is already writable, so normal host and macOS/Windows usage is unchanged.

### Resulting behaviour

| Environment | type | docker present | inside container | Executor | HOME |
|---|---|---|---|---|---|
| Host, native | local | – | no | Local | host, no-op |
| Host + Docker | docker | yes | no | Docker (`exec`, `HOME=/tmp` from #1097) | unchanged |
| **Dev container** | docker | **no** | **yes** | **Local (new)** | **redirected (new)** |
| Container + dind | docker | yes | yes | Docker (`exec`) | unchanged |
| macOS / Windows | docker | yes | no | Docker | no-op |

### Testing

- New unit tests: executor fallback (local when forced, docker otherwise) and `EnsureWritableHome` (keeps a writable HOME, redirects when unset/unwritable).
- `gofmt`, `go vet`, `go build` (linux/windows/darwin), `golangci-lint run ./...` and `go test ./...` all pass.
- Verified end-to-end in the real `ghcr.io/shopware/docker-dev` image as UID 1001: the CLI resolves to local execution (`exec: php bin/console ...`, no `docker: not found`), redirects `HOME` to `/tmp`, and a real `npm install` succeeds.

Refs #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)
