### PR TITLE
Remove PHP profiler from setup wizard; show free/paid in config

### DIFF
--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -257,19 +257,6 @@ func (m Model) saveSetupGuide() (tea.Model, tea.Cmd) {
 	}
 	m.setupGuide.deploymentHelperAdded = changed
 
-	if localCfg := m.setupGuide.localConfig(); localCfg != nil {
-		if err := shop.WriteLocalConfig(localCfg, m.projectRoot); err != nil {
-			m.setupGuide.err = err
-			m.setupGuide.step = setupStepDone
-			return m, nil
-		}
-		// Mirror the just-written profiler secrets onto the in-memory config
-		// so the first generated compose.yaml wires them up. They remain in
-		// .shopware-project.local.yml (not the committed config); this is
-		// only the runtime view ReadConfig would have produced on next launch.
-		mergeLocalProfilerSecrets(m.config, localCfg)
-	}
-
 	m.setupGuide.step = setupStepDone
 	return m, nil
 }

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -7,7 +7,6 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
 	"github.com/shopware/shopware-cli/internal/packagist"
 )
 
@@ -17,23 +16,15 @@ const (
 	setupStepWelcome setupStep = iota
 	setupStepAdminUser
 	setupStepDockerPHP
-	setupStepDockerProfiler
-	setupStepProfilerCreds
 	setupStepReview
 	setupStepDone
 )
-
-// profilerChoices is the list of profiler options shown in the setup guide UI.
-// The first entry uses "none" for display; internally it maps to "" (empty string)
-// which is the canonical value stored in config.
-var profilerChoices = []string{"none", dockerpkg.ProfilerXdebug, dockerpkg.ProfilerBlackfire, dockerpkg.ProfilerTideways, dockerpkg.ProfilerPcov, dockerpkg.ProfilerSpx}
 
 type setupGuide struct {
 	step                  setupStep
 	phpVersions           []string // PHP versions compatible with the project
 	phpConstraint         string   // raw constraint string, for display ("" if none)
 	phpCursor             int
-	profilerCursor        int
 	confirmYes            bool
 	deploymentHelperAdded bool // composer.json was updated to require shopware/deployment-helper
 	url                   textinput.Model
@@ -41,23 +32,18 @@ type setupGuide struct {
 	password              textinput.Model
 	passwordErr           string
 	credFocus             credFocus
-	blackfireServerID     textinput.Model
-	blackfireServerToken  textinput.Model
-	tidewaysAPIKey        textinput.Model
 
 	err error
 }
 
 // setupGuideConfig holds the final configuration values chosen by the user.
+// The setup wizard no longer selects a PHP profiler; it defaults to none and
+// the user can enable one later in the Config tab.
 type setupGuideConfig struct {
-	url                  string
-	username             string
-	password             string
-	phpVersion           string
-	profiler             string
-	blackfireServerID    string
-	blackfireServerToken string
-	tidewaysAPIKey       string
+	url        string
+	username   string
+	password   string
+	phpVersion string
 }
 
 // resolvePHPVersions reads composer.lock from projectRoot and returns the
@@ -112,53 +98,26 @@ func newSetupGuide(projectRoot string) setupGuide {
 	passwordInput.EchoMode = textinput.EchoPassword
 	passwordInput.SetValue("shopware")
 
-	blackfireIDInput := textinput.New()
-	blackfireIDInput.Placeholder = "Server ID"
-	blackfireIDInput.CharLimit = 128
-	blackfireIDInput.Prompt = ""
-
-	blackfireTokenInput := textinput.New()
-	blackfireTokenInput.Placeholder = "Server Token"
-	blackfireTokenInput.CharLimit = 128
-	blackfireTokenInput.Prompt = ""
-
-	tidewaysKeyInput := textinput.New()
-	tidewaysKeyInput.Placeholder = "API Key"
-	tidewaysKeyInput.CharLimit = 128
-	tidewaysKeyInput.Prompt = ""
-
 	phpVersions, phpCursor, phpConstraint := resolvePHPVersions(projectRoot)
 
 	return setupGuide{
-		step:                 setupStepWelcome,
-		phpVersions:          phpVersions,
-		phpConstraint:        phpConstraint,
-		phpCursor:            phpCursor,
-		profilerCursor:       0, // Default to none
-		confirmYes:           true,
-		url:                  urlInput,
-		username:             usernameInput,
-		password:             passwordInput,
-		blackfireServerID:    blackfireIDInput,
-		blackfireServerToken: blackfireTokenInput,
-		tidewaysAPIKey:       tidewaysKeyInput,
+		step:          setupStepWelcome,
+		phpVersions:   phpVersions,
+		phpConstraint: phpConstraint,
+		phpCursor:     phpCursor,
+		confirmYes:    true,
+		url:           urlInput,
+		username:      usernameInput,
+		password:      passwordInput,
 	}
 }
 
 func (sg *setupGuide) currentConfig() setupGuideConfig {
-	profiler := profilerChoices[sg.profilerCursor]
-	if profiler == "none" {
-		profiler = ""
-	}
 	return setupGuideConfig{
-		url:                  sg.url.Value(),
-		username:             sg.username.Value(),
-		password:             sg.password.Value(),
-		phpVersion:           sg.phpVersions[sg.phpCursor],
-		profiler:             profiler,
-		blackfireServerID:    sg.blackfireServerID.Value(),
-		blackfireServerToken: sg.blackfireServerToken.Value(),
-		tidewaysAPIKey:       sg.tidewaysAPIKey.Value(),
+		url:        sg.url.Value(),
+		username:   sg.username.Value(),
+		password:   sg.password.Value(),
+		phpVersion: sg.phpVersions[sg.phpCursor],
 	}
 }
 
@@ -173,10 +132,6 @@ func (sg *setupGuide) update(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
 		return sg.updateAdminUser(msg)
 	case setupStepDockerPHP:
 		return sg.updateDockerPHP(msg)
-	case setupStepDockerProfiler:
-		return sg.updateDockerProfiler(msg)
-	case setupStepProfilerCreds:
-		return sg.updateProfilerCreds(msg)
 	case setupStepReview:
 		return sg.updateReview(msg)
 	case setupStepDone:
@@ -292,74 +247,9 @@ func (sg *setupGuide) updateDockerPHP(msg tea.KeyPressMsg) (setupGuide, tea.Cmd)
 			sg.phpCursor++
 		}
 	case keyEnter:
-		sg.step = setupStepDockerProfiler
+		sg.step = setupStepReview
 		return *sg, nil
 	}
-	return *sg, nil
-}
-
-func (sg *setupGuide) updateDockerProfiler(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
-	switch msg.String() {
-	case keyUp, keyK:
-		if sg.profilerCursor > 0 {
-			sg.profilerCursor--
-		}
-	case keyDown, keyJ:
-		if sg.profilerCursor < len(profilerChoices)-1 {
-			sg.profilerCursor++
-		}
-	case keyEnter:
-		profiler := profilerChoices[sg.profilerCursor]
-		if !dockerpkg.ProfilerNeedsCredentials(profiler) {
-			sg.step = setupStepReview
-			return *sg, nil
-		}
-		sg.step = setupStepProfilerCreds
-		switch profiler {
-		case "blackfire":
-			sg.blackfireServerID.Focus()
-		case "tideways":
-			sg.tidewaysAPIKey.Focus()
-		}
-		return *sg, textinput.Blink
-	}
-	return *sg, nil
-}
-
-func (sg *setupGuide) updateProfilerCreds(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
-	if sg.blackfireServerID.Focused() {
-		if msg.String() == keyEnter {
-			sg.blackfireServerID.Blur()
-			sg.blackfireServerToken.Focus()
-			return *sg, textinput.Blink
-		}
-		var cmd tea.Cmd
-		sg.blackfireServerID, cmd = sg.blackfireServerID.Update(msg)
-		return *sg, cmd
-	}
-
-	if sg.blackfireServerToken.Focused() {
-		if msg.String() == keyEnter {
-			sg.blackfireServerToken.Blur()
-			sg.step = setupStepReview
-			return *sg, nil
-		}
-		var cmd tea.Cmd
-		sg.blackfireServerToken, cmd = sg.blackfireServerToken.Update(msg)
-		return *sg, cmd
-	}
-
-	if sg.tidewaysAPIKey.Focused() {
-		if msg.String() == keyEnter {
-			sg.tidewaysAPIKey.Blur()
-			sg.step = setupStepReview
-			return *sg, nil
-		}
-		var cmd tea.Cmd
-		sg.tidewaysAPIKey, cmd = sg.tidewaysAPIKey.Update(msg)
-		return *sg, cmd
-	}
-
 	return *sg, nil
 }
 

--- a/internal/devtui/setup_guide_apply.go
+++ b/internal/devtui/setup_guide_apply.go
@@ -43,7 +43,6 @@ func (sg *setupGuide) applyToConfig(cfg *shop.Config) {
 		cfg.Docker.PHP = &shop.ConfigDockerPHP{}
 	}
 	cfg.Docker.PHP.Version = c.phpVersion
-	cfg.Docker.PHP.Profiler = c.profiler
 }
 
 // ensureDeploymentHelper adds shopware/deployment-helper to the project's
@@ -83,31 +82,4 @@ func ensureDeploymentHelper(projectRoot string) (changed bool, err error) {
 		return false, err
 	}
 	return true, nil
-}
-
-// localConfig returns a partial Config containing secrets that should be
-// written to .shopware-project.local.yml. Profilers without external
-// credentials (none, xdebug, pcov, spx) return nil.
-func (sg *setupGuide) localConfig() *shop.Config {
-	c := sg.currentConfig()
-	switch c.profiler {
-	case "blackfire":
-		return &shop.Config{
-			Docker: &shop.ConfigDocker{
-				PHP: &shop.ConfigDockerPHP{
-					BlackfireServerID:    c.blackfireServerID,
-					BlackfireServerToken: c.blackfireServerToken,
-				},
-			},
-		}
-	case "tideways":
-		return &shop.Config{
-			Docker: &shop.ConfigDocker{
-				PHP: &shop.ConfigDockerPHP{
-					TidewaysAPIKey: c.tidewaysAPIKey,
-				},
-			},
-		}
-	}
-	return nil
 }

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -281,7 +281,6 @@ func TestNewSetupGuide(t *testing.T) {
 	// Without a composer.lock the wizard offers every supported PHP version
 	// and defaults the cursor to the highest.
 	assert.Equal(t, len(sg.phpVersions)-1, sg.phpCursor)
-	assert.Equal(t, 0, sg.profilerCursor) // Default to none
 	assert.True(t, sg.confirmYes)
 	assert.Equal(t, "http://127.0.0.1:8000", sg.url.Value())
 	assert.Equal(t, "admin", sg.username.Value())
@@ -290,23 +289,13 @@ func TestNewSetupGuide(t *testing.T) {
 
 func TestSetupGuideCurrentConfig(t *testing.T) {
 	sg := newSetupGuide("")
-	sg.phpCursor = 2      // 8.4
-	sg.profilerCursor = 0 // none
+	sg.phpCursor = 2 // 8.4
 
 	c := sg.currentConfig()
 	assert.Equal(t, "http://127.0.0.1:8000", c.url)
 	assert.Equal(t, "admin", c.username)
 	assert.Equal(t, "shopware", c.password)
 	assert.Equal(t, "8.4", c.phpVersion)
-	assert.Equal(t, "", c.profiler) // none -> ""
-}
-
-func TestSetupGuideCurrentConfig_Xdebug(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.profilerCursor = 1 // xdebug
-
-	c := sg.currentConfig()
-	assert.Equal(t, "xdebug", c.profiler)
 }
 
 func TestSetupGuideApplyToConfig(t *testing.T) {
@@ -343,35 +332,6 @@ func TestSetupGuideApplyToConfig_PreservesExistingURL(t *testing.T) {
 	assert.Equal(t, "http://127.0.0.1:8000", cfg.Environments["local"].URL)
 }
 
-func TestSetupGuideLocalConfig_None(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.profilerCursor = 0 // none
-
-	assert.Nil(t, sg.localConfig())
-}
-
-func TestSetupGuideLocalConfig_Blackfire(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.profilerCursor = 2 // blackfire
-	sg.blackfireServerID.SetValue("my-id")
-	sg.blackfireServerToken.SetValue("my-token")
-
-	localCfg := sg.localConfig()
-	assert.NotNil(t, localCfg)
-	assert.Equal(t, "my-id", localCfg.Docker.PHP.BlackfireServerID)
-	assert.Equal(t, "my-token", localCfg.Docker.PHP.BlackfireServerToken)
-}
-
-func TestSetupGuideLocalConfig_Tideways(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.profilerCursor = 3 // tideways
-	sg.tidewaysAPIKey.SetValue("my-key")
-
-	localCfg := sg.localConfig()
-	assert.NotNil(t, localCfg)
-	assert.Equal(t, "my-key", localCfg.Docker.PHP.TidewaysAPIKey)
-}
-
 func TestSetupGuideViewSteps(t *testing.T) {
 	sg := newSetupGuide("")
 
@@ -390,10 +350,6 @@ func TestSetupGuideViewSteps(t *testing.T) {
 	view = sg.viewContent()
 	assert.Contains(t, view, "PHP")
 
-	sg.step = setupStepDockerProfiler
-	view = sg.viewContent()
-	assert.Contains(t, view, "Profiler")
-
 	sg.step = setupStepReview
 	view = sg.viewContent()
 	assert.Contains(t, view, "Review")
@@ -408,99 +364,20 @@ func TestSetupGuideWelcomeDefaultConfirmYes(t *testing.T) {
 	assert.True(t, suggest.confirmYes)
 }
 
-func TestSetupGuideProfiler_NoneSkipsCredsStep(t *testing.T) {
+func TestSetupGuideDockerPHPAdvancesToReview(t *testing.T) {
 	sg := newSetupGuide("")
-	sg.step = setupStepDockerProfiler
-	sg.profilerCursor = 0 // none
+	sg.step = setupStepDockerPHP
 
 	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
 	assert.Equal(t, setupStepReview, next.step)
-	assert.False(t, next.blackfireServerID.Focused())
-	assert.False(t, next.tidewaysAPIKey.Focused())
 }
 
-func TestSetupGuideProfiler_BlackfireRoutesToCredsAndFocusesID(t *testing.T) {
+func TestSetupGuideStepNumbering(t *testing.T) {
 	sg := newSetupGuide("")
-	sg.step = setupStepDockerProfiler
-	sg.profilerCursor = 2 // blackfire
-
-	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.Equal(t, setupStepProfilerCreds, next.step)
-	assert.True(t, next.blackfireServerID.Focused())
-	assert.False(t, next.blackfireServerToken.Focused())
-}
-
-func TestSetupGuideProfiler_TidewaysRoutesToCredsAndFocusesKey(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.step = setupStepDockerProfiler
-	sg.profilerCursor = 3 // tideways
-
-	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.Equal(t, setupStepProfilerCreds, next.step)
-	assert.True(t, next.tidewaysAPIKey.Focused())
-}
-
-func TestSetupGuideProfiler_BlackfireCredsAdvanceThroughInputs(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.step = setupStepDockerProfiler
-	sg.profilerCursor = 2 // blackfire
-
-	// Enter on profiler step → focuses Server ID
-	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.True(t, sg.blackfireServerID.Focused())
-
-	// Enter advances ID → Token
-	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.False(t, sg.blackfireServerID.Focused())
-	assert.True(t, sg.blackfireServerToken.Focused())
-	assert.Equal(t, setupStepProfilerCreds, sg.step)
-
-	// Enter on Token advances to Review
-	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.False(t, sg.blackfireServerToken.Focused())
-	assert.Equal(t, setupStepReview, sg.step)
-}
-
-func TestSetupGuideProfiler_TidewaysCredsAdvanceToReview(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.step = setupStepDockerProfiler
-	sg.profilerCursor = 3 // tideways
-
-	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.True(t, sg.tidewaysAPIKey.Focused())
-
-	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	assert.False(t, sg.tidewaysAPIKey.Focused())
-	assert.Equal(t, setupStepReview, sg.step)
-}
-
-func TestSetupGuideViewProfilerCreds(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.step = setupStepProfilerCreds
-	sg.profilerCursor = 2 // blackfire
-	sg.blackfireServerID.Focus()
-
-	view := sg.viewContent()
-	assert.Contains(t, view, "Blackfire")
-	assert.Contains(t, view, "Server ID")
-}
-
-func TestSetupGuideStepNumbering_NoProfilerCreds(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.profilerCursor = 0 // none → no creds step
-	assert.Equal(t, 4, sg.totalSteps())
+	assert.Equal(t, 3, sg.totalSteps())
 	assert.Equal(t, 1, sg.stepNum(setupStepAdminUser))
 	assert.Equal(t, 2, sg.stepNum(setupStepDockerPHP))
-	assert.Equal(t, 3, sg.stepNum(setupStepDockerProfiler))
-	assert.Equal(t, 4, sg.stepNum(setupStepReview))
+	assert.Equal(t, 3, sg.stepNum(setupStepReview))
 	assert.Equal(t, 0, sg.stepNum(setupStepWelcome))
 	assert.Equal(t, 0, sg.stepNum(setupStepDone))
-}
-
-func TestSetupGuideStepNumbering_WithProfilerCreds(t *testing.T) {
-	sg := newSetupGuide("")
-	sg.profilerCursor = 2 // blackfire → adds creds step
-	assert.Equal(t, 5, sg.totalSteps())
-	assert.Equal(t, 4, sg.stepNum(setupStepProfilerCreds))
-	assert.Equal(t, 5, sg.stepNum(setupStepReview))
 }

--- a/internal/devtui/setup_guide_view.go
+++ b/internal/devtui/setup_guide_view.go
@@ -7,7 +7,6 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/lipgloss/v2"
 
-	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -19,10 +18,6 @@ func (sg setupGuide) viewContent() string {
 		return sg.viewAdminUser()
 	case setupStepDockerPHP:
 		return sg.viewDockerPHP()
-	case setupStepDockerProfiler:
-		return sg.viewDockerProfiler()
-	case setupStepProfilerCreds:
-		return sg.viewProfilerCreds()
 	case setupStepReview:
 		return sg.viewReview()
 	case setupStepDone:
@@ -35,15 +30,10 @@ func stepBadge(stepNum, totalSteps int) string {
 	return tui.TextBadge(fmt.Sprintf("Step %d/%d", stepNum, totalSteps))
 }
 
-// totalSteps returns the number of numbered wizard steps. The profiler
-// credentials step is only counted when the chosen profiler needs them.
+// totalSteps returns the number of numbered wizard steps:
+// admin account, PHP version, review.
 func (sg setupGuide) totalSteps() int {
-	// admin account, PHP version, profiler, review
-	total := 4
-	if dockerpkg.ProfilerNeedsCredentials(profilerChoices[sg.profilerCursor]) {
-		total++
-	}
-	return total
+	return 3
 }
 
 // stepNum returns the 1-based index of the given wizard step within the
@@ -55,15 +45,8 @@ func (sg setupGuide) stepNum(step setupStep) int {
 		return 1
 	case setupStepDockerPHP:
 		return 2
-	case setupStepDockerProfiler:
-		return 3
-	case setupStepProfilerCreds:
-		return 4
 	case setupStepReview:
-		if dockerpkg.ProfilerNeedsCredentials(profilerChoices[sg.profilerCursor]) {
-			return 5
-		}
-		return 4
+		return 3
 	case setupStepWelcome, setupStepDone:
 		return 0
 	}
@@ -155,65 +138,6 @@ func (sg setupGuide) viewDockerPHP() string {
 	return tui.RenderPhaseCard(b.String())
 }
 
-func (sg setupGuide) viewDockerProfiler() string {
-	var b strings.Builder
-	b.WriteString(stepBadge(sg.stepNum(setupStepDockerProfiler), sg.totalSteps()))
-	b.WriteString("\n\n")
-	b.WriteString(tui.TitleStyle.Render("PHP Profiler"))
-	b.WriteString("\n")
-	b.WriteString(tui.DimStyle.Render("Optionally enable a profiler for debugging."))
-	b.WriteString("\n")
-	b.WriteString(tui.DimStyle.Render("Can be changed later in the Config tab."))
-	b.WriteString("\n\n")
-
-	opts := make([]tui.SelectOption, len(profilerChoices))
-	for i, p := range profilerChoices {
-		label := p
-		desc := ""
-		switch p {
-		case "none":
-			label = "None"
-			desc = "recommended"
-		case "xdebug":
-			desc = "step debugging"
-		}
-		opts[i] = tui.SelectOption{Label: label, Detail: desc}
-	}
-	b.WriteString(tui.RenderSelectList("Profiler", "", opts, sg.profilerCursor))
-	b.WriteString("\n")
-	return tui.RenderPhaseCard(b.String())
-}
-
-func (sg setupGuide) viewProfilerCreds() string {
-	var b strings.Builder
-	b.WriteString(stepBadge(sg.stepNum(setupStepProfilerCreds), sg.totalSteps()))
-	b.WriteString("\n\n")
-
-	switch {
-	case sg.blackfireServerID.Focused():
-		b.WriteString(tui.TitleStyle.Render("Blackfire Configuration"))
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter your Blackfire Server ID from your Blackfire account."))
-		b.WriteString("\n\n")
-		b.WriteString(sg.blackfireServerID.View())
-	case sg.blackfireServerToken.Focused():
-		b.WriteString(tui.TitleStyle.Render("Blackfire Configuration"))
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter your Blackfire Server Token."))
-		b.WriteString("\n\n")
-		b.WriteString(sg.blackfireServerToken.View())
-	case sg.tidewaysAPIKey.Focused():
-		b.WriteString(tui.TitleStyle.Render("Tideways Configuration"))
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Enter your Tideways API key."))
-		b.WriteString("\n\n")
-		b.WriteString(sg.tidewaysAPIKey.View())
-	}
-
-	b.WriteString("\n\n")
-	return tui.RenderPhaseCard(b.String())
-}
-
 func (sg setupGuide) viewReview() string {
 	c := sg.currentConfig()
 	var b strings.Builder
@@ -231,11 +155,6 @@ func (sg setupGuide) viewReview() string {
 	b.WriteString(tui.KVRow("Password", secretStyle.Render(strings.Repeat("•", len(c.password)))))
 	b.WriteString(divider)
 	b.WriteString(tui.KVRow("PHP Version", valueStyle.Render("PHP "+c.phpVersion)))
-	profilerLabel := c.profiler
-	if profilerLabel == "" {
-		profilerLabel = "none"
-	}
-	b.WriteString(tui.KVRow("Profiler", valueStyle.Render(profilerLabel)))
 
 	b.WriteString("\n")
 	b.WriteString(tui.DimStyle.Render("This will create:"))
@@ -246,13 +165,6 @@ func (sg setupGuide) viewReview() string {
 	b.WriteString(tui.DimStyle.Render("  • "))
 	b.WriteString(tui.BoldText.Render("compose.yaml"))
 	b.WriteString("\n")
-
-	if c.profiler == "blackfire" || c.profiler == "tideways" {
-		b.WriteString(tui.DimStyle.Render("  • "))
-		b.WriteString(tui.BoldText.Render(".shopware-project.local.yml"))
-		b.WriteString(tui.DimStyle.Render(" (secrets only)"))
-		b.WriteString("\n")
-	}
 
 	b.WriteString("\n")
 	b.WriteString(renderConfirmButtons("Save & start", "Quit", sg.confirmYes))
@@ -317,13 +229,9 @@ func (sg setupGuide) footerHint() string {
 			tui.Shortcut{Key: "↑/↓/tab", Label: "Navigate"},
 			tui.Shortcut{Key: "enter", Label: "Continue"},
 		)
-	case setupStepDockerPHP, setupStepDockerProfiler:
+	case setupStepDockerPHP:
 		return tui.ShortcutBar(
 			tui.Shortcut{Key: "↑/↓", Label: "Select"},
-			tui.Shortcut{Key: "enter", Label: "Continue"},
-		)
-	case setupStepProfilerCreds:
-		return tui.ShortcutBar(
 			tui.Shortcut{Key: "enter", Label: "Continue"},
 		)
 	case setupStepReview:

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -233,10 +233,15 @@ func (m ConfigModel) PickerForCursor() Modal {
 		items := make([]listPickerItem, len(profilers))
 		for i, p := range profilers {
 			label := p
-			if p == "" {
+			detail := "free"
+			switch {
+			case p == "":
 				label = "none"
+				detail = ""
+			case dockerpkg.ProfilerIsPaid(p):
+				detail = "paid"
 			}
-			items[i] = listPickerItem{Label: label, Value: p}
+			items[i] = listPickerItem{Label: label, Detail: detail, Value: p}
 		}
 		return newListPicker(fieldProfiler, "PHP Profiler", "", items, m.profiler)
 	case fieldBlackfireServerID:

--- a/internal/devtui/tab_config_test.go
+++ b/internal/devtui/tab_config_test.go
@@ -170,6 +170,27 @@ func TestConfigModel_PickerForCursor_Select(t *testing.T) {
 	assert.ElementsMatch(t, phpVersions, values)
 }
 
+func TestConfigModel_PickerForCursor_ProfilerFreePaidLabels(t *testing.T) {
+	m := NewConfigModel(nil, nil)
+	m.cursor = fieldProfiler
+
+	modal := m.PickerForCursor()
+	picker, ok := modal.(*listPicker)
+	assert.True(t, ok)
+
+	details := make(map[string]string, len(picker.items))
+	for _, it := range picker.items {
+		details[it.Value] = it.Detail
+	}
+
+	assert.Equal(t, "", details[""])              // none has no free/paid badge
+	assert.Equal(t, "free", details["xdebug"])    // open source
+	assert.Equal(t, "free", details["pcov"])      // open source
+	assert.Equal(t, "free", details["spx"])       // open source
+	assert.Equal(t, "paid", details["blackfire"]) // commercial SaaS
+	assert.Equal(t, "paid", details["tideways"])  // commercial SaaS
+}
+
 func TestConfigModel_PickerForCursor_Text(t *testing.T) {
 	m := NewConfigModel(nil, nil)
 	m.profiler = indexOf(profilers, "blackfire", 0)

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -32,6 +32,13 @@ func ProfilerNeedsCredentials(profiler string) bool {
 	return profiler == ProfilerBlackfire || profiler == ProfilerTideways
 }
 
+// ProfilerIsPaid reports whether the given profiler is a commercial product
+// that requires a paid account or plan. Blackfire and Tideways are paid SaaS
+// products; xdebug, pcov and spx are free and open source.
+func ProfilerIsPaid(profiler string) bool {
+	return profiler == ProfilerBlackfire || profiler == ProfilerTideways
+}
+
 type ComposeOptions struct {
 	PHPVersion           string
 	PHPProfiler          string

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -20,6 +20,17 @@ func TestProfilerNeedsCredentials(t *testing.T) {
 	assert.True(t, ProfilerNeedsCredentials(ProfilerTideways))
 }
 
+func TestProfilerIsPaid(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ProfilerIsPaid(""))
+	assert.False(t, ProfilerIsPaid(ProfilerXdebug))
+	assert.False(t, ProfilerIsPaid(ProfilerPcov))
+	assert.False(t, ProfilerIsPaid(ProfilerSpx))
+	assert.True(t, ProfilerIsPaid(ProfilerBlackfire))
+	assert.True(t, ProfilerIsPaid(ProfilerTideways))
+}
+
 func TestGenerateComposeFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Addresses two scoped asks from #1113:

### 1. Remove the PHP Profiler from the setup/migration wizard
The `project dev` setup wizard no longer has a profiler step (or its conditional Blackfire/Tideways credentials step). The flow is now **Welcome → Admin Account → Docker PHP → Review → Done** — 3 numbered steps (was up to 5). During migration the profiler defaults to none; users enable one later in the Config tab.

### 2. Profiler selection shows free vs. paid
The Config tab profiler picker now shows a badge per option:
- **free**: xdebug, pcov, spx (open source)
- **paid**: blackfire, tideways (commercial SaaS, require an account/plan)
- none: no badge

Adds `docker.ProfilerIsPaid()` as the canonical classifier alongside the existing `ProfilerNeedsCredentials()`.

## Notes
- `mergeLocalProfilerSecrets` and the Config tab's `LocalConfig()` are untouched — the Config tab still writes Blackfire/Tideways secrets to `.shopware-project.local.yml`.
- The wizard's now-dead `localConfig()` (could only ever return nil after the profiler creds left the wizard) was removed.

## Tests
- Updated wizard tests for the new flow and step numbering; removed obsolete profiler-step tests.
- Added `TestConfigModel_PickerForCursor_ProfilerFreePaidLabels`, `TestProfilerIsPaid`, `TestSetupGuideDockerPHPAdvancesToReview`.
- `go test ./...`, `go vet`, gofmt, and golangci-lint on the touched packages all pass.

Refs #1113