### PR TITLE
fix(project): validate directly provided project name up front

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -106,6 +106,16 @@ var projectCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := parseCreateFlags(cmd, args)
 
+		// A name passed directly as an argument skips the interactive name
+		// prompt, which is where invalid names (e.g. wrong casing) are normally
+		// rejected live. Validate it up front so it is forbidden immediately
+		// instead of only after the rest of the form has been completed.
+		if opts.projectFolder != "" {
+			if err := validateProjectName(opts.projectFolder); err != nil {
+				return err
+			}
+		}
+
 		if opts.interactive {
 			tui.PrintBanner()
 		}

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -117,6 +117,22 @@ func TestValidateProjectName(t *testing.T) {
 	}
 }
 
+func TestProjectCreateRejectsInvalidNameArgument(t *testing.T) {
+	// A name provided directly as an argument must be rejected up front,
+	// before the interactive form or any network call, the same way the
+	// interactive name prompt rejects it live.
+	invalidNames := []string{"myShop", "MyShop", "müller", "my shop"}
+
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			projectCreateCmd.SetContext(t.Context())
+			err := projectCreateCmd.RunE(projectCreateCmd, []string{name})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid project name")
+		})
+	}
+}
+
 func TestProjectNameFieldDescription(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

When the project name is supplied directly as an argument, e.g.:

```
shopware-cli project create myShop
```

an invalid name (such as the wrong casing `myShop`) was **not** rejected up front.

The interactive form already validates the name live as you type and forbids invalid values. But when the name is passed as an argument, `runCreateForm` skips the name prompt entirely (the value is already set), so the invalid name was only caught later by the final preflight check:

- **Interactive mode:** the user had to fill out the *entire* rest of the form (version, Docker, deployment, CI, …) before being told the name was invalid.
- **Non-interactive mode:** the name was only validated *after* a network round-trip to fetch Shopware versions.

## Fix

Validate a directly provided project name immediately after parsing the flags — before the banner, the network call, and the interactive form. This makes the direct-input path forbid invalid names right away, matching the live validation of the interactive name prompt.

```go
if opts.projectFolder != "" {
    if err := validateProjectName(opts.projectFolder); err != nil {
        return err
    }
}
```

## Behaviour

Before — `project create myShop` fetched versions / ran the form first, then errored.
After — it fails instantly:

```
$ shopware-cli project create myShop
ERROR  invalid project name "myShop": only lowercase letters, digits, dashes (-) and underscores (_) are allowed, and it must start with a lowercase letter or digit, so it can be used as a Docker Compose project name
```

(returns in ~0.19s, before any network access)

## Tests

- Added `TestProjectCreateRejectsInvalidNameArgument`, asserting that an invalid name passed as an argument is rejected up front (no network/form needed).
- Existing `TestValidateProjectName` already covers the name rules (`myShop`, `MyShop`, umlauts, spaces, …).
- `go test ./cmd/project/`, `go vet ./cmd/project/`, and `gofmt` all pass.

https://claude.ai/code/session_01KUCeP8kU8bszv1nVZe2Qfr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUCeP8kU8bszv1nVZe2Qfr)_