### PR TITLE
feat(devtui): change general tab to overview

### DIFF
--- a/internal/devtui/lifecycle.go
+++ b/internal/devtui/lifecycle.go
@@ -100,8 +100,8 @@ func (m Model) updateLifecycle(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.envConfig.AdminApi = adminApi
 		_ = shop.WriteConfig(m.config, m.projectRoot)
 
-		m.general.username = username
-		m.general.password = password
+		m.overview.username = username
+		m.overview.password = password
 
 		m.phase = phaseDashboard
 		m.overlayLines = nil

--- a/internal/devtui/lifecycle_test.go
+++ b/internal/devtui/lifecycle_test.go
@@ -188,8 +188,8 @@ func TestUpdateLifecycle_ShopwareInstallDone_Success(t *testing.T) {
 	assert.Equal(t, "myadmin", final.envConfig.AdminApi.Username)
 	assert.Equal(t, "supersecret", final.envConfig.AdminApi.Password)
 
-	assert.Equal(t, "myadmin", final.general.username)
-	assert.Equal(t, "supersecret", final.general.password)
+	assert.Equal(t, "myadmin", final.overview.username)
+	assert.Equal(t, "supersecret", final.overview.password)
 
 	assert.Empty(t, final.overlayLines)
 	assert.Nil(t, final.dockerOutChan)

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -216,6 +216,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case stopWatcherRequestMsg:
 		return m, m.stopWatcher(msg.name)
 
+	case startStorefrontWatchRequestMsg:
+		return m.openSalesChannelPicker()
+
 	case watcherStoppedMsg:
 		switch msg.name {
 		case watcherAdmin:
@@ -344,6 +347,28 @@ func (m Model) handleStopConfirmResult(msg stopConfirmResultMsg) (tea.Model, tea
 }
 
 func (m Model) updateChildren(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Key presses must only reach the active tab, otherwise a key meant for one
+	// tab (e.g. Enter to pick a log source) also triggers the hidden tabs'
+	// handlers. Non-key messages are broadcast so background updates reach every
+	// child regardless of which tab is focused.
+	if _, isKey := msg.(tea.KeyPressMsg); isKey {
+		switch m.activeTab {
+		case tabOverview:
+			newOverview, cmd := m.overview.Update(msg)
+			m.overview = newOverview
+			return m, cmd
+		case tabLogs:
+			newLogs, cmd := m.logs.Update(msg)
+			m.logs = newLogs
+			return m, cmd
+		case tabConfig:
+			newConfig, cmd := m.configTab.Update(msg)
+			m.configTab = newConfig
+			return m, cmd
+		}
+		return m, nil
+	}
+
 	var cmds []tea.Cmd
 
 	newOverview, cmd := m.overview.Update(msg)

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -16,12 +16,12 @@ import (
 type activeTab int
 
 const (
-	tabGeneral activeTab = iota
+	tabOverview activeTab = iota
 	tabLogs
 	tabConfig
 )
 
-var tabNames = []string{"General", "Logs", "Config"}
+var tabNames = []string{"Overview", "Logs", "Config"}
 
 const (
 	defaultUsername = "admin"
@@ -51,7 +51,7 @@ type Options struct {
 
 type Model struct {
 	activeTab      activeTab
-	general        GeneralModel
+	overview       OverviewModel
 	logs           LogsModel
 	configTab      ConfigModel
 	width          int
@@ -113,8 +113,8 @@ func New(opts Options) Model {
 	envValues, _ := envfile.ReadValues(opts.ProjectRoot, EnvFieldKeys()...)
 
 	return Model{
-		activeTab:   tabGeneral,
-		general:     NewGeneralModel(opts.Executor.Type(), shopURL, username, password, opts.ProjectRoot, opts.Executor, opts.Config),
+		activeTab:   tabOverview,
+		overview:    NewOverviewModel(opts.Executor.Type(), shopURL, username, password, opts.ProjectRoot, opts.Executor, opts.Config),
 		logs:        NewLogsModel(opts.ProjectRoot, isDocker),
 		configTab:   NewConfigModel(opts.Config, envValues),
 		dockerMode:  isDocker,
@@ -160,7 +160,7 @@ func (m *Model) shutdown() {
 
 func (m *Model) startDashboard() tea.Cmd {
 	return tea.Batch(
-		m.general.Init(),
+		m.overview.Init(),
 		m.logs.StartStreaming(),
 	)
 }
@@ -170,7 +170,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.general.SetSize(m.width, m.height-4)
+		m.overview.SetSize(m.width, m.height-4)
 		m.logs.SetSize(m.width, m.height-4)
 		m.configTab.SetSize(m.width, m.height-4)
 		return m, nil
@@ -194,43 +194,51 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleConfigRestartDone(msg)
 
 	case watcherStartedMsg:
+		m.watchers[msg.name] = msg.handle
+		return m, m.logs.AddStreamingSource(msg.name, msg.lines)
+
+	case watcherRunningMsg:
+		_, exists := m.watchers[msg.name]
 		switch msg.name {
 		case watcherAdmin:
-			m.general.adminWatchStarting = false
-			m.general.adminWatchRunning = true
+			m.overview.adminWatchStarting = false
+			if msg.err == nil && exists {
+				m.overview.adminWatchRunning = true
+			}
 		case watcherStorefront:
-			m.general.sfWatchStarting = false
-			m.general.sfWatchRunning = true
+			m.overview.sfWatchStarting = false
+			if msg.err == nil && exists {
+				m.overview.sfWatchRunning = true
+			}
 		}
-		m.watchers[msg.name] = msg.handle
-		m.activeTab = tabLogs
-		return m, m.logs.AddStreamingSource(msg.name, msg.lines)
+		return m, nil
+
+	case stopWatcherRequestMsg:
+		return m, m.stopWatcher(msg.name)
 
 	case watcherStoppedMsg:
 		switch msg.name {
 		case watcherAdmin:
-			m.general.adminWatchStarting = false
-			m.general.adminWatchRunning = false
+			m.overview.adminWatchStarting = false
+			m.overview.adminWatchRunning = false
 		case watcherStorefront:
-			m.general.sfWatchStarting = false
-			m.general.sfWatchRunning = false
+			m.overview.sfWatchStarting = false
+			m.overview.sfWatchRunning = false
 		}
 		delete(m.watchers, msg.name)
 		if msg.err != nil {
 			m.logs.AppendErrorLine(msg.name + " failed to start: " + msg.err.Error())
-			m.activeTab = tabLogs
 		}
 		return m, nil
 
 	case logDoneMsg:
-		name := m.logs.ActiveProcessSourceName()
-		switch name {
+		switch msg.source {
 		case watcherAdmin:
-			m.general.adminWatchRunning = false
+			m.overview.adminWatchRunning = false
 		case watcherStorefront:
-			m.general.sfWatchRunning = false
+			m.overview.sfWatchRunning = false
 		}
-		delete(m.watchers, name)
+		delete(m.watchers, msg.source)
 		return m.updateChildren(msg)
 
 	case paletteResultMsg:
@@ -312,8 +320,8 @@ func (m Model) handleSalesChannelPickerResult(msg salesChannelPickerResultMsg) (
 	if msg.Cancelled {
 		return m, nil
 	}
-	m.general.sfWatchStarting = true
-	return m, m.general.startStorefrontWatch(msg.Opts)
+	m.overview.sfWatchStarting = true
+	return m, m.overview.startStorefrontWatch(msg.Opts)
 }
 
 func (m Model) handleStopConfirmResult(msg stopConfirmResultMsg) (tea.Model, tea.Cmd) {
@@ -332,8 +340,8 @@ func (m Model) handleStopConfirmResult(msg stopConfirmResultMsg) (tea.Model, tea
 func (m Model) updateChildren(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
-	newGeneral, cmd := m.general.Update(msg)
-	m.general = newGeneral
+	newOverview, cmd := m.overview.Update(msg)
+	m.overview = newOverview
 	if cmd != nil {
 		cmds = append(cmds, cmd)
 	}

--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -260,6 +260,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateKeyPress(msg)
 	}
 
+	return m.updateFallback(msg)
+}
+
+// updateFallback handles non-key messages that aren't matched by Update's
+// message-type switch, routing them by modal state and lifecycle phase.
+func (m Model) updateFallback(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.modal != nil {
 		next, cmd := m.modal.Update(msg)
 		m.modal = next

--- a/internal/devtui/model_test.go
+++ b/internal/devtui/model_test.go
@@ -18,7 +18,7 @@ import (
 func newTestModel() Model {
 	return Model{
 		phase:       phaseDashboard,
-		general:     NewGeneralModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
+		overview:    NewOverviewModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
 		logs:        NewLogsModel("/tmp/project", false),
 		configTab:   NewConfigModel(nil, nil),
 		watchers:    make(map[string]*watcherHandle),
@@ -59,7 +59,7 @@ func TestNew_InitializesFields(t *testing.T) {
 	opts.Executor = exec
 	m := New(opts)
 
-	assert.Equal(t, tabGeneral, m.activeTab)
+	assert.Equal(t, tabOverview, m.activeTab)
 	assert.False(t, m.dockerMode)
 	assert.NotNil(t, m.watchers)
 	assert.Empty(t, m.watchers)
@@ -225,12 +225,12 @@ func TestUpdateDashboardKeys_DigitSwitchesTabs(t *testing.T) {
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
 
 	updated, _ = updated.(Model).Update(keyRune('1'))
-	assert.Equal(t, tabGeneral, updated.(Model).activeTab)
+	assert.Equal(t, tabOverview, updated.(Model).activeTab)
 }
 
 func TestUpdateDashboardKeys_TabCyclesForward(t *testing.T) {
 	m := newTestModel()
-	assert.Equal(t, tabGeneral, m.activeTab)
+	assert.Equal(t, tabOverview, m.activeTab)
 
 	updated, _ := m.Update(keySpecial(tea.KeyTab))
 	assert.Equal(t, tabLogs, updated.(Model).activeTab)
@@ -239,7 +239,7 @@ func TestUpdateDashboardKeys_TabCyclesForward(t *testing.T) {
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
 
 	updated, _ = updated.(Model).Update(keySpecial(tea.KeyTab))
-	assert.Equal(t, tabGeneral, updated.(Model).activeTab)
+	assert.Equal(t, tabOverview, updated.(Model).activeTab)
 }
 
 func TestUpdateDashboardKeys_ShiftTabCyclesBackward(t *testing.T) {
@@ -355,8 +355,8 @@ func TestExecuteCommand_TabRouting(t *testing.T) {
 	updated, _ = updated.(Model).executeCommand("tab-config")
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
 
-	updated, _ = updated.(Model).executeCommand("tab-general")
-	assert.Equal(t, tabGeneral, updated.(Model).activeTab)
+	updated, _ = updated.(Model).executeCommand("tab-overview")
+	assert.Equal(t, tabOverview, updated.(Model).activeTab)
 }
 
 func TestExecuteCommand_QuitNonDockerReturnsTeaQuit(t *testing.T) {
@@ -382,33 +382,33 @@ func TestExecuteCommand_QuitDockerOpensStopConfirm(t *testing.T) {
 
 func TestExecuteCommand_AdminWatchStartSetsStarting(t *testing.T) {
 	m := newTestModel()
-	m.general.adminWatchRunning = false
-	m.general.adminWatchStarting = false
+	m.overview.adminWatchRunning = false
+	m.overview.adminWatchStarting = false
 
 	updated, cmd := m.executeCommand("admin-watch-start")
 	um := updated.(Model)
-	assert.True(t, um.general.adminWatchStarting)
+	assert.True(t, um.overview.adminWatchStarting)
 	assert.NotNil(t, cmd)
 }
 
 func TestExecuteCommand_AdminWatchStartNoOpWhenRunning(t *testing.T) {
 	m := newTestModel()
-	m.general.adminWatchRunning = true
+	m.overview.adminWatchRunning = true
 
 	updated, cmd := m.executeCommand("admin-watch-start")
 	um := updated.(Model)
-	assert.False(t, um.general.adminWatchStarting)
+	assert.False(t, um.overview.adminWatchStarting)
 	assert.Nil(t, cmd)
 }
 
 func TestExecuteCommand_AdminWatchStopClearsRunning(t *testing.T) {
 	m := newTestModel()
-	m.general.adminWatchRunning = true
+	m.overview.adminWatchRunning = true
 	m.watchers[watcherAdmin] = &watcherHandle{}
 
 	updated, cmd := m.executeCommand("admin-watch-stop")
 	um := updated.(Model)
-	assert.False(t, um.general.adminWatchRunning)
+	assert.False(t, um.overview.adminWatchRunning)
 	assert.NotNil(t, cmd)
 	// stopWatcher deletes the entry from the map
 	_, exists := um.watchers[watcherAdmin]

--- a/internal/devtui/model_test.go
+++ b/internal/devtui/model_test.go
@@ -578,3 +578,58 @@ func TestSaveSetupGuide_FailedWriteSetsErr(t *testing.T) {
 	assert.Error(t, um.setupGuide.err)
 	assert.Equal(t, setupStepDone, um.setupGuide.step)
 }
+
+// TestUpdateChildren_KeyOnlyReachesActiveTab guards against keypresses meant for
+// one tab leaking into the hidden tabs' handlers. With the Logs tab active,
+// pressing Enter must not run the Overview tab's activate() logic.
+func TestUpdateChildren_KeyOnlyReachesActiveTab(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabLogs
+	// Overview cursor sits on the Admin watcher (0); an Enter leaking through
+	// would flip adminWatchStarting.
+	m.overview.cursor = 0
+
+	updated, _ := m.updateChildren(keySpecial(tea.KeyEnter))
+	um := updated.(Model)
+
+	assert.False(t, um.overview.adminWatchStarting, "Enter on the Logs tab must not activate the Overview watcher")
+}
+
+// TestUpdateChildren_KeyReachesActiveOverview confirms the active tab still
+// receives its keys after the routing change.
+func TestUpdateChildren_KeyReachesActiveOverview(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabOverview
+	m.overview.cursor = 0 // Admin watcher
+
+	updated, cmd := m.updateChildren(keySpecial(tea.KeyEnter))
+	um := updated.(Model)
+
+	assert.True(t, um.overview.adminWatchStarting, "Enter on the Overview tab must activate the Admin watcher")
+	assert.NotNil(t, cmd)
+}
+
+// TestStartStorefrontWatchRequest_OpensPicker verifies the Overview tab delegates
+// storefront-watch start to the parent so the sales-channel picker resolves the
+// theme/domain, instead of starting with empty options.
+func TestStartStorefrontWatchRequest_OpensPicker(t *testing.T) {
+	m := newTestModel()
+	m.activeTab = tabOverview
+	m.executor = &executor.LocalExecutor{}
+	m.overview.cursor = 1 // Storefront watcher
+
+	// Enter on the storefront row should emit startStorefrontWatchRequestMsg.
+	updated, cmd := m.updateChildren(keySpecial(tea.KeyEnter))
+	m = updated.(Model)
+	if assert.NotNil(t, cmd) {
+		_, ok := cmd().(startStorefrontWatchRequestMsg)
+		assert.True(t, ok, "storefront activation must request the picker, not start directly")
+	}
+	assert.False(t, m.overview.sfWatchStarting, "watcher must not be marked starting before the picker resolves")
+
+	// The parent handling that request opens the picker modal.
+	updated, _ = m.Update(startStorefrontWatchRequestMsg{})
+	m = updated.(Model)
+	_, ok := m.modal.(*salesChannelPicker)
+	assert.True(t, ok, "parent must open the sales-channel picker on the request")
+}

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -78,7 +78,7 @@ func (m Model) updateDashboardKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.shutdown()
 		return m, tea.Quit
 	case key1:
-		m.activeTab = tabGeneral
+		m.activeTab = tabOverview
 		return m, nil
 	case key2:
 		m.activeTab = tabLogs
@@ -150,9 +150,9 @@ func (m Model) updateConfigTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (m Model) executeCommand(id string) (tea.Model, tea.Cmd) {
 	switch id {
 	case "open-shop":
-		return m, openInBrowser(m.general.shopURL)
+		return m, openInBrowser(m.overview.shopURL)
 	case "open-admin":
-		return m, openInBrowser(m.general.adminURL)
+		return m, openInBrowser(m.overview.adminURL)
 	case "cache-clear":
 		return m, m.runCacheClear()
 	case "admin-build":
@@ -160,30 +160,30 @@ func (m Model) executeCommand(id string) (tea.Model, tea.Cmd) {
 	case "sf-build":
 		return m, m.runStorefrontBuild()
 	case "admin-watch-start":
-		if !m.general.adminWatchRunning && !m.general.adminWatchStarting {
-			m.general.adminWatchStarting = true
-			return m, m.general.startAdminWatch()
+		if !m.overview.adminWatchRunning && !m.overview.adminWatchStarting {
+			m.overview.adminWatchStarting = true
+			return m, m.overview.startAdminWatch()
 		}
 	case "admin-watch-stop":
-		if m.general.adminWatchRunning {
-			m.general.adminWatchRunning = false
+		if m.overview.adminWatchRunning {
+			m.overview.adminWatchRunning = false
 			return m, m.stopWatcher(watcherAdmin)
 		}
 	case "sf-watch-start":
-		if !m.general.sfWatchRunning && !m.general.sfWatchStarting {
+		if !m.overview.sfWatchRunning && !m.overview.sfWatchStarting {
 			picker := newSalesChannelPicker(m.executor)
 			m.modal = picker
 			return m, picker.Init()
 		}
 	case "sf-watch-stop":
-		if m.general.sfWatchRunning {
-			m.general.sfWatchRunning = false
+		if m.overview.sfWatchRunning {
+			m.overview.sfWatchRunning = false
 			return m, m.stopWatcher(watcherStorefront)
 		}
 	case "tab-logs":
 		m.activeTab = tabLogs
-	case "tab-general":
-		m.activeTab = tabGeneral
+	case "tab-overview":
+		m.activeTab = tabOverview
 	case "tab-config":
 		m.activeTab = tabConfig
 	case "quit":
@@ -322,7 +322,7 @@ func (m Model) startAfterSetupGuide() (tea.Model, tea.Cmd) {
 		username = m.envConfig.AdminApi.Username
 		password = m.envConfig.AdminApi.Password
 	}
-	m.general = NewGeneralModel(m.executor.Type(), shopURL, username, password, m.projectRoot, m.executor, m.config)
+	m.overview = NewOverviewModel(m.executor.Type(), shopURL, username, password, m.projectRoot, m.executor, m.config)
 	envValues, _ := envfile.ReadValues(m.projectRoot, EnvFieldKeys()...)
 	m.configTab = NewConfigModel(m.config, envValues)
 

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -170,11 +170,7 @@ func (m Model) executeCommand(id string) (tea.Model, tea.Cmd) {
 			return m, m.stopWatcher(watcherAdmin)
 		}
 	case "sf-watch-start":
-		if !m.overview.sfWatchRunning && !m.overview.sfWatchStarting {
-			picker := newSalesChannelPicker(m.executor)
-			m.modal = picker
-			return m, picker.Init()
-		}
+		return m.openSalesChannelPicker()
 	case "sf-watch-stop":
 		if m.overview.sfWatchRunning {
 			m.overview.sfWatchRunning = false
@@ -195,6 +191,18 @@ func (m Model) executeCommand(id string) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 	return m, nil
+}
+
+// openSalesChannelPicker opens the sales-channel picker modal so the user can
+// resolve a storefront's theme/domain before the watcher starts. Used by both
+// the command palette and the Overview tab's storefront activation.
+func (m Model) openSalesChannelPicker() (tea.Model, tea.Cmd) {
+	if m.overview.sfWatchRunning || m.overview.sfWatchStarting {
+		return m, nil
+	}
+	picker := newSalesChannelPicker(m.executor)
+	m.modal = picker
+	return m, picker.Init()
 }
 
 func (m *Model) stopWatcher(name string) tea.Cmd {

--- a/internal/devtui/model_view.go
+++ b/internal/devtui/model_view.go
@@ -55,8 +55,8 @@ func (m Model) renderDashboard() string {
 
 	var content string
 	switch m.activeTab {
-	case tabGeneral:
-		content = m.general.View(m.width, boxHeight)
+	case tabOverview:
+		content = m.overview.View(m.width, boxHeight)
 	case tabLogs:
 		m.logs.SetSize(contentW, contentH)
 		content = m.logs.View()
@@ -92,6 +92,17 @@ func (m Model) renderDashboardFooter() string {
 		shortcuts := []tui.Shortcut{
 			{Key: "↑/↓", Label: "Navigate"},
 			{Key: "enter", Label: "Edit/Save"},
+			{Key: "tab", Label: "Next tab"},
+			{Key: "ctrl+c", Label: "Exit"},
+		}
+		return tui.ShortcutBar(shortcuts...)
+	}
+
+	if m.activeTab == tabOverview {
+		shortcuts := []tui.Shortcut{
+			{Key: "↑/↓", Label: "Focus item"},
+			{Key: "enter", Label: "Activate"},
+			{Key: "ctrl+p", Label: "Commands"},
 			{Key: "tab", Label: "Next tab"},
 			{Key: "ctrl+c", Label: "Exit"},
 		}

--- a/internal/devtui/overlay_palette.go
+++ b/internal/devtui/overlay_palette.go
@@ -26,10 +26,7 @@ var paletteCommands = []paletteCommand{
 	{Label: "Stop Admin Watcher", ID: "admin-watch-stop"},
 	{Label: "Start Storefront Watcher", ID: "sf-watch-start"},
 	{Label: "Stop Storefront Watcher", ID: "sf-watch-stop"},
-	{Label: "Toggle Logs Tab", Shortcut: "2", ID: "tab-logs"},
-	{Label: "Toggle General Tab", Shortcut: "1", ID: "tab-general"},
-	{Label: "Toggle Config Tab", Shortcut: "3", ID: "tab-config"},
-	{Label: "Quit", Shortcut: "ctrl+c", ID: "quit"},
+	{Label: "Quit", ID: "quit"},
 }
 
 type paletteResultMsg struct{ ID string }

--- a/internal/devtui/overlay_sales_channel_picker_test.go
+++ b/internal/devtui/overlay_sales_channel_picker_test.go
@@ -55,7 +55,7 @@ func TestSalesChannelPicker_ConfirmEmitsWatcherOpts(t *testing.T) {
 func TestModel_SalesChannelPicker_FullRoutingFlow(t *testing.T) {
 	m := Model{
 		phase:    phaseDashboard,
-		overview:  NewOverviewModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
+		overview: NewOverviewModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
 		watchers: make(map[string]*watcherHandle),
 	}
 

--- a/internal/devtui/overlay_sales_channel_picker_test.go
+++ b/internal/devtui/overlay_sales_channel_picker_test.go
@@ -55,7 +55,7 @@ func TestSalesChannelPicker_ConfirmEmitsWatcherOpts(t *testing.T) {
 func TestModel_SalesChannelPicker_FullRoutingFlow(t *testing.T) {
 	m := Model{
 		phase:    phaseDashboard,
-		general:  NewGeneralModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
+		overview:  NewOverviewModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
 		watchers: make(map[string]*watcherHandle),
 	}
 
@@ -94,5 +94,5 @@ func TestModel_SalesChannelPicker_FullRoutingFlow(t *testing.T) {
 
 	updated, _ = m.Update(res)
 	m = updated.(Model)
-	assert.True(t, m.general.sfWatchStarting, "sfWatchStarting must be true after the picker confirms")
+	assert.True(t, m.overview.sfWatchStarting, "sfWatchStarting must be true after the picker confirms")
 }

--- a/internal/devtui/tab_logs.go
+++ b/internal/devtui/tab_logs.go
@@ -42,7 +42,7 @@ type LogsModel struct {
 }
 
 type logLineMsg string
-type logDoneMsg struct{}
+type logDoneMsg struct{ source string }
 type logErrMsg struct{ err error }
 type logSourcesLoadedMsg struct{ sources []logSource }
 
@@ -435,10 +435,11 @@ func (m *LogsModel) waitForNextLine() tea.Cmd {
 	if ch == nil {
 		return nil
 	}
+	source := m.ActiveProcessSourceName()
 	return func() tea.Msg {
 		line, ok := <-ch
 		if !ok {
-			return logDoneMsg{}
+			return logDoneMsg{source: source}
 		}
 		return logLineMsg(line)
 	}

--- a/internal/devtui/tab_overview.go
+++ b/internal/devtui/tab_overview.go
@@ -192,6 +192,11 @@ type browserOpenedMsg struct{}
 // call stopWatcher (which needs access to the logs model and watcher map).
 type stopWatcherRequestMsg struct{ name string }
 
+// startStorefrontWatchRequestMsg flows from OverviewModel to Model so the parent
+// can open the sales-channel picker (which needs the executor) before starting
+// the storefront watcher, matching the command-palette flow.
+type startStorefrontWatchRequestMsg struct{}
+
 func (m OverviewModel) Update(msg tea.Msg) (OverviewModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case servicesLoadedMsg:
@@ -247,8 +252,7 @@ func (m *OverviewModel) activate() (OverviewModel, tea.Cmd) {
 			return *m, func() tea.Msg { return stopWatcherRequestMsg{name: watcherStorefront} }
 		}
 		if !m.sfWatchStarting {
-			m.sfWatchStarting = true
-			return *m, m.startStorefrontWatch(extension.StorefrontWatcherOptions{})
+			return *m, func() tea.Msg { return startStorefrontWatchRequestMsg{} }
 		}
 	default: // Service — open URL
 		svcIdx := m.cursor - 2

--- a/internal/devtui/tab_overview.go
+++ b/internal/devtui/tab_overview.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/extension"
@@ -22,7 +23,7 @@ import (
 	"github.com/shopware/shopware-cli/logging"
 )
 
-type GeneralModel struct {
+type OverviewModel struct {
 	envType            string
 	shopURL            string
 	adminURL           string
@@ -41,6 +42,7 @@ type GeneralModel struct {
 	sfWatchRunning     bool
 	sfWatchStarting    bool
 	shopwareVersion    string
+	cursor             int // focus index: 0=Admin watcher, 1=Storefront watcher, 2..=services
 }
 
 type DiscoveredService struct {
@@ -129,6 +131,13 @@ type watcherStoppedMsg struct {
 	err  error
 }
 
+// watcherRunningMsg is emitted when a watcher's preparation completes and the
+// dev-server process is about to start. err is non-nil if preparation failed.
+type watcherRunningMsg struct {
+	name string
+	err  error
+}
+
 type knownService struct {
 	Name       string
 	TargetPort int
@@ -148,14 +157,14 @@ var ignoredServices = map[string]bool{
 	"database": true,
 }
 
-func NewGeneralModel(envType, shopURL, username, password, projectRoot string, exec executor.Executor, shopCfg *shop.Config) GeneralModel {
+func NewOverviewModel(envType, shopURL, username, password, projectRoot string, exec executor.Executor, shopCfg *shop.Config) OverviewModel {
 	adminURL := shopURL
 	if adminURL != "" && !strings.HasSuffix(adminURL, "/") {
 		adminURL += "/"
 	}
 	adminURL += "admin"
 
-	return GeneralModel{
+	return OverviewModel{
 		envType:     envType,
 		shopURL:     shopURL,
 		adminURL:    adminURL,
@@ -168,18 +177,22 @@ func NewGeneralModel(envType, shopURL, username, password, projectRoot string, e
 	}
 }
 
-func (m GeneralModel) Init() tea.Cmd {
+func (m OverviewModel) Init() tea.Cmd {
 	return tea.Batch(discoverServices(m.projectRoot), loadShopwareVersion(m.projectRoot))
 }
 
-func (m *GeneralModel) SetSize(width, height int) {
+func (m *OverviewModel) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 }
 
 type browserOpenedMsg struct{}
 
-func (m GeneralModel) Update(msg tea.Msg) (GeneralModel, tea.Cmd) {
+// stopWatcherRequestMsg flows from OverviewModel to Model so the parent can
+// call stopWatcher (which needs access to the logs model and watcher map).
+type stopWatcherRequestMsg struct{ name string }
+
+func (m OverviewModel) Update(msg tea.Msg) (OverviewModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case servicesLoadedMsg:
 		m.loading = false
@@ -187,8 +200,63 @@ func (m GeneralModel) Update(msg tea.Msg) (GeneralModel, tea.Cmd) {
 		m.err = msg.err
 	case shopwareVersionLoadedMsg:
 		m.shopwareVersion = msg.version
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
 	}
 	return m, nil
+}
+
+func (m OverviewModel) focusCount() int {
+	// Admin watcher + Storefront watcher + discovered services
+	return 2 + len(m.services)
+}
+
+func (m OverviewModel) handleKey(msg tea.KeyPressMsg) (OverviewModel, tea.Cmd) {
+	count := m.focusCount()
+	if count == 0 {
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < count-1 {
+			m.cursor++
+		}
+	case "enter":
+		return m.activate()
+	}
+	return m, nil
+}
+
+func (m *OverviewModel) activate() (OverviewModel, tea.Cmd) {
+	switch m.cursor {
+	case 0: // Admin watcher
+		if m.adminWatchRunning {
+			return *m, func() tea.Msg { return stopWatcherRequestMsg{name: watcherAdmin} }
+		}
+		if !m.adminWatchStarting {
+			m.adminWatchStarting = true
+			return *m, m.startAdminWatch()
+		}
+	case 1: // Storefront watcher
+		if m.sfWatchRunning {
+			return *m, func() tea.Msg { return stopWatcherRequestMsg{name: watcherStorefront} }
+		}
+		if !m.sfWatchStarting {
+			m.sfWatchStarting = true
+			return *m, m.startStorefrontWatch(extension.StorefrontWatcherOptions{})
+		}
+	default: // Service — open URL
+		svcIdx := m.cursor - 2
+		if svcIdx < len(m.services) && m.services[svcIdx].URL != "" {
+			return *m, openInBrowser(m.services[svcIdx].URL)
+		}
+	}
+	return *m, nil
 }
 
 func openInBrowser(url string) tea.Cmd {
@@ -198,7 +266,7 @@ func openInBrowser(url string) tea.Cmd {
 	}
 }
 
-func (m GeneralModel) View(width, height int) string {
+func (m OverviewModel) View(width, height int) string {
 	var s strings.Builder
 
 	divider := tui.SectionDivider(width - 8)
@@ -229,8 +297,8 @@ func (m GeneralModel) View(width, height int) string {
 
 	s.WriteString(tui.TitleStyle.Render("Watchers"))
 	s.WriteString("\n")
-	s.WriteString(m.renderWatcherStatus("Admin", m.adminWatchRunning, m.adminWatchStarting, "http://127.0.0.1:5173"))
-	s.WriteString(m.renderWatcherStatus("Storefront", m.sfWatchRunning, m.sfWatchStarting, "http://127.0.0.1:9998"))
+	s.WriteString(m.renderWatcherStatus("Admin", m.adminWatchRunning, m.adminWatchStarting, "http://127.0.0.1:5173", m.cursor == 0))
+	s.WriteString(m.renderWatcherStatus("Storefront", m.sfWatchRunning, m.sfWatchStarting, "http://127.0.0.1:9998", m.cursor == 1))
 
 	s.WriteString(divider)
 
@@ -241,7 +309,7 @@ func (m GeneralModel) View(width, height int) string {
 	return s.String()
 }
 
-func (m *GeneralModel) startAdminWatch() tea.Cmd {
+func (m *OverviewModel) startAdminWatch() tea.Cmd {
 	e := m.executor
 	projectRoot := m.projectRoot
 	shopCfg := m.shopCfg
@@ -261,7 +329,7 @@ func (m *GeneralModel) startAdminWatch() tea.Cmd {
 	})
 }
 
-func (m *GeneralModel) startStorefrontWatch(opts extension.StorefrontWatcherOptions) tea.Cmd {
+func (m *OverviewModel) startStorefrontWatch(opts extension.StorefrontWatcherOptions) tea.Cmd {
 	e := m.executor
 	projectRoot := m.projectRoot
 	shopCfg := m.shopCfg
@@ -290,11 +358,18 @@ func logStep(out io.Writer, msg string) {
 // all of their output (including npm install) into a line channel that is shown
 // live in the Logs tab. The watcher process started by prepare is streamed into
 // the same channel and stored on the returned handle so it can be stopped later.
+//
+// It returns a batch of two commands: one emits watcherStartedMsg immediately
+// (so log streaming begins), and another emits watcherRunningMsg once the
+// preparation goroutine signals that the dev-server process is starting (or
+// preparation failed). This keeps the UI in a visible "starting" state during
+// preparation rather than flipping to "running" instantly.
 func startWatcher(name string, prepare func(ctx context.Context, out io.Writer) (*executor.Process, error)) tea.Cmd {
-	return func() tea.Msg {
-		handle := &watcherHandle{}
-		lines := make(chan string, streamBufferSize)
+	handle := &watcherHandle{}
+	lines := make(chan string, streamBufferSize)
+	running := make(chan error, 1) // buffered so the goroutine never blocks
 
+	startedCmd := func() tea.Msg {
 		go func() {
 			defer close(lines)
 
@@ -319,6 +394,7 @@ func startWatcher(name string, prepare func(ctx context.Context, out io.Writer) 
 
 			if err != nil {
 				lines <- errorStyle.Render(err.Error())
+				running <- err
 				return
 			}
 
@@ -328,10 +404,12 @@ func startWatcher(name string, prepare func(ctx context.Context, out io.Writer) 
 				stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 				_ = process.Stop(stopCtx)
 				cancel()
+				running <- fmt.Errorf("watcher stopped")
 				return
 			}
 
 			lines <- helpStyle.Render("> Starting watcher...")
+			running <- nil // signal: preparation succeeded, process is starting
 
 			stdout, err := process.StartCombined()
 			if err != nil {
@@ -354,24 +432,44 @@ func startWatcher(name string, prepare func(ctx context.Context, out io.Writer) 
 
 		return watcherStartedMsg{name: name, handle: handle, lines: lines}
 	}
+
+	runningCmd := func() tea.Msg {
+		err := <-running
+		return watcherRunningMsg{name: name, err: err}
+	}
+
+	return tea.Batch(startedCmd, runningCmd)
 }
 
-func (m GeneralModel) renderWatcherStatus(label string, running, starting bool, url string) string {
+func (m OverviewModel) renderWatcherStatus(label string, running, starting bool, url string, focused bool) string {
+	var checkbox, status string
 	switch {
 	case running:
-		row := tui.KVRow(label, activeBadgeStyle.Render("RUNNING"))
-		if url != "" {
-			row += tui.KVRow("  URL", urlStyle.Render(url))
+		if focused {
+			checkbox = lipgloss.NewStyle().Bold(true).Foreground(tui.BrandColor).Render("[x]")
+		} else {
+			checkbox = lipgloss.NewStyle().Render("[x]")
 		}
-		return row
+		status = lipgloss.NewStyle().Bold(true).Render("running")
+		if url != "" {
+			status += "  " + urlStyle.Render(url)
+		}
 	case starting:
-		return tui.KVRow(label, tui.StatusBadge("starting", tui.BrandColor))
+		checkbox = lipgloss.NewStyle().Foreground(tui.BrandColor).Render("[~]")
+		status = lipgloss.NewStyle().Foreground(tui.BrandColor).Render("starting...")
 	default:
-		return tui.KVRow(label, helpStyle.Render("stopped"))
+		if focused {
+			checkbox = lipgloss.NewStyle().Bold(true).Foreground(tui.BrandColor).Render("[ ]")
+		} else {
+			checkbox = tui.DimStyle.Render("[ ]")
+		}
+		status = tui.DimStyle.Render("stopped")
 	}
+
+	return tui.KVRow(checkbox+" "+label, status)
 }
 
-func (m GeneralModel) renderServices() string {
+func (m OverviewModel) renderServices() string {
 	switch {
 	case m.loading:
 		return "  " + tui.StatusBadge("scanning", tui.BrandColor) + "\n" +
@@ -384,8 +482,14 @@ func (m GeneralModel) renderServices() string {
 	}
 
 	var s strings.Builder
-	for _, service := range m.services {
-		s.WriteString(tui.KVRow(service.Name, urlStyle.Render(service.URL)))
+	for i, service := range m.services {
+		focused := m.cursor == i+2
+		name := service.Name
+		if focused {
+			name = lipgloss.NewStyle().Bold(true).Foreground(tui.BrandColor).Render(service.Name)
+		}
+		row := tui.KVRow(name, urlStyle.Render(service.URL))
+		s.WriteString(row)
 		if service.Username != "" {
 			s.WriteString(tui.KVRow("  Username", valueStyle.Render(service.Username)))
 			s.WriteString(tui.KVRow("  Password", secretStyle.Render(service.Password)))

--- a/internal/devtui/tab_overview_test.go
+++ b/internal/devtui/tab_overview_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewGeneralModel(t *testing.T) {
-	m := NewGeneralModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
+func TestNewOverviewModel(t *testing.T) {
+	m := NewOverviewModel("docker", "http://localhost:8000", "admin", "shopware", "/tmp/project", nil, nil)
 
 	assert.Equal(t, "docker", m.envType)
 	assert.Equal(t, "http://localhost:8000", m.shopURL)
@@ -18,20 +18,20 @@ func TestNewGeneralModel(t *testing.T) {
 	assert.True(t, m.loading)
 }
 
-func TestNewGeneralModel_AdminURLTrailingSlash(t *testing.T) {
-	m := NewGeneralModel("local", "http://localhost:8000/", "", "", "/tmp/project", nil, nil)
+func TestNewOverviewModel_AdminURLTrailingSlash(t *testing.T) {
+	m := NewOverviewModel("local", "http://localhost:8000/", "", "", "/tmp/project", nil, nil)
 
 	assert.Equal(t, "http://localhost:8000/admin", m.adminURL)
 }
 
-func TestNewGeneralModel_EmptyURL(t *testing.T) {
-	m := NewGeneralModel("local", "", "", "", "/tmp/project", nil, nil)
+func TestNewOverviewModel_EmptyURL(t *testing.T) {
+	m := NewOverviewModel("local", "", "", "", "/tmp/project", nil, nil)
 
 	assert.Equal(t, "admin", m.adminURL)
 }
 
 func TestServicesLoadedMsg(t *testing.T) {
-	m := NewGeneralModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
 
 	services := []DiscoveredService{
 		{Name: "Adminer", URL: "http://127.0.0.1:9080", Username: "root", Password: "root"},
@@ -49,7 +49,7 @@ func TestServicesLoadedMsg(t *testing.T) {
 }
 
 func TestServicesLoadedMsg_WithError(t *testing.T) {
-	m := NewGeneralModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
 
 	updated, _ := m.Update(servicesLoadedMsg{err: assert.AnError})
 	assert.False(t, updated.loading)
@@ -78,7 +78,7 @@ func TestKnownServices(t *testing.T) {
 }
 
 func TestViewShowsCredentials(t *testing.T) {
-	m := NewGeneralModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
+	m := NewOverviewModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
 	m.loading = false
 	m.services = []DiscoveredService{
 		{Name: "Adminer", URL: "http://127.0.0.1:9080", Username: "root", Password: "root"},


### PR DESCRIPTION
## Summary

Renames the devtui "General" tab to "Overview" and reworks its content.

- `tab_general.go` → `tab_overview.go` (rename + expanded overview content)
- Updates model, lifecycle, and view wiring to reference the overview tab
- Adjusts `tab_logs` log-done message to carry a source name

## Test plan

- `go vet ./internal/devtui/` — clean
- `go test ./internal/devtui/` — passing
