### PR TITLE
feat: support asset caching for extension zip

### DIFF
--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -140,6 +140,7 @@ var extensionZipCmd = &cobra.Command{
 			}
 
 			assetBuildConfig := extension.AssetBuildConfig{
+				EnableAssetCaching: extCfg.Build.Zip.Assets.EnableAssetCaching,
 				CleanupNodeModules: true,
 				ShopwareRoot:       os.Getenv("SHOPWARE_PROJECT_ROOT"),
 				ShopwareVersion:    shopwareConstraint,

--- a/internal/extension/asset_cache_test.go
+++ b/internal/extension/asset_cache_test.go
@@ -1,0 +1,122 @@
+package extension
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shyim/go-version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateDiskCache points the default cache at a temp dir and disables the
+// GitHub Actions cache backend so the test exercises the local disk cache.
+func isolateDiskCache(t *testing.T) {
+	t.Helper()
+	t.Setenv("SHOPWARE_CLI_CACHE_DIR", t.TempDir())
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_WORKFLOW", "")
+}
+
+// newAdditionalCacheEntry builds an extension entry whose only cached artifact
+// is an additional_caches output path, so the cache round-trip can be tested
+// without running a real asset build.
+func newAdditionalCacheEntry(t *testing.T, sourceContent string) (*ExtensionAssetConfigEntry, string) {
+	t.Helper()
+	basePath := t.TempDir() + "/"
+
+	srcDir := filepath.Join(basePath, "Resources", "app", "custom", "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "index.js"), []byte(sourceContent), 0o644))
+
+	outputDir := filepath.Join(basePath, "Resources", "public", "custom")
+	require.NoError(t, os.MkdirAll(outputDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "compiled.js"), []byte("BUILD_ARTIFACT"), 0o644))
+
+	entry := &ExtensionAssetConfigEntry{
+		BasePath:      basePath,
+		TechnicalName: "TestExtension",
+		AdditionalCaches: []ConfigBuildZipAssetsAdditionalCache{
+			{
+				Path:        "Resources/public/custom",
+				SourcePaths: []string{"Resources/app/custom/src"},
+			},
+		},
+	}
+
+	return entry, outputDir
+}
+
+func newShopwareConstraint(t *testing.T) *version.Constraints {
+	t.Helper()
+	constraint, err := version.NewConstraint("~6.6.0")
+	require.NoError(t, err)
+	return &constraint
+}
+
+func TestAssetCache_StoreAndRestoreWhenEnabled(t *testing.T) {
+	isolateDiskCache(t)
+
+	entry, outputDir := newAdditionalCacheEntry(t, "console.log('v1')")
+	assetCfg := AssetBuildConfig{
+		EnableAssetCaching: true,
+		ShopwareVersion:    newShopwareConstraint(t),
+	}
+	sources := ExtensionAssetConfig{"TestExtension": entry}
+
+	require.NoError(t, storeAssetCaches(t.Context(), sources, assetCfg))
+
+	// Wipe the output, then restore it from cache.
+	require.NoError(t, os.RemoveAll(outputDir))
+	require.NoError(t, restoreAssetCaches(t.Context(), sources, assetCfg))
+
+	restored, err := os.ReadFile(filepath.Join(outputDir, "compiled.js"))
+	require.NoError(t, err, "output should be restored from cache")
+	assert.Equal(t, "BUILD_ARTIFACT", string(restored))
+}
+
+func TestAssetCache_DisabledIsNoOp(t *testing.T) {
+	isolateDiskCache(t)
+
+	entry, outputDir := newAdditionalCacheEntry(t, "console.log('v1')")
+	assetCfg := AssetBuildConfig{
+		EnableAssetCaching: false,
+		ShopwareVersion:    newShopwareConstraint(t),
+	}
+	sources := ExtensionAssetConfig{"TestExtension": entry}
+
+	// Storing with caching disabled must not write anything.
+	require.NoError(t, storeAssetCaches(t.Context(), sources, assetCfg))
+
+	require.NoError(t, os.RemoveAll(outputDir))
+	require.NoError(t, restoreAssetCaches(t.Context(), sources, assetCfg))
+
+	_, err := os.Stat(filepath.Join(outputDir, "compiled.js"))
+	assert.True(t, os.IsNotExist(err), "nothing should be cached or restored when disabled")
+}
+
+func TestAssetCache_SourceChangeBustsKey(t *testing.T) {
+	isolateDiskCache(t)
+
+	assetCfg := AssetBuildConfig{
+		EnableAssetCaching: true,
+		ShopwareVersion:    newShopwareConstraint(t),
+	}
+
+	// Store cache for an extension built from source "v1".
+	v1Entry, _ := newAdditionalCacheEntry(t, "console.log('v1')")
+	require.NoError(t, storeAssetCaches(t.Context(), ExtensionAssetConfig{"TestExtension": v1Entry}, assetCfg))
+
+	// A different extension with changed source "v2" must miss the cache,
+	// so its output is left untouched (not overwritten by the v1 artifact).
+	v2Entry, v2Output := newAdditionalCacheEntry(t, "console.log('v2')")
+	require.NoError(t, os.WriteFile(filepath.Join(v2Output, "compiled.js"), []byte("LOCAL_V2"), 0o644))
+
+	require.NoError(t, restoreAssetCaches(t.Context(), ExtensionAssetConfig{"TestExtension": v2Entry}, assetCfg))
+
+	content, err := os.ReadFile(filepath.Join(v2Output, "compiled.js"))
+	require.NoError(t, err)
+	assert.Equal(t, "LOCAL_V2", string(content), "changed source must not restore the stale cached artifact")
+}

--- a/internal/extension/config.go
+++ b/internal/extension/config.go
@@ -57,6 +57,8 @@ type ConfigBuildZipComposer struct {
 type ConfigBuildZipAssets struct {
 	// When enabled, the shopware-cli build the assets
 	Enabled bool `yaml:"enabled"`
+	// When enabled, compiled assets are cached and restored across builds, keyed by the source-file content hash
+	EnableAssetCaching bool `yaml:"enable_asset_caching"`
 	// Commands to run before the assets build
 	BeforeHooks []string `yaml:"before_hooks,omitempty"`
 	// Commands to run after the assets build

--- a/internal/extension/config_schema.json
+++ b/internal/extension/config_schema.json
@@ -104,6 +104,10 @@
           "type": "boolean",
           "description": "When enabled, the shopware-cli build the assets"
         },
+        "enable_asset_caching": {
+          "type": "boolean",
+          "description": "When enabled, compiled assets are cached and restored across builds, keyed by the source-file content hash"
+        },
         "before_hooks": {
           "items": {
             "type": "string"


### PR DESCRIPTION
## What

Adds an `enable_asset_caching` opt-in to `build.zip.assets` in `.shopware-extension.yml`, so `extension zip` reuses the existing asset cache machinery — mirroring the `asset_caching` setting already available for `project ci`.

```yaml
build:
  zip:
    assets:
      enabled: true
      enable_asset_caching: true
```

## Why

The cache layer is environment-agnostic (GitHub Actions cache in CI, disk cache otherwise) and already runs inside `BuildAssetsForExtensions` (restore + store). But the zip path never set `EnableAssetCaching`, so caching — **including the already-configurable `additional_caches`** — was silently inert during `extension zip`. Only `project ci` ever turned it on.

## How

- `internal/extension/config.go` — add `EnableAssetCaching` to `ConfigBuildZipAssets` (yaml: `enable_asset_caching`).
- `cmd/extension/extension_zip.go` — wire it into the `AssetBuildConfig` passed to `BuildAssetsForExtensions`.
- `internal/extension/config_schema.json` — add the matching schema property (hand-maintained, embedded).
- `internal/extension/asset_cache_test.go` — tests for store/restore round-trip, disabled-is-no-op, and source-change busts the cache key.

## Behavior / compatibility

**Off by default** (zero value `false`). Existing extensions are unaffected unless they explicitly opt in. Extensions that already configured `additional_caches` will only start caching once they set `enable_asset_caching: true`.

## Notes (deliberately out of scope)

- The cache key (`sw-cli-<shopwareVersion>-<contentHash>`) does not include the CLI/esbuild version — a CLI upgrade alone won't bust the cache. Same as the existing `project ci` path, so not a regression; can be added separately if desired.
- The opt-in is a global flag on the zip path (zip builds one extension at a time). Making a per-extension flag also apply under `project ci` would require moving the boolean into the per-source entry — not done here.

## Verification

- `go build ./...`, `go vet ./internal/extension/... ./cmd/extension/...` — clean
- `go test ./internal/extension/` — passes (new tests included)
- `gofmt` — clean