### PR TITLE
feat: support multi-step deployment hooks in project config schema

### DIFF
--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -396,8 +396,7 @@ type ConfigDeploymentHook struct {
 }
 
 func (h *ConfigDeploymentHook) UnmarshalYAML(value *yaml.Node) error {
-	switch value.Kind {
-	case yaml.ScalarNode:
+	if value.Kind == yaml.ScalarNode {
 		var script string
 		if err := value.Decode(&script); err != nil {
 			return err
@@ -409,7 +408,9 @@ func (h *ConfigDeploymentHook) UnmarshalYAML(value *yaml.Node) error {
 		}
 
 		return nil
-	case yaml.SequenceNode:
+	}
+
+	if value.Kind == yaml.SequenceNode {
 		steps := make([]ConfigDeploymentHookStep, 0, len(value.Content))
 		for _, node := range value.Content {
 			if node.Kind == yaml.ScalarNode {
@@ -434,9 +435,9 @@ func (h *ConfigDeploymentHook) UnmarshalYAML(value *yaml.Node) error {
 		h.Steps = steps
 
 		return nil
-	default:
-		return fmt.Errorf("invalid hook: expected a script string or a list of steps")
 	}
+
+	return fmt.Errorf("invalid hook: expected a script string or a list of steps")
 }
 
 func (ConfigDeploymentHook) JSONSchema() *jsonschema.Schema {

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -329,17 +329,17 @@ func (c *ConfigDump) NormalizeFakerExpressions() {
 type ConfigDeployment struct {
 	Hooks struct {
 		// The pre hook will be executed before the deployment
-		Pre string `yaml:"pre"`
+		Pre ConfigDeploymentHook `yaml:"pre"`
 		// The post hook will be executed after the deployment
-		Post string `yaml:"post"`
+		Post ConfigDeploymentHook `yaml:"post"`
 		// The pre-install hook will be executed before the installation
-		PreInstall string `yaml:"pre-install"`
+		PreInstall ConfigDeploymentHook `yaml:"pre-install"`
 		// The post-install hook will be executed after the installation
-		PostInstall string `yaml:"post-install"`
+		PostInstall ConfigDeploymentHook `yaml:"post-install"`
 		// The pre-update hook will be executed before the update
-		PreUpdate string `yaml:"pre-update"`
+		PreUpdate ConfigDeploymentHook `yaml:"pre-update"`
 		// The post-update hook will be executed after the update
-		PostUpdate string `yaml:"post-update"`
+		PostUpdate ConfigDeploymentHook `yaml:"post-update"`
 	} `yaml:"hooks"`
 
 	Store struct {
@@ -378,6 +378,100 @@ type ConfigDeployment struct {
 type ConfigDeploymentStaging struct {
 	// When enabled, staging setup commands will be executed during installation and upgrade
 	Enabled bool `yaml:"enabled,omitempty"`
+}
+
+// ConfigDeploymentHookStep is a single titled step of a deployment hook.
+type ConfigDeploymentHookStep struct {
+	// An optional title shown in the deployment output for this step
+	Title string `yaml:"title,omitempty"`
+	// The script that is executed for this step
+	Script string `yaml:"script"`
+}
+
+// ConfigDeploymentHook is a deployment hook. It can either be a single script
+// (string) or a list of steps that are executed individually. Each step can be
+// a plain script string or an object with a "title" and a "script".
+type ConfigDeploymentHook struct {
+	Steps []ConfigDeploymentHookStep
+}
+
+func (h *ConfigDeploymentHook) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var script string
+		if err := value.Decode(&script); err != nil {
+			return err
+		}
+
+		h.Steps = nil
+		if script != "" {
+			h.Steps = []ConfigDeploymentHookStep{{Script: script}}
+		}
+
+		return nil
+	case yaml.SequenceNode:
+		steps := make([]ConfigDeploymentHookStep, 0, len(value.Content))
+		for _, node := range value.Content {
+			if node.Kind == yaml.ScalarNode {
+				var script string
+				if err := node.Decode(&script); err != nil {
+					return err
+				}
+
+				steps = append(steps, ConfigDeploymentHookStep{Script: script})
+
+				continue
+			}
+
+			var step ConfigDeploymentHookStep
+			if err := node.Decode(&step); err != nil {
+				return err
+			}
+
+			steps = append(steps, step)
+		}
+
+		h.Steps = steps
+
+		return nil
+	default:
+		return fmt.Errorf("invalid hook: expected a script string or a list of steps")
+	}
+}
+
+func (ConfigDeploymentHook) JSONSchema() *jsonschema.Schema {
+	stepProperties := orderedmap.New[string, *jsonschema.Schema]()
+	stepProperties.Set("title", &jsonschema.Schema{
+		Type:        "string",
+		Description: "An optional title shown in the deployment output for this step",
+	})
+	stepProperties.Set("script", &jsonschema.Schema{
+		Type:        "string",
+		Description: "The script that is executed for this step",
+	})
+
+	step := &jsonschema.Schema{
+		Type:                 "object",
+		Properties:           stepProperties,
+		Required:             []string{"script"},
+		AdditionalProperties: jsonschema.FalseSchema,
+	}
+
+	return &jsonschema.Schema{
+		Description: "Either a single script or a list of steps (a script string or a {title, script} object) executed individually",
+		OneOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{
+				Type: "array",
+				Items: &jsonschema.Schema{
+					OneOf: []*jsonschema.Schema{
+						{Type: "string"},
+						step,
+					},
+				},
+			},
+		},
+	}
 }
 
 type ConfigDeploymentOverrides map[string]struct {

--- a/internal/shop/config_hook_test.go
+++ b/internal/shop/config_hook_test.go
@@ -1,0 +1,62 @@
+package shop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigDeploymentHookUnmarshalString(t *testing.T) {
+	var d ConfigDeployment
+	require.NoError(t, yaml.Unmarshal([]byte("hooks:\n  pre: |\n    echo hi\n"), &d))
+
+	assert.Equal(t, []ConfigDeploymentHookStep{{Script: "echo hi\n"}}, d.Hooks.Pre.Steps)
+}
+
+func TestConfigDeploymentHookUnmarshalEmptyString(t *testing.T) {
+	var d ConfigDeployment
+	require.NoError(t, yaml.Unmarshal([]byte("hooks:\n  pre: ''\n"), &d))
+
+	assert.Nil(t, d.Hooks.Pre.Steps)
+}
+
+func TestConfigDeploymentHookUnmarshalStepList(t *testing.T) {
+	yml := "hooks:\n" +
+		"  post:\n" +
+		"    - title: Warm up the cache\n" +
+		"      script: bin/console cache:warmup\n" +
+		"    - title: Notify the team\n" +
+		"      script: ./notify.sh\n"
+
+	var d ConfigDeployment
+	require.NoError(t, yaml.Unmarshal([]byte(yml), &d))
+
+	assert.Equal(t, []ConfigDeploymentHookStep{
+		{Title: "Warm up the cache", Script: "bin/console cache:warmup"},
+		{Title: "Notify the team", Script: "./notify.sh"},
+	}, d.Hooks.Post.Steps)
+}
+
+func TestConfigDeploymentHookUnmarshalStringListShorthand(t *testing.T) {
+	yml := "hooks:\n" +
+		"  pre-update:\n" +
+		"    - echo first\n" +
+		"    - echo second\n"
+
+	var d ConfigDeployment
+	require.NoError(t, yaml.Unmarshal([]byte(yml), &d))
+
+	assert.Equal(t, []ConfigDeploymentHookStep{
+		{Script: "echo first"},
+		{Script: "echo second"},
+	}, d.Hooks.PreUpdate.Steps)
+}
+
+func TestConfigDeploymentHookUnmarshalInvalid(t *testing.T) {
+	var d ConfigDeployment
+	err := yaml.Unmarshal([]byte("hooks:\n  pre:\n    foo: bar\n"), &d)
+
+	assert.Error(t, err)
+}

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -254,22 +254,22 @@
         "hooks": {
           "properties": {
             "pre": {
-              "type": "string"
+              "$ref": "#/$defs/ConfigDeploymentHook"
             },
             "post": {
-              "type": "string"
+              "$ref": "#/$defs/ConfigDeploymentHook"
             },
             "pre-install": {
-              "type": "string"
+              "$ref": "#/$defs/ConfigDeploymentHook"
             },
             "post-install": {
-              "type": "string"
+              "$ref": "#/$defs/ConfigDeploymentHook"
             },
             "pre-update": {
-              "type": "string"
+              "$ref": "#/$defs/ConfigDeploymentHook"
             },
             "post-update": {
-              "type": "string"
+              "$ref": "#/$defs/ConfigDeploymentHook"
             }
           },
           "additionalProperties": false,
@@ -350,6 +350,41 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "ConfigDeploymentHook": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "An optional title shown in the deployment output for this step"
+                  },
+                  "script": {
+                    "type": "string",
+                    "description": "The script that is executed for this step"
+                  }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "script"
+                ]
+              }
+            ]
+          },
+          "type": "array"
+        }
+      ],
+      "description": "Either a single script or a list of steps (a script string or a {title, script} object) executed individually"
     },
     "ConfigDeploymentOverrides": {
       "additionalProperties": {


### PR DESCRIPTION
## What

Update the `.shopware-project.yml` config schema so deployment hooks (`pre`, `post`, `pre-install`, `post-install`, `pre-update`, `post-update`) accept **both** the existing single-script form and the new multi-step form.

## Why

The deployment-helper now allows a hook to be defined as a list of titled steps that are executed individually, for clearer per-step output. This PR keeps shopware-cli's schema and config parsing in sync so the new form validates in editors and doesn't break `ReadConfig`.

Companion to shopware/deployment-helper#89.

## Supported forms

```yaml
deployment:
  hooks:
    # old: single script (unchanged)
    pre: |
      echo "Before deployment"

    # new: list of titled steps
    post:
      - title: Warm up the cache
        script: |
          bin/console cache:warmup
      - title: Notify the team
        script: ./notify.sh

    # new: shorthand list of script strings (untitled steps)
    pre-update:
      - echo "first"
      - echo "second"
```

## How

- New `ConfigDeploymentHook` / `ConfigDeploymentHookStep` types in `internal/shop/config.go`.
  - `UnmarshalYAML` accepts a string, a list of `{title, script}` objects, or a shorthand list of script strings; errors on anything else. This matters because `ReadConfig` unmarshals the project config, so a plain `string` field would fail on the new list form.
  - `JSONSchema()` emits `oneOf: [string, array<oneOf: [string, {title, script}]>]`, mirroring the existing custom-schema pattern used by `ConfigDeploymentOverrides`.
- Regenerated `internal/shop/config_schema.json` via `scripts/schema.go`.

## Backwards compatibility

Fully backwards compatible — string hooks parse and validate exactly as before.

## Testing

- New `internal/shop/config_hook_test.go` covers string, empty string, step list, string-list shorthand, and the invalid case.
- `go test ./internal/shop/`, `go vet`, and `gofmt` all clean. Schema regeneration is stable.
