### PR TITLE
fix: package HEAD instead of newest repo tag in extension zip

### DIFF
--- a/internal/extension/git.go
+++ b/internal/extension/git.go
@@ -12,7 +12,11 @@ import (
 )
 
 func gitTagOrBranchOfFolder(ctx context.Context, source string) (string, error) {
-	tagCmd := exec.CommandContext(ctx, "git", "-C", source, "tag", "--sort=-creatordate")
+	// Prefer a tag that points exactly at HEAD. This keeps the resulting filename
+	// in sync with the actually checked-out commit (e.g. when a CI pipeline builds
+	// a specific tag in detached-HEAD state). Picking the newest tag in the repo
+	// regardless of HEAD would package the wrong tree (see issue #1116 / #753).
+	tagCmd := exec.CommandContext(ctx, "git", "-C", source, "tag", "--points-at", "HEAD", "--sort=-creatordate")
 
 	stdout, err := tagCmd.Output()
 	if err != nil {

--- a/internal/extension/git_test.go
+++ b/internal/extension/git_test.go
@@ -1,0 +1,98 @@
+package extension
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+}
+
+func TestGitCopyFolderArchivesHeadNotNewestTag(t *testing.T) {
+	source := t.TempDir()
+	ctx := context.Background()
+
+	gitRun(t, source, "init")
+	gitRun(t, source, "config", "commit.gpgsign", "false")
+	gitRun(t, source, "config", "tag.gpgSign", "false")
+	gitRun(t, source, "config", "tag.forceSignAnnotated", "false")
+
+	// Older release 1.0.0
+	writeFile(t, source, "composer.json", `{"version":"1.0.0"}`)
+	gitRun(t, source, "add", ".")
+	gitRun(t, source, "commit", "-m", "1.0.0")
+
+	// Current release 2.0.0 on HEAD
+	writeFile(t, source, "composer.json", `{"version":"2.0.0"}`)
+	gitRun(t, source, "add", ".")
+	gitRun(t, source, "commit", "-m", "2.0.0")
+	gitRun(t, source, "tag", "-a", "-m", "2.0.0", "2.0.0")
+
+	// Tag the older commit *after* the newer one, so a -creatordate sort over all
+	// tags would surface 1.0.0 first - the regression from issue #1116.
+	gitRun(t, source, "tag", "-a", "-m", "1.0.0", "1.0.0", "HEAD~1")
+
+	target := t.TempDir()
+
+	tag, err := GitCopyFolder(ctx, source, target, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0.0", tag)
+
+	content, err := os.ReadFile(filepath.Join(target, "composer.json"))
+	require.NoError(t, err)
+	assert.Equal(t, `{"version":"2.0.0"}`, string(content))
+}
+
+func TestGitCopyFolderFallsBackToBranchWithoutTagAtHead(t *testing.T) {
+	source := t.TempDir()
+	ctx := context.Background()
+
+	gitRun(t, source, "init")
+	gitRun(t, source, "config", "commit.gpgsign", "false")
+	gitRun(t, source, "config", "tag.gpgSign", "false")
+	gitRun(t, source, "config", "tag.forceSignAnnotated", "false")
+	gitRun(t, source, "checkout", "-b", "main")
+
+	writeFile(t, source, "composer.json", `{"version":"1.0.0"}`)
+	gitRun(t, source, "add", ".")
+	gitRun(t, source, "commit", "-m", "1.0.0")
+	gitRun(t, source, "tag", "-a", "-m", "1.0.0", "1.0.0")
+
+	// New unreleased commit on top of the tag - no tag points at HEAD.
+	writeFile(t, source, "composer.json", `{"version":"1.0.1"}`)
+	gitRun(t, source, "add", ".")
+	gitRun(t, source, "commit", "-m", "wip")
+
+	target := t.TempDir()
+
+	tag, err := GitCopyFolder(ctx, source, target, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "main", tag)
+
+	content, err := os.ReadFile(filepath.Join(target, "composer.json"))
+	require.NoError(t, err)
+	assert.Equal(t, `{"version":"1.0.1"}`, string(content))
+}

--- a/internal/extension/git_test.go
+++ b/internal/extension/git_test.go
@@ -1,7 +1,6 @@
 package extension
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +12,7 @@ import (
 
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
 	cmd.Env = append(os.Environ(),
 		"GIT_AUTHOR_NAME=test",
 		"GIT_AUTHOR_EMAIL=test@example.com",
@@ -24,14 +23,14 @@ func gitRun(t *testing.T, dir string, args ...string) {
 	require.NoError(t, err, "git %v: %s", args, string(out))
 }
 
-func writeFile(t *testing.T, dir, name, content string) {
+func writeComposerJSON(t *testing.T, dir, content string) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "composer.json"), []byte(content), 0o644))
 }
 
 func TestGitCopyFolderArchivesHeadNotNewestTag(t *testing.T) {
 	source := t.TempDir()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	gitRun(t, source, "init")
 	gitRun(t, source, "config", "commit.gpgsign", "false")
@@ -39,12 +38,12 @@ func TestGitCopyFolderArchivesHeadNotNewestTag(t *testing.T) {
 	gitRun(t, source, "config", "tag.forceSignAnnotated", "false")
 
 	// Older release 1.0.0
-	writeFile(t, source, "composer.json", `{"version":"1.0.0"}`)
+	writeComposerJSON(t, source, `{"version":"1.0.0"}`)
 	gitRun(t, source, "add", ".")
 	gitRun(t, source, "commit", "-m", "1.0.0")
 
 	// Current release 2.0.0 on HEAD
-	writeFile(t, source, "composer.json", `{"version":"2.0.0"}`)
+	writeComposerJSON(t, source, `{"version":"2.0.0"}`)
 	gitRun(t, source, "add", ".")
 	gitRun(t, source, "commit", "-m", "2.0.0")
 	gitRun(t, source, "tag", "-a", "-m", "2.0.0", "2.0.0")
@@ -67,7 +66,7 @@ func TestGitCopyFolderArchivesHeadNotNewestTag(t *testing.T) {
 
 func TestGitCopyFolderFallsBackToBranchWithoutTagAtHead(t *testing.T) {
 	source := t.TempDir()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	gitRun(t, source, "init")
 	gitRun(t, source, "config", "commit.gpgsign", "false")
@@ -75,13 +74,13 @@ func TestGitCopyFolderFallsBackToBranchWithoutTagAtHead(t *testing.T) {
 	gitRun(t, source, "config", "tag.forceSignAnnotated", "false")
 	gitRun(t, source, "checkout", "-b", "main")
 
-	writeFile(t, source, "composer.json", `{"version":"1.0.0"}`)
+	writeComposerJSON(t, source, `{"version":"1.0.0"}`)
 	gitRun(t, source, "add", ".")
 	gitRun(t, source, "commit", "-m", "1.0.0")
 	gitRun(t, source, "tag", "-a", "-m", "1.0.0", "1.0.0")
 
 	// New unreleased commit on top of the tag - no tag points at HEAD.
-	writeFile(t, source, "composer.json", `{"version":"1.0.1"}`)
+	writeComposerJSON(t, source, `{"version":"1.0.1"}`)
 	gitRun(t, source, "add", ".")
 	gitRun(t, source, "commit", "-m", "wip")
 


### PR DESCRIPTION
## Problem

`shopware-cli extension zip <path>` without `--git-commit` packages the **wrong git tree**. The zip filename reflects the current version (from `composer.json`), but its contents are an *older* tagged version — so `account producer extension upload` skips the upload as "Binary version is already published".

## Root cause

In `internal/extension/git.go`, the default ref resolution ran:

```go
git tag --sort=-creatordate
```

and took the first tag — **the newest tag in the whole repo, regardless of where HEAD points** — then `git archive`d that tag's tree. The selected tag depends on tag creation dates, not on the checked-out commit. In CI building a specific tag (detached HEAD), a different tag created later sorts first and its stale tree gets packaged.

This is the same defect as #753 (built `1.4.4`, got a `v1.3.7.zip`).

## Fix

Restrict the tag lookup to tags pointing at HEAD:

```go
git tag --points-at HEAD --sort=-creatordate
```

falling back to the current branch as before. The resolved ref/filename now always matches the checked-out commit.

## Tests

Added `internal/extension/git_test.go`:
- Regression case: tags `1.0.0`/`2.0.0` where `1.0.0` is tagged *later* (so a creatordate sort surfaces it first) — asserts HEAD's `2.0.0` tree is packaged. Verified this **fails on the old code** and passes with the fix.
- Fallback case: unreleased commit on top of a tag (no tag at HEAD) — asserts branch name + latest tree.

Fixes #1116. Same defect as #753.