### PR TITLE
fix: make asset content hash independent of extension base path

### DIFF
--- a/internal/extension/asset_config.go
+++ b/internal/extension/asset_config.go
@@ -273,8 +273,10 @@ func (e *ExtensionAssetConfigEntry) GetContentHash() (string, error) {
 	// Combine hashes in sorted order for consistency
 	hasher := xxhash.New()
 	for _, file := range files {
-		// Write file path and its hash
-		if _, err := hasher.Write([]byte(file)); err != nil {
+		// Write the BasePath-relative file path so the hash stays stable
+		// regardless of where the extension is located on disk (e.g. the
+		// temp directory used by `extension zip`).
+		if _, err := hasher.Write([]byte(e.relPath(file))); err != nil {
 			return "", err
 		}
 		if _, err := fmt.Fprintf(hasher, "%x", fileHashes[file]); err != nil {
@@ -402,8 +404,9 @@ func (e *ExtensionAssetConfigEntry) hashSingleFile(filePath string) (uint64, err
 
 	hasher := xxhash.New()
 
-	// Write the file path to the hasher for uniqueness
-	if _, err := hasher.Write([]byte(filePath)); err != nil {
+	// Write the BasePath-relative file path to the hasher for uniqueness so
+	// the hash does not depend on the absolute location of the extension.
+	if _, err := hasher.Write([]byte(e.relPath(filePath))); err != nil {
 		return 0, err
 	}
 
@@ -413,6 +416,20 @@ func (e *ExtensionAssetConfigEntry) hashSingleFile(filePath string) (uint64, err
 	}
 
 	return hasher.Sum64(), nil
+}
+
+// relPath returns the given path relative to the extension BasePath. It is used
+// when folding file paths into the content hash so the resulting cache key is
+// independent of the absolute extension location (e.g. the temp directory used
+// by `extension zip`). It falls back to the input path if it cannot be made
+// relative.
+func (e *ExtensionAssetConfigEntry) relPath(p string) string {
+	rel, err := filepath.Rel(filepath.Clean(e.BasePath), p)
+	if err != nil {
+		return p
+	}
+
+	return filepath.ToSlash(rel)
 }
 
 func (e *ExtensionAssetConfigEntry) GetOutputAdminPath() string {

--- a/internal/extension/asset_config_test.go
+++ b/internal/extension/asset_config_test.go
@@ -40,6 +40,36 @@ func TestGetContentHash_AdditionalCaches(t *testing.T) {
 	assert.NotEqual(t, hash1, hash2)
 }
 
+func TestGetContentHash_StableAcrossBasePaths(t *testing.T) {
+	// `extension zip` copies the extension into a fresh temp dir on every run,
+	// so the content hash must not depend on the absolute BasePath, otherwise
+	// the cache key changes every run and never hits.
+	build := func(t *testing.T) string {
+		t.Helper()
+		base := t.TempDir() + "/"
+
+		srcDir := filepath.Join(base, "Resources", "app", "custom", "src")
+		require.NoError(t, os.MkdirAll(srcDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "index.js"), []byte("console.log('v1')"), 0o644))
+
+		entry := &ExtensionAssetConfigEntry{
+			BasePath: base,
+			AdditionalCaches: []ConfigBuildZipAssetsAdditionalCache{
+				{
+					Path:        "Resources/public/custom",
+					SourcePaths: []string{"Resources/app/custom/src"},
+				},
+			},
+		}
+
+		hash, err := entry.GetContentHash()
+		require.NoError(t, err)
+		return hash
+	}
+
+	assert.Equal(t, build(t), build(t), "identical content in different base paths must hash equally")
+}
+
 func TestGetContentHash_AssetConfigChangeInvalidatesHash(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Problem

Asset caching never hits for `extension zip` (added in #1114). Enabling `enable_asset_caching: true` and running zip repeatedly always rebuilds — a new cache entry is stored under a different key every run.

## Root cause

The content hash (`ExtensionAssetConfigEntry.GetContentHash`) folded each file's **absolute path** into the cache key (in both `GetContentHash` and `hashSingleFile`). `extension zip` copies the extension into a fresh `os.MkdirTemp("", "extension")` directory on every run (`extension_zip.go:67`), so every file's absolute path — and therefore the key `sw-cli-<version>-<contentHash>` — changed each run. Result: store-under-new-key every time, never restore.

This is why `project ci` was unaffected: it builds from a stable `ShopwareRoot`, so the absolute paths don't change between runs.

## Fix

Fold the **`BasePath`-relative** path into the hash instead of the absolute path, via a small `relPath` helper (normalized to forward slashes). The key now depends only on file contents and their location *within* the extension, making it stable regardless of where the extension is copied.

## Verification

Reproduced against a real plugin (`FroshAdminDashboard`) with an isolated cache dir:

- **Before:** two runs → two distinct cache keys, no restore, full rebuild each time.
- **After:** run 1 builds (~18s); run 2 logs `Restored administration assets ... from cache` and skips the build; a single cache key across both runs.

Added regression test `TestGetContentHash_StableAcrossBasePaths` (identical content in different base dirs must hash equally). Full `go test ./internal/extension/`, `go vet`, and `gofmt` are clean.