### PR TITLE
Combine admin username and password into single credentials step

### DIFF
--- a/internal/devtui/install_wizard.go
+++ b/internal/devtui/install_wizard.go
@@ -33,8 +33,18 @@ const (
 	installStepAsk installStep = iota
 	installStepLanguage
 	installStepCurrency
-	installStepUsername
-	installStepPassword
+	installStepCredentials
+)
+
+// credFocus identifies which element of a combined admin-account step
+// (username field, password field, or the show-password checkbox) currently
+// has focus. It is shared by the install wizard and the setup guide.
+type credFocus int
+
+const (
+	credFocusUsername credFocus = iota
+	credFocusPassword
+	credFocusShowPassword
 )
 
 type installLanguage struct {
@@ -62,15 +72,15 @@ var (
 )
 
 type installWizard struct {
-	step            installStep
-	cursor          int
-	confirmYes      bool
-	language        string
-	currency        string
-	username        textinput.Model
-	password        textinput.Model
-	checkboxFocused bool
-	passwordErr     string
+	step        installStep
+	cursor      int
+	confirmYes  bool
+	language    string
+	currency    string
+	username    textinput.Model
+	password    textinput.Model
+	credFocus   credFocus
+	passwordErr string
 }
 
 type installProgress struct {
@@ -105,10 +115,8 @@ func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.updateInstallStepLanguage(msg)
 	case installStepCurrency:
 		return m.updateInstallStepCurrency(msg)
-	case installStepUsername:
-		return m.updateInstallStepUsername(msg)
-	case installStepPassword:
-		return m.updateInstallStepPassword(msg)
+	case installStepCredentials:
+		return m.updateInstallStepCredentials(msg)
 	}
 
 	return m, nil
@@ -164,57 +172,67 @@ func (m Model) updateInstallStepCurrency(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		}
 	case keyEnter:
 		m.install.currency = installCurrencies[m.install.cursor]
-		m.install.step = installStepUsername
+		m.install.step = installStepCredentials
 		m.install.username.SetValue(defaultUsername)
-		m.install.username.Focus()
-		return m, textinput.Blink
+		m.install.password.SetValue("shopware")
+		return m.focusInstallCred(credFocusUsername)
 	}
 	return m, nil
 }
 
-func (m Model) updateInstallStepUsername(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == keyEnter {
-		m.install.step = installStepPassword
-		m.install.username.Blur()
-		m.install.password.SetValue("shopware")
-		m.install.password.Focus()
-		m.install.checkboxFocused = false
-		return m, textinput.Blink
+// focusInstallCred moves focus to the given element of the combined admin
+// account step, clamping to the valid range and syncing the text input focus.
+func (m Model) focusInstallCred(target credFocus) (tea.Model, tea.Cmd) {
+	if target < credFocusUsername {
+		target = credFocusUsername
 	}
+	if target > credFocusShowPassword {
+		target = credFocusShowPassword
+	}
+	m.install.credFocus = target
+	m.install.username.Blur()
+	m.install.password.Blur()
 	var cmd tea.Cmd
-	m.install.username, cmd = m.install.username.Update(msg)
+	switch target {
+	case credFocusUsername:
+		m.install.username.Focus()
+		cmd = textinput.Blink
+	case credFocusPassword:
+		m.install.password.Focus()
+		cmd = textinput.Blink
+	}
 	return m, cmd
 }
 
-func (m Model) updateInstallStepPassword(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+func (m Model) updateInstallStepCredentials(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case keyEnter:
-		return m.handleInstallPasswordEnter()
+		return m.handleInstallCredentialsEnter()
 	case keyTab, keyDown:
-		if !m.install.checkboxFocused {
-			m.install.checkboxFocused = true
-			m.install.password.Blur()
-		}
-		return m, nil
+		return m.focusInstallCred(m.install.credFocus + 1)
 	case keyShiftTab, keyUp:
-		if m.install.checkboxFocused {
-			m.install.checkboxFocused = false
-			m.install.password.Focus()
-			return m, textinput.Blink
-		}
-		return m, nil
+		return m.focusInstallCred(m.install.credFocus - 1)
 	}
-	if m.install.checkboxFocused {
-		return m, nil
+	switch m.install.credFocus {
+	case credFocusUsername:
+		var cmd tea.Cmd
+		m.install.username, cmd = m.install.username.Update(msg)
+		return m, cmd
+	case credFocusPassword:
+		m.install.passwordErr = ""
+		var cmd tea.Cmd
+		m.install.password, cmd = m.install.password.Update(msg)
+		return m, cmd
 	}
-	m.install.passwordErr = ""
-	var cmd tea.Cmd
-	m.install.password, cmd = m.install.password.Update(msg)
-	return m, cmd
+	return m, nil
 }
 
-func (m Model) handleInstallPasswordEnter() (tea.Model, tea.Cmd) {
-	if m.install.checkboxFocused {
+func (m Model) handleInstallCredentialsEnter() (tea.Model, tea.Cmd) {
+	switch m.install.credFocus {
+	case credFocusUsername:
+		// Enter on the username field advances to the password field.
+		return m.focusInstallCred(credFocusPassword)
+	case credFocusShowPassword:
 		if m.install.password.EchoMode == textinput.EchoPassword {
 			m.install.password.EchoMode = textinput.EchoNormal
 		} else {
@@ -227,6 +245,7 @@ func (m Model) handleInstallPasswordEnter() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.install.passwordErr = ""
+	m.install.username.Blur()
 	m.install.password.Blur()
 	m.phase = phaseInstalling
 	m.overlayLines = nil
@@ -248,7 +267,7 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 		b.WriteString(renderConfirmButtons("Initialize now", "No, skip", m.install.confirmYes))
 
 	case installStepLanguage:
-		b.WriteString(tui.TextBadge("Step 1/4"))
+		b.WriteString(tui.TextBadge("Step 1/3"))
 		b.WriteString("\n\n")
 		opts := make([]tui.SelectOption, len(installLanguages))
 		for i, lang := range installLanguages {
@@ -257,7 +276,7 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 		b.WriteString(tui.RenderSelectList("Default Language", "Select the primary language for your storefront", opts, m.install.cursor))
 
 	case installStepCurrency:
-		b.WriteString(tui.TextBadge("Step 2/4"))
+		b.WriteString(tui.TextBadge("Step 2/3"))
 		b.WriteString("\n\n")
 		opts := make([]tui.SelectOption, len(installCurrencies))
 		for i, curr := range installCurrencies {
@@ -265,29 +284,26 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 		}
 		b.WriteString(tui.RenderSelectList("Default Currency", "Select the default currency for pricing", opts, m.install.cursor))
 
-	case installStepUsername:
-		b.WriteString(tui.TextBadge("Step 3/4"))
+	case installStepCredentials:
+		b.WriteString(tui.TextBadge("Step 3/3"))
 		b.WriteString("\n\n")
-		b.WriteString(tui.TitleStyle.Render("Admin Username"))
+		b.WriteString(tui.TitleStyle.Render("Admin Account"))
 		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter the username for the admin account"))
+		b.WriteString(tui.DimStyle.Render("Set the username and password for the admin account"))
 		b.WriteString("\n\n")
+		b.WriteString(tui.DimStyle.Render("Username"))
+		b.WriteString("\n")
 		b.WriteString(m.install.username.View())
-
-	case installStepPassword:
-		b.WriteString(tui.TextBadge("Step 4/4"))
 		b.WriteString("\n\n")
-		b.WriteString(tui.TitleStyle.Render("Admin Password"))
+		b.WriteString(tui.DimStyle.Render("Password (default: shopware)"))
 		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter the password for the admin account (default: shopware)"))
-		b.WriteString("\n\n")
 		b.WriteString(m.install.password.View())
 		if m.install.passwordErr != "" {
 			b.WriteString("\n")
 			b.WriteString(errorStyle.Render(m.install.passwordErr))
 		}
 		b.WriteString("\n\n")
-		b.WriteString(renderShowPasswordCheckbox(m.install.password.EchoMode == textinput.EchoNormal, m.install.checkboxFocused))
+		b.WriteString(renderShowPasswordCheckbox(m.install.password.EchoMode == textinput.EchoNormal, m.install.credFocus == credFocusShowPassword))
 	}
 }
 
@@ -303,19 +319,15 @@ func (m Model) installFooterHint() string {
 			tui.Shortcut{Key: "↑/↓", Label: "Select"},
 			tui.Shortcut{Key: "enter", Label: "Confirm"},
 		)
-	case installStepUsername:
-		return tui.ShortcutBar(
-			tui.Shortcut{Key: "enter", Label: "Continue"},
-		)
-	case installStepPassword:
-		if m.install.checkboxFocused {
+	case installStepCredentials:
+		if m.install.credFocus == credFocusShowPassword {
 			return tui.ShortcutBar(
-				tui.Shortcut{Key: "↑", Label: "Back"},
+				tui.Shortcut{Key: "↑/↓/tab", Label: "Navigate"},
 				tui.Shortcut{Key: "enter", Label: "Toggle"},
 			)
 		}
 		return tui.ShortcutBar(
-			tui.Shortcut{Key: "↓/tab", Label: "Show password"},
+			tui.Shortcut{Key: "↑/↓/tab", Label: "Navigate"},
 			tui.Shortcut{Key: "enter", Label: "Install"},
 		)
 	}

--- a/internal/devtui/install_wizard.go
+++ b/internal/devtui/install_wizard.go
@@ -200,6 +200,8 @@ func (m Model) focusInstallCred(target credFocus) (tea.Model, tea.Cmd) {
 	case credFocusPassword:
 		m.install.password.Focus()
 		cmd = textinput.Blink
+	case credFocusShowPassword:
+		// The checkbox has no text input to focus.
 	}
 	return m, cmd
 }
@@ -223,6 +225,8 @@ func (m Model) updateInstallStepCredentials(msg tea.KeyPressMsg) (tea.Model, tea
 		var cmd tea.Cmd
 		m.install.password, cmd = m.install.password.Update(msg)
 		return m, cmd
+	case credFocusShowPassword:
+		// The checkbox swallows typed keys.
 	}
 	return m, nil
 }
@@ -239,6 +243,8 @@ func (m Model) handleInstallCredentialsEnter() (tea.Model, tea.Cmd) {
 			m.install.password.EchoMode = textinput.EchoPassword
 		}
 		return m, nil
+	case credFocusPassword:
+		// Enter on the password field submits; handled below.
 	}
 	if err := validateAdminPassword(m.install.password.Value()); err != nil {
 		m.install.passwordErr = err.Error()

--- a/internal/devtui/install_wizard_test.go
+++ b/internal/devtui/install_wizard_test.go
@@ -133,8 +133,10 @@ func TestInstallStepCurrency_UpDownAndEnter(t *testing.T) {
 	updated, cmd := mm.updateInstallPrompt(enterKey())
 	out := updated.(Model)
 	assert.Equal(t, "USD", out.install.currency)
-	assert.Equal(t, installStepUsername, out.install.step)
+	assert.Equal(t, installStepCredentials, out.install.step)
 	assert.Equal(t, defaultUsername, out.install.username.Value())
+	assert.Equal(t, "shopware", out.install.password.Value())
+	assert.Equal(t, credFocusUsername, out.install.credFocus)
 	assert.True(t, out.install.username.Focused())
 	assert.NotNil(t, cmd)
 }
@@ -148,94 +150,128 @@ func TestInstallStepCurrency_CursorClampedAtBounds(t *testing.T) {
 	assert.Equal(t, len(installCurrencies)-1, updated.(Model).install.cursor)
 }
 
-func TestInstallStepUsername_EnterAdvancesToPassword(t *testing.T) {
+func TestInstallStepCredentials_EnterOnUsernameFocusesPassword(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepUsername
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusUsername
 	m.install.username.SetValue("custom-admin")
 	m.install.username.Focus()
 
 	updated, cmd := m.updateInstallPrompt(enterKey())
 	mm := updated.(Model)
-	assert.Equal(t, installStepPassword, mm.install.step)
+	assert.Equal(t, installStepCredentials, mm.install.step)
+	assert.Equal(t, credFocusPassword, mm.install.credFocus)
 	assert.False(t, mm.install.username.Focused())
 	assert.True(t, mm.install.password.Focused())
-	assert.Equal(t, "shopware", mm.install.password.Value())
-	assert.False(t, mm.install.checkboxFocused)
 	assert.NotNil(t, cmd)
 }
 
-func TestInstallStepUsername_TypedKeysGoToInput(t *testing.T) {
+func TestInstallStepCredentials_TypedKeysGoToUsername(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepUsername
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusUsername
+	m.install.username.SetValue("")
 	m.install.username.Focus()
 
 	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
-	assert.Equal(t, installStepUsername, updated.(Model).install.step)
+	mm := updated.(Model)
+	assert.Equal(t, installStepCredentials, mm.install.step)
+	assert.Equal(t, "x", mm.install.username.Value())
 }
 
-func TestInstallStepPassword_TabFocusesCheckbox(t *testing.T) {
+func TestInstallStepCredentials_TabFromUsernameFocusesPassword(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusUsername
+
+	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	mm := updated.(Model)
+	assert.Equal(t, credFocusPassword, mm.install.credFocus)
+	assert.True(t, mm.install.password.Focused())
+}
+
+func TestInstallStepCredentials_TabFromPasswordFocusesCheckbox(t *testing.T) {
+	m := newTestInstallModel()
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusPassword
 	m.install.password.Focus()
 
 	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
 	mm := updated.(Model)
-	assert.True(t, mm.install.checkboxFocused)
+	assert.Equal(t, credFocusShowPassword, mm.install.credFocus)
 	assert.False(t, mm.install.password.Focused())
 }
 
-func TestInstallStepPassword_DownFocusesCheckbox(t *testing.T) {
+func TestInstallStepCredentials_DownFromPasswordFocusesCheckbox(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusPassword
 	m.install.password.Focus()
 
 	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
-	assert.True(t, updated.(Model).install.checkboxFocused)
+	assert.Equal(t, credFocusShowPassword, updated.(Model).install.credFocus)
 }
 
-func TestInstallStepPassword_ShiftTabUnfocusesCheckbox(t *testing.T) {
+func TestInstallStepCredentials_ShiftTabFromCheckboxFocusesPassword(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
-	m.install.checkboxFocused = true
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusShowPassword
 
 	updated, cmd := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab, Mod: tea.ModShift}))
 	mm := updated.(Model)
-	assert.False(t, mm.install.checkboxFocused)
+	assert.Equal(t, credFocusPassword, mm.install.credFocus)
 	assert.True(t, mm.install.password.Focused())
 	assert.NotNil(t, cmd)
 }
 
-func TestInstallStepPassword_UpUnfocusesCheckbox(t *testing.T) {
+func TestInstallStepCredentials_UpFromCheckboxFocusesPassword(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
-	m.install.checkboxFocused = true
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusShowPassword
 
 	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
 	mm := updated.(Model)
-	assert.False(t, mm.install.checkboxFocused)
+	assert.Equal(t, credFocusPassword, mm.install.credFocus)
 	assert.True(t, mm.install.password.Focused())
 }
 
-func TestInstallStepPassword_EnterOnCheckboxTogglesEcho(t *testing.T) {
+func TestInstallStepCredentials_NavigationClampsAtBounds(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
-	m.install.checkboxFocused = true
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusUsername
+
+	// Up/shift-tab at the first element should stay on username.
+	updated, _ := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+	assert.Equal(t, credFocusUsername, updated.(Model).install.credFocus)
+
+	// Tab past the checkbox should stay on the checkbox.
+	m2 := newTestInstallModel()
+	m2.install.step = installStepCredentials
+	m2.install.credFocus = credFocusShowPassword
+	updated, _ = m2.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	assert.Equal(t, credFocusShowPassword, updated.(Model).install.credFocus)
+}
+
+func TestInstallStepCredentials_EnterOnCheckboxTogglesEcho(t *testing.T) {
+	m := newTestInstallModel()
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusShowPassword
 	m.install.password.EchoMode = textinput.EchoPassword
 
 	updated, _ := m.updateInstallPrompt(enterKey())
 	mm := updated.(Model)
 	assert.Equal(t, textinput.EchoNormal, mm.install.password.EchoMode)
-	assert.Equal(t, installStepPassword, mm.install.step, "should stay on password step")
+	assert.Equal(t, installStepCredentials, mm.install.step, "should stay on credentials step")
 
 	updated, _ = mm.updateInstallPrompt(enterKey())
 	assert.Equal(t, textinput.EchoPassword, updated.(Model).install.password.EchoMode)
 }
 
-func TestInstallStepPassword_CheckboxFocusedSwallowsTypedKeys(t *testing.T) {
+func TestInstallStepCredentials_CheckboxFocusedSwallowsTypedKeys(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusShowPassword
 	m.install.password.SetValue("orig")
-	m.install.checkboxFocused = true
 
 	updated, cmd := m.updateInstallPrompt(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
 	mm := updated.(Model)
@@ -252,23 +288,25 @@ func TestValidateAdminPassword(t *testing.T) {
 	assert.Error(t, validateAdminPassword("äöü"))
 }
 
-func TestInstallStepPassword_EnterWithShortPasswordBlocks(t *testing.T) {
+func TestInstallStepCredentials_EnterWithShortPasswordBlocks(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusPassword
 	m.install.password.SetValue("shopwar")
 	m.install.password.Focus()
 
 	updated, cmd := m.updateInstallPrompt(enterKey())
 	mm := updated.(Model)
-	assert.Equal(t, installStepPassword, mm.install.step, "should stay on the password step")
+	assert.Equal(t, installStepCredentials, mm.install.step, "should stay on the credentials step")
 	assert.Equal(t, phaseInstallPrompt, mm.phase, "should not start installing")
 	assert.NotEmpty(t, mm.install.passwordErr, "should set a validation error")
 	assert.Nil(t, cmd)
 }
 
-func TestInstallStepPassword_EnterWithValidPasswordStartsInstall(t *testing.T) {
+func TestInstallStepCredentials_EnterWithValidPasswordStartsInstall(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusPassword
 	m.install.password.SetValue("shopware")
 	m.install.password.Focus()
 
@@ -279,9 +317,10 @@ func TestInstallStepPassword_EnterWithValidPasswordStartsInstall(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
-func TestInstallStepPassword_TypingClearsError(t *testing.T) {
+func TestInstallStepCredentials_TypingClearsError(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusPassword
 	m.install.passwordErr = "password must be at least 8 characters long"
 	m.install.password.Focus()
 
@@ -291,7 +330,7 @@ func TestInstallStepPassword_TypingClearsError(t *testing.T) {
 
 func TestRenderInstallPrompt_PasswordErrorShown(t *testing.T) {
 	m := newTestInstallModel()
-	m.install.step = installStepPassword
+	m.install.step = installStepCredentials
 	m.install.passwordErr = "password must be at least 8 characters long"
 
 	var b strings.Builder
@@ -307,10 +346,9 @@ func TestRenderInstallPrompt_AllStepsDoNotPanic(t *testing.T) {
 		expects []string
 	}{
 		{installStepAsk, []string{"Shopware is not initialized yet", "Initialize now"}},
-		{installStepLanguage, []string{"Step 1/4", "Default Language"}},
-		{installStepCurrency, []string{"Step 2/4", "Default Currency"}},
-		{installStepUsername, []string{"Step 3/4", "Admin Username"}},
-		{installStepPassword, []string{"Step 4/4", "Admin Password"}},
+		{installStepLanguage, []string{"Step 1/3", "Default Language"}},
+		{installStepCurrency, []string{"Step 2/3", "Default Currency"}},
+		{installStepCredentials, []string{"Step 3/3", "Admin Account", "Username", "Password"}},
 	}
 
 	for _, s := range steps {
@@ -338,17 +376,14 @@ func TestInstallFooterHint_PerStep(t *testing.T) {
 	m.install.step = installStepCurrency
 	assert.Contains(t, m.installFooterHint(), "Select")
 
-	m.install.step = installStepUsername
-	assert.Contains(t, m.installFooterHint(), "Continue")
-
-	m.install.step = installStepPassword
-	m.install.checkboxFocused = false
+	m.install.step = installStepCredentials
+	m.install.credFocus = credFocusPassword
 	assert.Contains(t, m.installFooterHint(), "Install")
-	assert.Contains(t, m.installFooterHint(), "Show password")
+	assert.Contains(t, m.installFooterHint(), "Navigate")
 
-	m.install.checkboxFocused = true
+	m.install.credFocus = credFocusShowPassword
 	assert.Contains(t, m.installFooterHint(), "Toggle")
-	assert.Contains(t, m.installFooterHint(), "Back")
+	assert.Contains(t, m.installFooterHint(), "Navigate")
 }
 
 func TestInstallFooterHint_UnknownStepReturnsEmpty(t *testing.T) {

--- a/internal/devtui/lifecycle_test.go
+++ b/internal/devtui/lifecycle_test.go
@@ -167,7 +167,7 @@ func TestUpdateLifecycle_ShopwareInstallDone_Success(t *testing.T) {
 		envConfig:   &shop.EnvironmentConfig{},
 		watchers:    make(map[string]*watcherHandle),
 		install: installWizard{
-			step:     installStepPassword,
+			step:     installStepCredentials,
 			username: usernameInput,
 			password: passwordInput,
 		},

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -16,7 +16,6 @@ type setupStep int
 const (
 	setupStepWelcome setupStep = iota
 	setupStepAdminUser
-	setupStepAdminPassword
 	setupStepDockerPHP
 	setupStepDockerProfiler
 	setupStepProfilerCreds
@@ -41,7 +40,7 @@ type setupGuide struct {
 	username              textinput.Model
 	password              textinput.Model
 	passwordErr           string
-	showPassword          bool
+	credFocus             credFocus
 	blackfireServerID     textinput.Model
 	blackfireServerToken  textinput.Model
 	tidewaysAPIKey        textinput.Model
@@ -172,8 +171,6 @@ func (sg *setupGuide) update(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
 		return sg.updateWelcome(msg)
 	case setupStepAdminUser:
 		return sg.updateAdminUser(msg)
-	case setupStepAdminPassword:
-		return sg.updateAdminPassword(msg)
 	case setupStepDockerPHP:
 		return sg.updateDockerPHP(msg)
 	case setupStepDockerProfiler:
@@ -200,50 +197,82 @@ func (sg *setupGuide) updateWelcome(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
 	case keyEnter:
 		if sg.confirmYes {
 			sg.step = setupStepAdminUser
-			sg.username.Focus()
-			return *sg, textinput.Blink
+			return sg.focusAdminCred(credFocusUsername)
 		}
 		return *sg, tea.Quit
 	}
 	return *sg, nil
 }
 
-func (sg *setupGuide) updateAdminUser(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
-	if msg.String() == keyEnter {
-		sg.username.Blur()
-		sg.step = setupStepAdminPassword
-		sg.password.Focus()
-		return *sg, textinput.Blink
+// focusAdminCred moves focus to the given element of the combined admin
+// account step, clamping to the valid range and syncing the text input focus.
+func (sg *setupGuide) focusAdminCred(target credFocus) (setupGuide, tea.Cmd) {
+	if target < credFocusUsername {
+		target = credFocusUsername
 	}
+	if target > credFocusShowPassword {
+		target = credFocusShowPassword
+	}
+	sg.credFocus = target
+	sg.username.Blur()
+	sg.password.Blur()
 	var cmd tea.Cmd
-	sg.username, cmd = sg.username.Update(msg)
+	switch target {
+	case credFocusUsername:
+		sg.username.Focus()
+		cmd = textinput.Blink
+	case credFocusPassword:
+		sg.password.Focus()
+		cmd = textinput.Blink
+	}
 	return *sg, cmd
 }
 
-func (sg *setupGuide) updateAdminPassword(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
+func (sg *setupGuide) updateAdminUser(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
 	switch msg.String() {
 	case keyEnter:
-		if err := validateAdminPassword(sg.password.Value()); err != nil {
-			sg.passwordErr = err.Error()
-			return *sg, nil
-		}
+		return sg.handleAdminUserEnter()
+	case keyTab, keyDown:
+		return sg.focusAdminCred(sg.credFocus + 1)
+	case keyShiftTab, keyUp:
+		return sg.focusAdminCred(sg.credFocus - 1)
+	}
+	switch sg.credFocus {
+	case credFocusUsername:
+		var cmd tea.Cmd
+		sg.username, cmd = sg.username.Update(msg)
+		return *sg, cmd
+	case credFocusPassword:
 		sg.passwordErr = ""
-		sg.password.Blur()
-		sg.step = setupStepDockerPHP
-		return *sg, nil
-	case keyTab:
-		sg.showPassword = !sg.showPassword
-		if sg.showPassword {
+		var cmd tea.Cmd
+		sg.password, cmd = sg.password.Update(msg)
+		return *sg, cmd
+	}
+	return *sg, nil
+}
+
+func (sg *setupGuide) handleAdminUserEnter() (setupGuide, tea.Cmd) {
+	switch sg.credFocus {
+	case credFocusUsername:
+		// Enter on the username field advances to the password field.
+		return sg.focusAdminCred(credFocusPassword)
+	case credFocusShowPassword:
+		if sg.password.EchoMode == textinput.EchoPassword {
 			sg.password.EchoMode = textinput.EchoNormal
 		} else {
 			sg.password.EchoMode = textinput.EchoPassword
 		}
 		return *sg, nil
 	}
+	if err := validateAdminPassword(sg.password.Value()); err != nil {
+		sg.passwordErr = err.Error()
+		return *sg, nil
+	}
 	sg.passwordErr = ""
-	var cmd tea.Cmd
-	sg.password, cmd = sg.password.Update(msg)
-	return *sg, cmd
+	sg.username.Blur()
+	sg.password.Blur()
+	sg.step = setupStepDockerPHP
+	return *sg, nil
 }
 
 func (sg *setupGuide) updateDockerPHP(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -224,6 +224,8 @@ func (sg *setupGuide) focusAdminCred(target credFocus) (setupGuide, tea.Cmd) {
 	case credFocusPassword:
 		sg.password.Focus()
 		cmd = textinput.Blink
+	case credFocusShowPassword:
+		// The checkbox has no text input to focus.
 	}
 	return *sg, cmd
 }
@@ -247,6 +249,8 @@ func (sg *setupGuide) updateAdminUser(msg tea.KeyPressMsg) (setupGuide, tea.Cmd)
 		var cmd tea.Cmd
 		sg.password, cmd = sg.password.Update(msg)
 		return *sg, cmd
+	case credFocusShowPassword:
+		// The checkbox swallows typed keys.
 	}
 	return *sg, nil
 }
@@ -263,6 +267,8 @@ func (sg *setupGuide) handleAdminUserEnter() (setupGuide, tea.Cmd) {
 			sg.password.EchoMode = textinput.EchoPassword
 		}
 		return *sg, nil
+	case credFocusPassword:
+		// Enter on the password field submits; handled below.
 	}
 	if err := validateAdminPassword(sg.password.Value()); err != nil {
 		sg.passwordErr = err.Error()

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 
@@ -46,19 +47,33 @@ func TestResolvePHPVersions_NoMatchingVersionsFallsBackToAll(t *testing.T) {
 	assert.Equal(t, "^9.0", constraint)
 }
 
-func TestSetupGuideAdminPassword_ShortPasswordBlocksAdvance(t *testing.T) {
+func TestSetupGuideAdminUser_EnterOnUsernameFocusesPassword(t *testing.T) {
 	sg := newSetupGuide("")
-	sg.step = setupStepAdminPassword
+	sg.step = setupStepAdminUser
+	sg.credFocus = credFocusUsername
+	sg.username.Focus()
+
+	out, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, setupStepAdminUser, out.step, "should stay on the admin account step")
+	assert.Equal(t, credFocusPassword, out.credFocus)
+	assert.True(t, out.password.Focused())
+}
+
+func TestSetupGuideAdminUser_ShortPasswordBlocksAdvance(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepAdminUser
+	sg.credFocus = credFocusPassword
 	sg.password.SetValue("shopwar")
 
 	out, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.Equal(t, setupStepAdminPassword, out.step, "should stay on the admin password step")
+	assert.Equal(t, setupStepAdminUser, out.step, "should stay on the admin account step")
 	assert.NotEmpty(t, out.passwordErr, "should set a validation error")
 }
 
-func TestSetupGuideAdminPassword_ValidPasswordAdvances(t *testing.T) {
+func TestSetupGuideAdminUser_ValidPasswordAdvances(t *testing.T) {
 	sg := newSetupGuide("")
-	sg.step = setupStepAdminPassword
+	sg.step = setupStepAdminUser
+	sg.credFocus = credFocusPassword
 	sg.password.SetValue("shopware")
 
 	out, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
@@ -66,13 +81,41 @@ func TestSetupGuideAdminPassword_ValidPasswordAdvances(t *testing.T) {
 	assert.Empty(t, out.passwordErr)
 }
 
-func TestSetupGuideAdminPassword_TypingClearsError(t *testing.T) {
+func TestSetupGuideAdminUser_TypingClearsError(t *testing.T) {
 	sg := newSetupGuide("")
-	sg.step = setupStepAdminPassword
+	sg.step = setupStepAdminUser
+	sg.credFocus = credFocusPassword
 	sg.passwordErr = "password must be at least 8 characters long"
 
 	out, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
 	assert.Empty(t, out.passwordErr)
+}
+
+func TestSetupGuideAdminUser_TabNavigatesFocus(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepAdminUser
+	sg.credFocus = credFocusUsername
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	assert.Equal(t, credFocusPassword, sg.credFocus)
+	assert.True(t, sg.password.Focused())
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	assert.Equal(t, credFocusShowPassword, sg.credFocus)
+	assert.False(t, sg.password.Focused())
+}
+
+func TestSetupGuideAdminUser_EnterOnCheckboxTogglesEcho(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepAdminUser
+	sg.credFocus = credFocusShowPassword
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, textinput.EchoNormal, sg.password.EchoMode)
+	assert.Equal(t, setupStepAdminUser, sg.step)
+
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	assert.Equal(t, textinput.EchoPassword, sg.password.EchoMode)
 }
 
 func TestSetupGuideReview_QuitButtonQuits(t *testing.T) {
@@ -340,10 +383,7 @@ func TestSetupGuideViewSteps(t *testing.T) {
 	sg.username.Focus()
 	view = sg.viewContent()
 	assert.Contains(t, view, "Step")
-
-	sg.step = setupStepAdminPassword
-	sg.password.Focus()
-	view = sg.viewContent()
+	assert.Contains(t, view, "Username")
 	assert.Contains(t, view, "Password")
 
 	sg.step = setupStepDockerPHP
@@ -448,12 +488,11 @@ func TestSetupGuideViewProfilerCreds(t *testing.T) {
 func TestSetupGuideStepNumbering_NoProfilerCreds(t *testing.T) {
 	sg := newSetupGuide("")
 	sg.profilerCursor = 0 // none → no creds step
-	assert.Equal(t, 5, sg.totalSteps())
+	assert.Equal(t, 4, sg.totalSteps())
 	assert.Equal(t, 1, sg.stepNum(setupStepAdminUser))
-	assert.Equal(t, 2, sg.stepNum(setupStepAdminPassword))
-	assert.Equal(t, 3, sg.stepNum(setupStepDockerPHP))
-	assert.Equal(t, 4, sg.stepNum(setupStepDockerProfiler))
-	assert.Equal(t, 5, sg.stepNum(setupStepReview))
+	assert.Equal(t, 2, sg.stepNum(setupStepDockerPHP))
+	assert.Equal(t, 3, sg.stepNum(setupStepDockerProfiler))
+	assert.Equal(t, 4, sg.stepNum(setupStepReview))
 	assert.Equal(t, 0, sg.stepNum(setupStepWelcome))
 	assert.Equal(t, 0, sg.stepNum(setupStepDone))
 }
@@ -461,7 +500,7 @@ func TestSetupGuideStepNumbering_NoProfilerCreds(t *testing.T) {
 func TestSetupGuideStepNumbering_WithProfilerCreds(t *testing.T) {
 	sg := newSetupGuide("")
 	sg.profilerCursor = 2 // blackfire → adds creds step
-	assert.Equal(t, 6, sg.totalSteps())
-	assert.Equal(t, 5, sg.stepNum(setupStepProfilerCreds))
-	assert.Equal(t, 6, sg.stepNum(setupStepReview))
+	assert.Equal(t, 5, sg.totalSteps())
+	assert.Equal(t, 4, sg.stepNum(setupStepProfilerCreds))
+	assert.Equal(t, 5, sg.stepNum(setupStepReview))
 }

--- a/internal/devtui/setup_guide_view.go
+++ b/internal/devtui/setup_guide_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/bubbles/v2/textinput"
 	"charm.land/lipgloss/v2"
 
 	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
@@ -16,8 +17,6 @@ func (sg setupGuide) viewContent() string {
 		return sg.viewWelcome()
 	case setupStepAdminUser:
 		return sg.viewAdminUser()
-	case setupStepAdminPassword:
-		return sg.viewAdminPassword()
 	case setupStepDockerPHP:
 		return sg.viewDockerPHP()
 	case setupStepDockerProfiler:
@@ -39,8 +38,8 @@ func stepBadge(stepNum, totalSteps int) string {
 // totalSteps returns the number of numbered wizard steps. The profiler
 // credentials step is only counted when the chosen profiler needs them.
 func (sg setupGuide) totalSteps() int {
-	// admin user, admin password, PHP version, profiler, review
-	total := 5
+	// admin account, PHP version, profiler, review
+	total := 4
 	if dockerpkg.ProfilerNeedsCredentials(profilerChoices[sg.profilerCursor]) {
 		total++
 	}
@@ -54,19 +53,17 @@ func (sg setupGuide) stepNum(step setupStep) int {
 	switch step {
 	case setupStepAdminUser:
 		return 1
-	case setupStepAdminPassword:
-		return 2
 	case setupStepDockerPHP:
-		return 3
+		return 2
 	case setupStepDockerProfiler:
-		return 4
+		return 3
 	case setupStepProfilerCreds:
-		return 5
+		return 4
 	case setupStepReview:
 		if dockerpkg.ProfilerNeedsCredentials(profilerChoices[sg.profilerCursor]) {
-			return 6
+			return 5
 		}
-		return 5
+		return 4
 	case setupStepWelcome, setupStepDone:
 		return 0
 	}
@@ -114,30 +111,23 @@ func (sg setupGuide) viewAdminUser() string {
 	var b strings.Builder
 	b.WriteString(stepBadge(sg.stepNum(setupStepAdminUser), sg.totalSteps()))
 	b.WriteString("\n\n")
-	b.WriteString(tui.TitleStyle.Render("Admin Username"))
+	b.WriteString(tui.TitleStyle.Render("Admin Account"))
 	b.WriteString("\n")
-	b.WriteString(tui.DimStyle.Render("Username for the Shopware admin panel and API access."))
+	b.WriteString(tui.DimStyle.Render("Credentials for the Shopware admin panel and API access."))
 	b.WriteString("\n\n")
+	b.WriteString(tui.DimStyle.Render("Username"))
+	b.WriteString("\n")
 	b.WriteString(sg.username.View())
 	b.WriteString("\n\n")
-	return tui.RenderPhaseCard(b.String())
-}
-
-func (sg setupGuide) viewAdminPassword() string {
-	var b strings.Builder
-	b.WriteString(stepBadge(sg.stepNum(setupStepAdminPassword), sg.totalSteps()))
-	b.WriteString("\n\n")
-	b.WriteString(tui.TitleStyle.Render("Admin Password"))
+	b.WriteString(tui.DimStyle.Render("Password"))
 	b.WriteString("\n")
-	b.WriteString(tui.DimStyle.Render("Password for the Shopware admin panel and API access."))
-	b.WriteString("\n\n")
 	b.WriteString(sg.password.View())
 	if sg.passwordErr != "" {
 		b.WriteString("\n")
 		b.WriteString(errorStyle.Render(sg.passwordErr))
 	}
 	b.WriteString("\n\n")
-	b.WriteString(renderShowPasswordCheckbox(sg.showPassword, false))
+	b.WriteString(renderShowPasswordCheckbox(sg.password.EchoMode == textinput.EchoNormal, sg.credFocus == credFocusShowPassword))
 	b.WriteString("\n\n")
 	return tui.RenderPhaseCard(b.String())
 }
@@ -317,12 +307,14 @@ func (sg setupGuide) footerHint() string {
 			tui.Shortcut{Key: "enter", Label: "Confirm"},
 		)
 	case setupStepAdminUser:
+		if sg.credFocus == credFocusShowPassword {
+			return tui.ShortcutBar(
+				tui.Shortcut{Key: "↑/↓/tab", Label: "Navigate"},
+				tui.Shortcut{Key: "enter", Label: "Toggle"},
+			)
+		}
 		return tui.ShortcutBar(
-			tui.Shortcut{Key: "enter", Label: "Continue"},
-		)
-	case setupStepAdminPassword:
-		return tui.ShortcutBar(
-			tui.Shortcut{Key: "tab", Label: "Show password"},
+			tui.Shortcut{Key: "↑/↓/tab", Label: "Navigate"},
 			tui.Shortcut{Key: "enter", Label: "Continue"},
 		)
 	case setupStepDockerPHP, setupStepDockerProfiler:


### PR DESCRIPTION
## Summary
Refactors the install wizard and setup guide to combine the separate username and password steps into a single unified "Admin Account" step. This improves the user experience by reducing the number of steps and allowing navigation between username, password, and show-password checkbox within a single view.

## Key Changes

- **Consolidated Steps**: Merged `installStepUsername` and `installStepPassword` into a single `installStepCredentials` step in the install wizard, reducing total steps from 4 to 3
- **Shared Focus Management**: Introduced `credFocus` type to track which element (username field, password field, or show-password checkbox) has focus, replacing the separate `checkboxFocused` boolean
- **New Helper Function**: Added `focusInstallCred()` and `focusAdminCred()` methods to centralize focus management with proper clamping and text input synchronization
- **Unified Navigation**: Implemented consistent keyboard navigation (Tab/Shift-Tab/Up/Down) across all three credential elements within the single step
- **Setup Guide Alignment**: Applied the same consolidation to the setup guide, removing `setupStepAdminPassword` and merging it with `setupStepAdminUser`
- **UI Updates**: 
  - Combined step titles from "Admin Username" and "Admin Password" to "Admin Account"
  - Updated step badges from "Step 3/4" and "Step 4/4" to "Step 3/3"
  - Improved footer hints to show consistent navigation shortcuts
- **Test Coverage**: Updated all related tests to reflect the new consolidated step structure and focus management

## Implementation Details

The refactoring maintains all existing functionality while improving code organization:
- Focus state is now managed through a single `credFocus` enum rather than multiple boolean flags
- The `focusInstallCred()` helper ensures focus is properly synchronized between the UI state and text input components
- Navigation between fields is now handled uniformly through the focus management helper
- Password validation and echo mode toggling remain unchanged but are now part of the unified credentials step

https://claude.ai/code/session_01NdR79TXGS6fs6BvzuTqN3u