### PR TITLE
refactor(devtui): clean up setup guide done view and add tests

### DIFF
--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -368,6 +368,28 @@ func TestSetupGuideWelcomeDefaultConfirmYes(t *testing.T) {
 	assert.True(t, suggest.confirmYes)
 }
 
+func TestSetupGuideViewDone_Success(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepDone
+
+	view := sg.viewContent()
+	assert.Contains(t, view, "Setup's complete!")
+	assert.Contains(t, view, "Configuration saved")
+	assert.Contains(t, view, "Press Enter to start the Docker containers")
+}
+
+func TestSetupGuideViewDone_Error(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.step = setupStepDone
+	sg.err = assert.AnError
+
+	view := sg.viewContent()
+	assert.Contains(t, view, "Configuration failed")
+	// The success-only chrome must not leak into the error screen.
+	assert.NotContains(t, view, "Setup's complete!")
+	assert.NotContains(t, view, "Press Enter to start the Docker containers")
+}
+
 func TestSetupGuideDockerPHPAdvancesToReview(t *testing.T) {
 	sg := newSetupGuide("")
 	sg.step = setupStepDockerPHP

--- a/internal/devtui/setup_guide_view.go
+++ b/internal/devtui/setup_guide_view.go
@@ -179,8 +179,8 @@ func (sg setupGuide) viewReview() string {
 }
 
 func (sg setupGuide) viewDone() string {
-	var b strings.Builder
 	if sg.err != nil {
+		var b strings.Builder
 		b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(tui.ErrorColor).Render("Configuration failed"))
 		b.WriteString("\n\n")
 		b.WriteString(errorStyle.Render(sg.err.Error()))
@@ -189,29 +189,35 @@ func (sg setupGuide) viewDone() string {
 		b.WriteString(tui.BoldText.Render(".shopware-project.yml"))
 		b.WriteString("\n")
 		b.WriteString(tui.DimStyle.Render("or try again with shopware-cli project dev"))
-	} else {
-		b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(tui.SuccessColor).Render("✓ Configuration saved"))
 		b.WriteString("\n\n")
-		b.WriteString(tui.DimStyle.Render("Your project is now configured for Docker development."))
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("The environment will start on the next screen."))
-
-		if sg.deploymentHelperAdded {
-			b.WriteString("\n\n")
-			b.WriteString(tui.BoldText.Render("Note: "))
-			b.WriteString(tui.DimStyle.Render("Added "))
-			b.WriteString(valueStyle.Render("shopware/deployment-helper"))
-			b.WriteString(tui.DimStyle.Render(" to "))
-			b.WriteString(tui.BoldText.Render("composer.json"))
-			b.WriteString(tui.DimStyle.Render("."))
-			b.WriteString("\n")
-			b.WriteString(tui.DimStyle.Render("Run "))
-			b.WriteString(tui.BoldText.Render("composer update shopware/deployment-helper"))
-			b.WriteString(tui.DimStyle.Render(" before installing Shopware."))
-		}
+		return tui.RenderPhaseCard(b.String())
 	}
+
+	var b strings.Builder
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(tui.SuccessColor).Render("✓ Configuration saved"))
 	b.WriteString("\n\n")
-	return tui.RenderPhaseCard(b.String())
+	b.WriteString(tui.DimStyle.Render("Your project is now configured for Docker development."))
+	b.WriteString("\n")
+	b.WriteString(tui.DimStyle.Render("The environment will start on the next screen."))
+
+	if sg.deploymentHelperAdded {
+		b.WriteString("\n\n")
+		b.WriteString(tui.BoldText.Render("Note: "))
+		b.WriteString(tui.DimStyle.Render("Added "))
+		b.WriteString(valueStyle.Render("shopware/deployment-helper"))
+		b.WriteString(tui.DimStyle.Render(" to "))
+		b.WriteString(tui.BoldText.Render("composer.json"))
+		b.WriteString(tui.DimStyle.Render("."))
+		b.WriteString("\n")
+		b.WriteString(tui.DimStyle.Render("Run "))
+		b.WriteString(tui.BoldText.Render("composer update shopware/deployment-helper"))
+		b.WriteString(tui.DimStyle.Render(" before installing Shopware."))
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(tui.BoldText.Render("Press Enter to start the Docker containers and open the project dev workspace."))
+	b.WriteString("\n\n")
+	return tui.RenderPhaseCardCowsay("Setup's complete!", b.String())
 }
 
 func (sg setupGuide) footerHint() string {


### PR DESCRIPTION
## Summary

Separates error and success paths in `viewDone()` with an early return pattern, making the logic clearer and eliminating the large `if/else` block.

## Changes

- **`setup_guide_view.go`**: Refactored `viewDone()` — error path returns early with `RenderPhaseCard`, success path uses `RenderPhaseCardCowsay` for a friendlier finish screen
- **`setup_guide_test.go`**: Added `TestSetupGuideViewDone_Success` and `TestSetupGuideViewDone_Error` covering both code paths