### PR TITLE
refactor(devtui): simplify PHP tab and add version recommendation

### DIFF
--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -23,7 +23,6 @@ const (
 type setupGuide struct {
 	step                  setupStep
 	phpVersions           []string // PHP versions compatible with the project
-	phpConstraint         string   // raw constraint string, for display ("" if none)
 	phpCursor             int
 	confirmYes            bool
 	deploymentHelperAdded bool // composer.json was updated to require shopware/deployment-helper
@@ -98,17 +97,16 @@ func newSetupGuide(projectRoot string) setupGuide {
 	passwordInput.EchoMode = textinput.EchoPassword
 	passwordInput.SetValue("shopware")
 
-	phpVersions, phpCursor, phpConstraint := resolvePHPVersions(projectRoot)
+	phpVersions, phpCursor, _ := resolvePHPVersions(projectRoot)
 
 	return setupGuide{
-		step:          setupStepWelcome,
-		phpVersions:   phpVersions,
-		phpConstraint: phpConstraint,
-		phpCursor:     phpCursor,
-		confirmYes:    true,
-		url:           urlInput,
-		username:      usernameInput,
-		password:      passwordInput,
+		step:        setupStepWelcome,
+		phpVersions: phpVersions,
+		phpCursor:   phpCursor,
+		confirmYes:  true,
+		url:         urlInput,
+		username:    usernameInput,
+		password:    passwordInput,
 	}
 }
 

--- a/internal/devtui/setup_guide_view.go
+++ b/internal/devtui/setup_guide_view.go
@@ -127,16 +127,15 @@ func (sg setupGuide) viewDockerPHP() string {
 	b.WriteString(tui.TitleStyle.Render("Docker Configuration"))
 	b.WriteString("\n")
 	b.WriteString(tui.DimStyle.Render("Select the PHP version for your Docker containers."))
-	if sg.phpConstraint != "" {
-		b.WriteString("\n")
-		b.WriteString(tui.DimStyle.Render("Filtered by shopware/core require.php: "))
-		b.WriteString(valueStyle.Render(sg.phpConstraint))
-	}
 	b.WriteString("\n\n")
 
 	opts := make([]tui.SelectOption, len(sg.phpVersions))
 	for i, v := range sg.phpVersions {
-		opts[i] = tui.SelectOption{Label: "PHP " + v}
+		label := "PHP " + v
+		if i == len(sg.phpVersions)-1 {
+			label += " " + tui.DimStyle.Render("(Recommended)")
+		}
+		opts[i] = tui.SelectOption{Label: label}
 	}
 	b.WriteString(tui.RenderSelectList("PHP Version", "", opts, sg.phpCursor))
 	b.WriteString("\n")


### PR DESCRIPTION
## Summary

Cleans up the Docker PHP version step in the setup guide.

## Changes

- **Remove redundant filter text** — the "Filtered by shopware/core require.php" line was duplicative since the select list below already shows only compatible versions
- **Clean up dead code** — removed unused `phpConstraint` field from `setupGuide` struct
- **Add recommended label** — the latest PHP version now shows "(Recommended)"