### PR TITLE
Clarify admin account panel in dev wizards

### DIFF
--- a/internal/devtui/install_wizard.go
+++ b/internal/devtui/install_wizard.go
@@ -295,13 +295,14 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 		b.WriteString("\n\n")
 		b.WriteString(tui.TitleStyle.Render("Admin Account"))
 		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Set the username and password for the admin account"))
+		b.WriteString(tui.DimStyle.Render("The login for the Shopware admin panel and API."))
 		b.WriteString("\n\n")
-		b.WriteString(tui.DimStyle.Render("Username"))
+		b.WriteString(valueStyle.Render("Choose a username"))
 		b.WriteString("\n")
 		b.WriteString(m.install.username.View())
 		b.WriteString("\n\n")
-		b.WriteString(tui.DimStyle.Render("Password (default: shopware)"))
+		b.WriteString(valueStyle.Render("Choose a password"))
+		b.WriteString(tui.DimStyle.Render("  at least 8 characters"))
 		b.WriteString("\n")
 		b.WriteString(m.install.password.View())
 		if m.install.passwordErr != "" {
@@ -310,6 +311,8 @@ func (m Model) renderInstallPrompt(b *strings.Builder) {
 		}
 		b.WriteString("\n\n")
 		b.WriteString(renderShowPasswordCheckbox(m.install.password.EchoMode == textinput.EchoNormal, m.install.credFocus == credFocusShowPassword))
+		b.WriteString("\n\n")
+		b.WriteString(tui.DimStyle.Render("Used to create the Shopware admin user."))
 	}
 }
 

--- a/internal/devtui/install_wizard_test.go
+++ b/internal/devtui/install_wizard_test.go
@@ -335,7 +335,7 @@ func TestRenderInstallPrompt_PasswordErrorShown(t *testing.T) {
 
 	var b strings.Builder
 	m.renderInstallPrompt(&b)
-	assert.Contains(t, b.String(), "at least 8 characters")
+	assert.Contains(t, b.String(), "password must be at least 8 characters long")
 }
 
 func TestRenderInstallPrompt_AllStepsDoNotPanic(t *testing.T) {
@@ -348,7 +348,7 @@ func TestRenderInstallPrompt_AllStepsDoNotPanic(t *testing.T) {
 		{installStepAsk, []string{"Shopware is not initialized yet", "Initialize now"}},
 		{installStepLanguage, []string{"Step 1/3", "Default Language"}},
 		{installStepCurrency, []string{"Step 2/3", "Default Currency"}},
-		{installStepCredentials, []string{"Step 3/3", "Admin Account", "Username", "Password"}},
+		{installStepCredentials, []string{"Step 3/3", "Admin Account", "Choose a username", "Choose a password"}},
 	}
 
 	for _, s := range steps {

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -103,6 +103,10 @@ func TestSetupGuideAdminUser_TabNavigatesFocus(t *testing.T) {
 	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
 	assert.Equal(t, credFocusShowPassword, sg.credFocus)
 	assert.False(t, sg.password.Focused())
+
+	// Tab past the checkbox stays on the checkbox.
+	sg, _ = sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	assert.Equal(t, credFocusShowPassword, sg.credFocus)
 }
 
 func TestSetupGuideAdminUser_EnterOnCheckboxTogglesEcho(t *testing.T) {
@@ -343,8 +347,8 @@ func TestSetupGuideViewSteps(t *testing.T) {
 	sg.username.Focus()
 	view = sg.viewContent()
 	assert.Contains(t, view, "Step")
-	assert.Contains(t, view, "Username")
-	assert.Contains(t, view, "Password")
+	assert.Contains(t, view, "Choose a username")
+	assert.Contains(t, view, "Choose a password")
 
 	sg.step = setupStepDockerPHP
 	view = sg.viewContent()

--- a/internal/devtui/setup_guide_view.go
+++ b/internal/devtui/setup_guide_view.go
@@ -96,13 +96,14 @@ func (sg setupGuide) viewAdminUser() string {
 	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Admin Account"))
 	b.WriteString("\n")
-	b.WriteString(tui.DimStyle.Render("Credentials for the Shopware admin panel and API access."))
+	b.WriteString(tui.DimStyle.Render("The login for your local Shopware admin panel and API."))
 	b.WriteString("\n\n")
-	b.WriteString(tui.DimStyle.Render("Username"))
+	b.WriteString(valueStyle.Render("Choose a username"))
 	b.WriteString("\n")
 	b.WriteString(sg.username.View())
 	b.WriteString("\n\n")
-	b.WriteString(tui.DimStyle.Render("Password"))
+	b.WriteString(valueStyle.Render("Choose a password"))
+	b.WriteString(tui.DimStyle.Render("  at least 8 characters"))
 	b.WriteString("\n")
 	b.WriteString(sg.password.View())
 	if sg.passwordErr != "" {
@@ -112,6 +113,10 @@ func (sg setupGuide) viewAdminUser() string {
 	b.WriteString("\n\n")
 	b.WriteString(renderShowPasswordCheckbox(sg.password.EchoMode == textinput.EchoNormal, sg.credFocus == credFocusShowPassword))
 	b.WriteString("\n\n")
+	b.WriteString(tui.DimStyle.Render("Will be written to "))
+	b.WriteString(tui.BoldText.Render(".shopware-project.yml"))
+	b.WriteString(tui.DimStyle.Render(" — use a throwaway password for local dev."))
+	b.WriteString("\n")
 	return tui.RenderPhaseCard(b.String())
 }
 


### PR DESCRIPTION
## What

Improves the combined admin user/password panel for both the setup (migration) wizard and the install wizard, per the admin-panel checklist in #1113.

### Changes
- **CTA-style labels** — "Choose a username" / "Choose a password" instead of the bare "Username" / "Password", making the fields obviously actionable.
- **Clearer subtitle** — states this is the login for the *local* Shopware admin panel and API.
- **Inline password rule** — "at least 8 characters" shown next to the password label so the requirement is visible up front, not only after a validation error.
- **Storage note (setup wizard)** — "Will be written to `.shopware-project.yml` — use a throwaway password for local dev." Honest about where the value lands (the file is committed by default in user projects) and future-tense, since nothing is written until the Review step is confirmed.
- **Purpose note (install wizard)** — "Used to create the Shopware admin user." (the install wizard creates the DB user rather than persisting credentials to that file).
- **Consistent spacing** — each field reads as its own group with even vertical rhythm.

### Rendered (setup wizard)
```
Admin Account
The login for your local Shopware admin panel and API.

Choose a username
admin

Choose a password  at least 8 characters
********

[ ] Show password

Will be written to .shopware-project.yml — use a throwaway password for local dev.
```

## Notes / out of scope
- We considered an auto-generate-password action but dropped it: it contradicts the "use a throwaway password" guidance for local dev.

## Tests
Updated navigation/clamp and view-content assertions for the new copy. `go test ./...`, `go vet`, gofmt, and golangci-lint on the touched package all pass.

Refs #1113