### PR TITLE
feat(devtui): rename Logs tab to Instance with grouped sources

### DIFF
--- a/internal/devtui/model.go
+++ b/internal/devtui/model.go
@@ -17,11 +17,11 @@ type activeTab int
 
 const (
 	tabOverview activeTab = iota
-	tabLogs
+	tabInstance
 	tabConfig
 )
 
-var tabNames = []string{"Overview", "Logs", "Config"}
+var tabNames = []string{"Overview", "Instance", "Config"}
 
 const (
 	defaultUsername = "admin"
@@ -52,7 +52,7 @@ type Options struct {
 type Model struct {
 	activeTab      activeTab
 	overview       OverviewModel
-	logs           LogsModel
+	instance       InstanceModel
 	configTab      ConfigModel
 	width          int
 	height         int
@@ -115,7 +115,7 @@ func New(opts Options) Model {
 	return Model{
 		activeTab:   tabOverview,
 		overview:    NewOverviewModel(opts.Executor.Type(), shopURL, username, password, opts.ProjectRoot, opts.Executor, opts.Config),
-		logs:        NewLogsModel(opts.ProjectRoot, isDocker),
+		instance:    NewInstanceModel(opts.ProjectRoot, isDocker),
 		configTab:   NewConfigModel(opts.Config, envValues),
 		dockerMode:  isDocker,
 		projectRoot: opts.ProjectRoot,
@@ -147,7 +147,7 @@ func (m Model) Init() tea.Cmd {
 }
 
 func (m *Model) shutdown() {
-	m.logs.StopStreaming()
+	m.instance.StopStreaming()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -161,7 +161,7 @@ func (m *Model) shutdown() {
 func (m *Model) startDashboard() tea.Cmd {
 	return tea.Batch(
 		m.overview.Init(),
-		m.logs.StartStreaming(),
+		m.instance.StartStreaming(),
 	)
 }
 
@@ -171,7 +171,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.overview.SetSize(m.width, m.height-4)
-		m.logs.SetSize(m.width, m.height-4)
+		m.instance.SetSize(m.width, m.height-4)
 		m.configTab.SetSize(m.width, m.height-4)
 		return m, nil
 
@@ -195,7 +195,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case watcherStartedMsg:
 		m.watchers[msg.name] = msg.handle
-		return m, m.logs.AddStreamingSource(msg.name, msg.lines)
+		return m, m.instance.AddStreamingSource(msg.name, msg.lines)
 
 	case watcherRunningMsg:
 		_, exists := m.watchers[msg.name]
@@ -230,7 +230,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		delete(m.watchers, msg.name)
 		if msg.err != nil {
-			m.logs.AppendErrorLine(msg.name + " failed to start: " + msg.err.Error())
+			m.instance.AppendErrorLine(msg.name + " failed to start: " + msg.err.Error())
 		}
 		return m, nil
 
@@ -357,9 +357,9 @@ func (m Model) updateChildren(msg tea.Msg) (tea.Model, tea.Cmd) {
 			newOverview, cmd := m.overview.Update(msg)
 			m.overview = newOverview
 			return m, cmd
-		case tabLogs:
-			newLogs, cmd := m.logs.Update(msg)
-			m.logs = newLogs
+		case tabInstance:
+			newInstance, cmd := m.instance.Update(msg)
+			m.instance = newInstance
 			return m, cmd
 		case tabConfig:
 			newConfig, cmd := m.configTab.Update(msg)
@@ -377,8 +377,8 @@ func (m Model) updateChildren(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, cmd)
 	}
 
-	newLogs, cmd := m.logs.Update(msg)
-	m.logs = newLogs
+	newInstance, cmd := m.instance.Update(msg)
+	m.instance = newInstance
 	if cmd != nil {
 		cmds = append(cmds, cmd)
 	}

--- a/internal/devtui/model_test.go
+++ b/internal/devtui/model_test.go
@@ -19,7 +19,7 @@ func newTestModel() Model {
 	return Model{
 		phase:       phaseDashboard,
 		overview:    NewOverviewModel("local", "http://localhost:8000", "", "", "/tmp/project", nil, nil),
-		logs:        NewLogsModel("/tmp/project", false),
+		instance:    NewInstanceModel("/tmp/project", false),
 		configTab:   NewConfigModel(nil, nil),
 		watchers:    make(map[string]*watcherHandle),
 		projectRoot: "/tmp/project",
@@ -219,7 +219,7 @@ func TestUpdateDashboardKeys_DigitSwitchesTabs(t *testing.T) {
 	m := newTestModel()
 
 	updated, _ := m.Update(keyRune('2'))
-	assert.Equal(t, tabLogs, updated.(Model).activeTab)
+	assert.Equal(t, tabInstance, updated.(Model).activeTab)
 
 	updated, _ = updated.(Model).Update(keyRune('3'))
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
@@ -233,7 +233,7 @@ func TestUpdateDashboardKeys_TabCyclesForward(t *testing.T) {
 	assert.Equal(t, tabOverview, m.activeTab)
 
 	updated, _ := m.Update(keySpecial(tea.KeyTab))
-	assert.Equal(t, tabLogs, updated.(Model).activeTab)
+	assert.Equal(t, tabInstance, updated.(Model).activeTab)
 
 	updated, _ = updated.(Model).Update(keySpecial(tea.KeyTab))
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
@@ -249,7 +249,7 @@ func TestUpdateDashboardKeys_ShiftTabCyclesBackward(t *testing.T) {
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
 
 	updated, _ = updated.(Model).Update(keyShiftTabMsg())
-	assert.Equal(t, tabLogs, updated.(Model).activeTab)
+	assert.Equal(t, tabInstance, updated.(Model).activeTab)
 }
 
 func TestUpdateDashboardKeys_QuitWhenNotDockerQuits(t *testing.T) {
@@ -349,8 +349,8 @@ func TestUpdateConfigTab_EnterOnPickerFieldOpensModal(t *testing.T) {
 func TestExecuteCommand_TabRouting(t *testing.T) {
 	m := newTestModel()
 
-	updated, _ := m.executeCommand("tab-logs")
-	assert.Equal(t, tabLogs, updated.(Model).activeTab)
+	updated, _ := m.executeCommand("tab-instance")
+	assert.Equal(t, tabInstance, updated.(Model).activeTab)
 
 	updated, _ = updated.(Model).executeCommand("tab-config")
 	assert.Equal(t, tabConfig, updated.(Model).activeTab)
@@ -584,7 +584,7 @@ func TestSaveSetupGuide_FailedWriteSetsErr(t *testing.T) {
 // pressing Enter must not run the Overview tab's activate() logic.
 func TestUpdateChildren_KeyOnlyReachesActiveTab(t *testing.T) {
 	m := newTestModel()
-	m.activeTab = tabLogs
+	m.activeTab = tabInstance
 	// Overview cursor sits on the Admin watcher (0); an Enter leaking through
 	// would flip adminWatchStarting.
 	m.overview.cursor = 0

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -81,7 +81,7 @@ func (m Model) updateDashboardKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.activeTab = tabOverview
 		return m, nil
 	case key2:
-		m.activeTab = tabLogs
+		m.activeTab = tabInstance
 		return m, nil
 	case key3:
 		m.activeTab = tabConfig
@@ -176,8 +176,8 @@ func (m Model) executeCommand(id string) (tea.Model, tea.Cmd) {
 			m.overview.sfWatchRunning = false
 			return m, m.stopWatcher(watcherStorefront)
 		}
-	case "tab-logs":
-		m.activeTab = tabLogs
+	case "tab-instance":
+		m.activeTab = tabInstance
 	case "tab-overview":
 		m.activeTab = tabOverview
 	case "tab-config":
@@ -206,7 +206,7 @@ func (m Model) openSalesChannelPicker() (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) stopWatcher(name string) tea.Cmd {
-	m.logs.StopStreaming()
+	m.instance.StopStreaming()
 
 	h := m.watchers[name]
 	delete(m.watchers, name)

--- a/internal/devtui/model_view.go
+++ b/internal/devtui/model_view.go
@@ -45,7 +45,7 @@ func (m Model) renderDashboard() string {
 
 	padV := 1
 	padH := 3
-	if m.activeTab == tabLogs {
+	if m.activeTab == tabInstance {
 		padV = 0
 		padH = 1
 	}
@@ -57,9 +57,9 @@ func (m Model) renderDashboard() string {
 	switch m.activeTab {
 	case tabOverview:
 		content = m.overview.View(m.width, boxHeight)
-	case tabLogs:
-		m.logs.SetSize(contentW, contentH)
-		content = m.logs.View()
+	case tabInstance:
+		m.instance.SetSize(contentW, contentH)
+		content = m.instance.View()
 	case tabConfig:
 		content = m.configTab.View(m.width, boxHeight)
 	}
@@ -76,12 +76,12 @@ func (m Model) renderDashboard() string {
 }
 
 func (m Model) renderDashboardFooter() string {
-	if m.activeTab == tabLogs {
-		followState := "Follow"
+	if m.activeTab == tabInstance {
 		shortcuts := []tui.Shortcut{
-			{Key: "↑/↓", Label: "Move cursor"},
-			{Key: "enter", Label: "Open source"},
-			{Key: "f", Label: followState},
+			{Key: "↑/↓", Label: "Navigate"},
+			{Key: "enter", Label: "Select source"},
+			{Key: "pgup/pgdn", Label: "Scroll"},
+			{Key: "f", Label: "Follow"},
 			{Key: "tab", Label: "Next tab"},
 			{Key: "ctrl+c", Label: "Exit"},
 		}

--- a/internal/devtui/styles.go
+++ b/internal/devtui/styles.go
@@ -37,15 +37,14 @@ var (
 	sidebarStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(tui.BorderColor).
-			Padding(1, 1)
+			Padding(0, 1)
 
 	sidebarItemStyle = lipgloss.NewStyle().
 				Foreground(tui.MutedColor).
 				Padding(0, 1)
 
 	selectedSidebarItemStyle = lipgloss.NewStyle().
-					Foreground(tui.TextColor).
-					Background(tui.SubtleBgColor).
+					Foreground(tui.BrandColor).
 					Bold(true).
 					Padding(0, 1)
 
@@ -54,8 +53,7 @@ var (
 				Padding(0, 1)
 
 	activeSelectedSidebarItemStyle = lipgloss.NewStyle().
-					Foreground(tui.TextColor).
-					Background(tui.SelectedBgColor).
+					Foreground(tui.BrandColor).
 					Bold(true).
 					Padding(0, 1)
 

--- a/internal/devtui/tab_instance.go
+++ b/internal/devtui/tab_instance.go
@@ -16,8 +16,17 @@ import (
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
+type logSourceKind int
+
+const (
+	sourceContainer logSourceKind = iota // docker compose logs <service>
+	sourceProcess                        // watcher / app process (lineChan or process)
+	sourceFile                           // var/log/*.log
+)
+
 type logSource struct {
 	name      string
+	kind      logSourceKind
 	container string
 	filePath  string
 	process   *executor.Process
@@ -25,7 +34,7 @@ type logSource struct {
 	dead      bool
 }
 
-type LogsModel struct {
+type InstanceModel struct {
 	viewport      viewport.Model
 	sources       []logSource
 	cursor        int
@@ -48,8 +57,8 @@ type logSourcesLoadedMsg struct{ sources []logSource }
 
 const sidebarWidth = 28
 
-func NewLogsModel(projectRoot string, dockerMode bool) LogsModel {
-	return LogsModel{
+func NewInstanceModel(projectRoot string, dockerMode bool) InstanceModel {
+	return InstanceModel{
 		projectRoot: projectRoot,
 		dockerMode:  dockerMode,
 		follow:      true,
@@ -57,11 +66,11 @@ func NewLogsModel(projectRoot string, dockerMode bool) LogsModel {
 	}
 }
 
-func (m LogsModel) Init() tea.Cmd {
+func (m InstanceModel) Init() tea.Cmd {
 	return nil
 }
 
-func (m LogsModel) Update(msg tea.Msg) (LogsModel, tea.Cmd) {
+func (m InstanceModel) Update(msg tea.Msg) (InstanceModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case logSourcesLoadedMsg:
 		m.sources = msg.sources
@@ -138,42 +147,97 @@ func (m LogsModel) Update(msg tea.Msg) (LogsModel, tea.Cmd) {
 	return m, cmd
 }
 
-func (m LogsModel) View() string {
+func (m InstanceModel) View() string {
 	return lipgloss.JoinHorizontal(lipgloss.Top, m.renderSidebar(), m.renderContent())
 }
 
-func (m LogsModel) renderSidebar() string {
+func (m InstanceModel) renderSidebar() string {
 	var b strings.Builder
-	b.WriteString(tui.TitleStyle.Render("Sources"))
-	b.WriteString("\n\n")
-
-	for i, src := range m.sources {
-		item := src.name
-		if i == m.active {
-			item = lipgloss.JoinHorizontal(
-				lipgloss.Center,
-				item,
-				" ",
-				activeBadgeStyle.Render("LIVE"),
-			)
-		}
-
-		style := sidebarItemStyle
-		switch {
-		case i == m.cursor && m.cursor == m.active:
-			style = activeSelectedSidebarItemStyle
-		case i == m.cursor:
-			style = selectedSidebarItemStyle
-		case i == m.active:
-			style = activeSidebarItemStyle
-		}
-
-		b.WriteString(style.Width(sidebarWidth - 4).Render(item))
-		b.WriteString("\n")
-	}
+	b.WriteString(tui.TitleStyle.Render("Instance Stack"))
+	b.WriteString("\n")
 
 	if len(m.sources) == 0 {
-		b.WriteString(helpStyle.Render("No log sources found yet."))
+		b.WriteString(helpStyle.Render("No sources found yet."))
+		return sidebarStyle.
+			Width(sidebarWidth).
+			Height(max(m.height-3, 8)).
+			Render(b.String())
+	}
+
+	// Group sources by kind in a fixed order: containers, processes, files.
+	type group struct {
+		header  string
+		sources []int // indices into m.sources
+	}
+	groupOrder := []logSourceKind{sourceContainer, sourceProcess, sourceFile}
+	groupHeaders := map[logSourceKind]string{
+		sourceContainer: "Containers",
+		sourceProcess:   "Processes",
+		sourceFile:      "Log Files",
+	}
+	var groups []group
+	for _, kind := range groupOrder {
+		var indices []int
+		for i, src := range m.sources {
+			if src.kind == kind {
+				indices = append(indices, i)
+			}
+		}
+		if len(indices) > 0 {
+			groups = append(groups, group{header: groupHeaders[kind], sources: indices})
+		}
+	}
+
+	groupHeaderStyle := lipgloss.NewStyle().
+		Foreground(tui.MutedColor).
+		Bold(true).
+		Padding(0, 1)
+
+	for gi, g := range groups {
+		if gi > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(groupHeaderStyle.Render(strings.ToUpper(g.header)))
+		b.WriteString("\n")
+
+		for _, i := range g.sources {
+			src := m.sources[i]
+			indicator := tui.DimStyle.Render("·")
+			if i == m.active {
+				indicator = activeBadgeStyle.Render("●")
+			} else if src.kind == sourceProcess && (src.lineChan != nil || src.process != nil) && !src.dead {
+				indicator = activeBadgeStyle.Render("●")
+			}
+
+			item := lipgloss.JoinHorizontal(lipgloss.Center, indicator, " ", src.name)
+			if i == m.active {
+				item = lipgloss.JoinHorizontal(
+					lipgloss.Center,
+					item,
+					" ",
+					activeBadgeStyle.Render("LIVE"),
+				)
+			}
+
+			style := sidebarItemStyle
+			switch {
+			case i == m.cursor && m.cursor == m.active:
+				style = activeSelectedSidebarItemStyle
+			case i == m.cursor:
+				style = selectedSidebarItemStyle
+			case i == m.active:
+				style = activeSidebarItemStyle
+			}
+
+			if i == m.cursor {
+				item = lipgloss.JoinHorizontal(lipgloss.Center, lipgloss.NewStyle().Foreground(tui.BrandColor).Bold(true).Render("▸"), " ", item)
+			} else {
+				item = lipgloss.JoinHorizontal(lipgloss.Center, "  ", item)
+			}
+
+			b.WriteString(style.Width(sidebarWidth - 4).Render(item))
+			b.WriteString("\n")
+		}
 	}
 
 	return sidebarStyle.
@@ -182,10 +246,20 @@ func (m LogsModel) renderSidebar() string {
 		Render(b.String())
 }
 
-func (m LogsModel) renderContent() string {
+func (m InstanceModel) renderContent() string {
 	sourceName := "No source selected"
+	kindLabel := ""
 	if m.active >= 0 && m.active < len(m.sources) {
-		sourceName = m.sources[m.active].name
+		src := m.sources[m.active]
+		sourceName = src.name
+		switch src.kind {
+		case sourceContainer:
+			kindLabel = "container"
+		case sourceProcess:
+			kindLabel = "process"
+		case sourceFile:
+			kindLabel = "file"
+		}
 	}
 
 	followBadge := warningBadgeStyle.Render("FOLLOW OFF")
@@ -198,7 +272,11 @@ func (m LogsModel) renderContent() string {
 		Bold(true).
 		Render(sourceName)
 
-	header := headerText + " " + followBadge
+	header := headerText
+	if kindLabel != "" {
+		header += " " + tui.TextBadge(kindLabel)
+	}
+	header += " " + followBadge
 
 	return contentPanelStyle.Render(
 		lipgloss.JoinVertical(
@@ -210,7 +288,7 @@ func (m LogsModel) renderContent() string {
 	)
 }
 
-func (m *LogsModel) SetSize(width, height int) {
+func (m *InstanceModel) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 	viewportWidth := max(width-sidebarWidth-8, 20)
@@ -218,14 +296,14 @@ func (m *LogsModel) SetSize(width, height int) {
 	m.viewport.SetHeight(max(height-7, 8))
 }
 
-func (m *LogsModel) StartStreaming() tea.Cmd {
+func (m *InstanceModel) StartStreaming() tea.Cmd {
 	return m.discoverSources()
 }
 
-func (m *LogsModel) AddProcessSource(name string, process *executor.Process) tea.Cmd {
+func (m *InstanceModel) AddProcessSource(name string, process *executor.Process) tea.Cmd {
 	m.stopStreaming()
 
-	src := logSource{name: name, process: process}
+	src := logSource{name: name, kind: sourceProcess, process: process}
 
 	idx := -1
 	for i, s := range m.sources {
@@ -252,10 +330,10 @@ func (m *LogsModel) AddProcessSource(name string, process *executor.Process) tea
 
 // AddStreamingSource registers a log source backed by an externally fed line
 // channel (e.g. a watcher's preparation steps) and starts displaying it live.
-func (m *LogsModel) AddStreamingSource(name string, lineChan <-chan string) tea.Cmd {
+func (m *InstanceModel) AddStreamingSource(name string, lineChan <-chan string) tea.Cmd {
 	m.stopStreaming()
 
-	src := logSource{name: name, lineChan: lineChan}
+	src := logSource{name: name, kind: sourceProcess, lineChan: lineChan}
 
 	idx := -1
 	for i, s := range m.sources {
@@ -281,11 +359,11 @@ func (m *LogsModel) AddStreamingSource(name string, lineChan <-chan string) tea.
 	return m.waitForNextLine()
 }
 
-func (m *LogsModel) StopStreaming() {
+func (m *InstanceModel) StopStreaming() {
 	m.stopStreaming()
 }
 
-func (m *LogsModel) AppendErrorLine(msg string) {
+func (m *InstanceModel) AppendErrorLine(msg string) {
 	m.lines = append(m.lines, errorStyle.Render(msg))
 	m.viewport.SetContent(strings.Join(m.lines, "\n"))
 	if m.follow {
@@ -293,7 +371,7 @@ func (m *LogsModel) AppendErrorLine(msg string) {
 	}
 }
 
-func (m *LogsModel) ActiveProcessSourceName() string {
+func (m *InstanceModel) ActiveProcessSourceName() string {
 	if m.active >= 0 && m.active < len(m.sources) {
 		src := m.sources[m.active]
 		if src.process != nil || src.lineChan != nil {
@@ -303,7 +381,7 @@ func (m *LogsModel) ActiveProcessSourceName() string {
 	return ""
 }
 
-func (m *LogsModel) stopStreaming() {
+func (m *InstanceModel) stopStreaming() {
 	if m.cancel != nil {
 		m.cancel()
 		m.cancel = nil
@@ -312,7 +390,7 @@ func (m *LogsModel) stopStreaming() {
 	m.logChan = nil
 }
 
-func (m *LogsModel) startCurrentSource() tea.Cmd {
+func (m *InstanceModel) startCurrentSource() tea.Cmd {
 	if m.active < 0 || m.active >= len(m.sources) {
 		return nil
 	}
@@ -341,7 +419,7 @@ func (m *LogsModel) startCurrentSource() tea.Cmd {
 	return m.streamFile(src.filePath)
 }
 
-func (m *LogsModel) streamProcess(src logSource) tea.Cmd {
+func (m *InstanceModel) streamProcess(src logSource) tea.Cmd {
 	p := src.process
 	cmd := p.Cmd
 	m.activeProcess = p
@@ -375,7 +453,7 @@ func (m *LogsModel) streamProcess(src logSource) tea.Cmd {
 	return m.waitForNextLine()
 }
 
-func (m *LogsModel) streamContainer(container string) tea.Cmd {
+func (m *InstanceModel) streamContainer(container string) tea.Cmd {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 
@@ -385,7 +463,7 @@ func (m *LogsModel) streamContainer(container string) tea.Cmd {
 	return m.streamCommand(ctx, cmd, true)
 }
 
-func (m *LogsModel) streamFile(filePath string) tea.Cmd {
+func (m *InstanceModel) streamFile(filePath string) tea.Cmd {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 
@@ -394,7 +472,7 @@ func (m *LogsModel) streamFile(filePath string) tea.Cmd {
 	return m.streamCommand(ctx, cmd, false)
 }
 
-func (m *LogsModel) streamCommand(ctx context.Context, cmd *exec.Cmd, mergeStderr bool) tea.Cmd {
+func (m *InstanceModel) streamCommand(ctx context.Context, cmd *exec.Cmd, mergeStderr bool) tea.Cmd {
 	ch := make(chan string, 100)
 	m.logChan = ch
 
@@ -430,7 +508,7 @@ func (m *LogsModel) streamCommand(ctx context.Context, cmd *exec.Cmd, mergeStder
 	return m.waitForNextLine()
 }
 
-func (m *LogsModel) waitForNextLine() tea.Cmd {
+func (m *InstanceModel) waitForNextLine() tea.Cmd {
 	ch := m.logChan
 	if ch == nil {
 		return nil
@@ -445,7 +523,7 @@ func (m *LogsModel) waitForNextLine() tea.Cmd {
 	}
 }
 
-func (m *LogsModel) discoverSources() tea.Cmd {
+func (m *InstanceModel) discoverSources() tea.Cmd {
 	projectRoot := m.projectRoot
 	dockerMode := m.dockerMode
 	return func() tea.Msg {
@@ -478,6 +556,7 @@ func discoverContainers(projectRoot string) []logSource {
 		}
 		sources = append(sources, logSource{
 			name:      line,
+			kind:      sourceContainer,
 			container: line,
 		})
 	}
@@ -501,6 +580,7 @@ func discoverLogFiles(projectRoot string) []logSource {
 		}
 		sources = append(sources, logSource{
 			name:     entry.Name(),
+			kind:     sourceFile,
 			filePath: filepath.Join(logDir, entry.Name()),
 		})
 	}

--- a/internal/devtui/tab_instance_test.go
+++ b/internal/devtui/tab_instance_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewLogsModel(t *testing.T) {
-	m := NewLogsModel("/tmp/project", true)
+func TestNewInstanceModel(t *testing.T) {
+	m := NewInstanceModel("/tmp/project", true)
 
 	assert.Equal(t, "/tmp/project", m.projectRoot)
 	assert.True(t, m.dockerMode)
@@ -21,8 +21,8 @@ func TestNewLogsModel(t *testing.T) {
 	assert.Empty(t, m.lines)
 }
 
-func TestLogsModel_LogLineMsg_AppendsLine(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_LogLineMsg_AppendsLine(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 
 	updated, _ := m.Update(logLineMsg("first line"))
@@ -32,8 +32,8 @@ func TestLogsModel_LogLineMsg_AppendsLine(t *testing.T) {
 	assert.Equal(t, []string{"first line", "second line"}, updated.lines)
 }
 
-func TestLogsModel_LogLineMsg_NoCap(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_LogLineMsg_NoCap(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 
 	const count = 1500
@@ -42,11 +42,11 @@ func TestLogsModel_LogLineMsg_NoCap(t *testing.T) {
 		current, _ = current.Update(logLineMsg("line"))
 	}
 
-	assert.Len(t, current.lines, count, "LogsModel does not currently cap line buffer")
+	assert.Len(t, current.lines, count, "InstanceModel does not currently cap line buffer")
 }
 
-func TestLogsModel_LogLineMsg_FollowAutoScrolls(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_LogLineMsg_FollowAutoScrolls(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 10)
 
 	current := m
@@ -58,8 +58,8 @@ func TestLogsModel_LogLineMsg_FollowAutoScrolls(t *testing.T) {
 	assert.True(t, current.viewport.AtBottom(), "follow mode should keep viewport at the bottom")
 }
 
-func TestLogsModel_LogErrMsg_StylesErrorLine(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_LogErrMsg_StylesErrorLine(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 
 	updated, cmd := m.Update(logErrMsg{err: errors.New("boom")})
@@ -71,8 +71,8 @@ func TestLogsModel_LogErrMsg_StylesErrorLine(t *testing.T) {
 	assert.Equal(t, expected, updated.lines[0])
 }
 
-func TestLogsModel_LogDoneMsg_AppendsTerminator(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_LogDoneMsg_AppendsTerminator(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "test"}}
 	m.active = 0
@@ -83,8 +83,8 @@ func TestLogsModel_LogDoneMsg_AppendsTerminator(t *testing.T) {
 	assert.Contains(t, updated.lines[0], "log stream ended")
 }
 
-func TestLogsModel_FollowToggle(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_FollowToggle(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 	assert.True(t, m.follow)
 
@@ -97,8 +97,8 @@ func TestLogsModel_FollowToggle(t *testing.T) {
 	assert.True(t, updated.follow)
 }
 
-func TestLogsModel_SourcesLoadedMsg(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_SourcesLoadedMsg(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 
 	sources := []logSource{
 		{name: "web"},
@@ -111,16 +111,16 @@ func TestLogsModel_SourcesLoadedMsg(t *testing.T) {
 	assert.Equal(t, 0, updated.cursor)
 }
 
-func TestLogsModel_SourcesLoadedMsg_EmptyKeepsInactive(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_SourcesLoadedMsg_EmptyKeepsInactive(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 
 	updated, cmd := m.Update(logSourcesLoadedMsg{sources: nil})
 	assert.Nil(t, cmd)
 	assert.Equal(t, -1, updated.active)
 }
 
-func TestLogsModel_CursorNavigation(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_CursorNavigation(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.sources = []logSource{{name: "a"}, {name: "b"}, {name: "c"}}
 	m.cursor = 0
 
@@ -144,8 +144,8 @@ func TestLogsModel_CursorNavigation(t *testing.T) {
 	assert.Equal(t, 0, updated.cursor, "cursor should clamp at zero")
 }
 
-func TestLogsModel_EnterResetsLinesAndFollow(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_EnterResetsLinesAndFollow(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{
 		{name: "a", filePath: "/nonexistent/a.log"},
@@ -166,8 +166,8 @@ func TestLogsModel_EnterResetsLinesAndFollow(t *testing.T) {
 	updated.StopStreaming()
 }
 
-func TestLogsModel_EnterNoChangeWhenCursorEqualsActive(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_EnterNoChangeWhenCursorEqualsActive(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.sources = []logSource{{name: "a"}}
 	m.active = 0
 	m.cursor = 0
@@ -179,8 +179,8 @@ func TestLogsModel_EnterNoChangeWhenCursorEqualsActive(t *testing.T) {
 	assert.Equal(t, []string{"keep"}, updated.lines)
 }
 
-func TestLogsModel_StopStreamingClearsState(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_StopStreamingClearsState(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	ch := make(chan string, 1)
 	m.logChan = ch
 	cancelCalled := false
@@ -196,15 +196,15 @@ func TestLogsModel_StopStreamingClearsState(t *testing.T) {
 	assert.Nil(t, m.activeProcess)
 }
 
-func TestLogsModel_StopStreaming_NoState(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_StopStreaming_NoState(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	assert.NotPanics(t, func() {
 		m.StopStreaming()
 	})
 }
 
-func TestLogsModel_ActiveProcessSourceName(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_ActiveProcessSourceName(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	assert.Equal(t, "", m.ActiveProcessSourceName())
 
 	m.sources = []logSource{{name: "file-only", filePath: "/tmp/x.log"}}
@@ -213,8 +213,8 @@ func TestLogsModel_ActiveProcessSourceName(t *testing.T) {
 		"sources without a Process should not be reported as process sources")
 }
 
-func TestLogsModel_View_FollowBadgeOn(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_View_FollowBadgeOn(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 	m.follow = true
 
@@ -226,8 +226,8 @@ func TestLogsModel_View_FollowBadgeOn(t *testing.T) {
 	assert.NotContains(t, view, "FOLLOW OFF")
 }
 
-func TestLogsModel_View_FollowBadgeOff(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_View_FollowBadgeOff(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 	m.follow = false
 
@@ -236,16 +236,16 @@ func TestLogsModel_View_FollowBadgeOff(t *testing.T) {
 	assert.NotContains(t, view, "FOLLOW ON")
 }
 
-func TestLogsModel_View_NoSourceSelected(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_View_NoSourceSelected(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 
 	view := m.View()
 	assert.Contains(t, view, "No source selected")
 }
 
-func TestLogsModel_View_ShowsActiveSourceAndLive(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_View_ShowsActiveSourceAndLive(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 	m.sources = []logSource{{name: "varnish"}, {name: "mysql"}}
 	m.active = 0
@@ -257,7 +257,7 @@ func TestLogsModel_View_ShowsActiveSourceAndLive(t *testing.T) {
 	assert.Contains(t, view, "mysql")
 }
 
-func TestLogsModel_View_RendersAtVariousSizes(t *testing.T) {
+func TestInstanceModel_View_RendersAtVariousSizes(t *testing.T) {
 	sizes := []struct {
 		w, h int
 	}{
@@ -268,7 +268,7 @@ func TestLogsModel_View_RendersAtVariousSizes(t *testing.T) {
 	}
 
 	for _, sz := range sizes {
-		m := NewLogsModel("/tmp", false)
+		m := NewInstanceModel("/tmp", false)
 		m.SetSize(sz.w, sz.h)
 		assert.NotPanics(t, func() {
 			_ = m.View()
@@ -276,16 +276,16 @@ func TestLogsModel_View_RendersAtVariousSizes(t *testing.T) {
 	}
 }
 
-func TestLogsModel_View_NoSourcesShowsHelp(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_View_NoSourcesShowsHelp(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 
 	view := m.View()
-	assert.Contains(t, view, "No log sources found")
+	assert.Contains(t, view, "No sources found")
 }
 
-func TestLogsModel_LogLineMsg_RendersInViewport(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_LogLineMsg_RendersInViewport(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)
 
 	updated, _ := m.Update(logLineMsg("hello world"))
@@ -294,7 +294,7 @@ func TestLogsModel_LogLineMsg_RendersInViewport(t *testing.T) {
 		"viewport content should include appended log line, got %q", content)
 }
 
-func TestLogsModel_Init(t *testing.T) {
-	m := NewLogsModel("/tmp", false)
+func TestInstanceModel_Init(t *testing.T) {
+	m := NewInstanceModel("/tmp", false)
 	assert.Nil(t, m.Init())
 }


### PR DESCRIPTION
## Description

Renames the **Logs** tab to **Instance** and reorganizes its sidebar into grouped source categories, giving users a clear view of the full instance stack — running containers, application processes (watchers), and log files.

Part of #1113 — Overview tab / Instance tab redesign.

## Changes

- **Tab rename**: `Logs` → `Instance` (model, files, palette command, footer)
- **Source categorization**: added `logSourceKind` (`container`/`process`/`file`) to each log source
- **Grouped sidebar**: sources grouped under `CONTAINERS`, `PROCESSES`, `LOG FILES` headers with fixed display order
- **Status indicators**: `●` (live/running) vs `·` (inactive/stopped) per source
- **Kind badge**: content area header shows `[container]` / `[process]` / `[file]`
- **Cursor indicator**: `▸` marks the focused sidebar item for clear navigation
- **Footer shortcuts**: added `enter → Select source` and `pgup/pgdn → Scroll`
- **No auto tab switching**: removed automatic switch to Logs tab on watcher start/stop/error — user stays in control
- **Bugfix**: `logDoneMsg` now carries the source name, preventing a stale log-done signal from clearing the wrong watcher's running state

## Checklist

- [x] Code follows the project's coding conventions
- [x] Tests added/adjusted (`tab_instance_test.go` updated for renamed model)
- [x] `golangci-lint` passes with 0 issues
- [x] `go build ./...` passes
- [x] `go test ./internal/devtui/...` passes (158 tests)
