### PR TITLE
Auto-detect and resolve web service port in dev environment

### DIFF
--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -210,6 +210,13 @@ func (e *devEnvironment) start(cmd *cobra.Command) error {
 		shopURL = e.envCfg.URL
 	}
 
+	var services []devtui.DiscoveredService
+	if e.executor.Type() == executor.TypeDocker {
+		var webPort int
+		services, webPort, _ = devtui.DiscoverComposeServices(cmd.Context(), e.projectRoot)
+		shopURL = devtui.ResolveShopURL(shopURL, webPort)
+	}
+
 	if shopURL != "" {
 		adminURL := shopURL
 		if !strings.HasSuffix(adminURL, "/") {
@@ -223,15 +230,12 @@ func (e *devEnvironment) start(cmd *cobra.Command) error {
 		fmt.Println()
 	}
 
-	if e.executor.Type() == executor.TypeDocker {
-		services, _ := devtui.DiscoverServices(cmd.Context(), e.projectRoot)
-		if len(services) > 0 {
-			fmt.Println(tui.SectionTitleStyle.Render("  Services"))
-			for _, svc := range services {
-				fmt.Println(tui.DimText.Render("  "+svc.Name+": ") + tui.BoldText.Render(svc.URL))
-			}
-			fmt.Println()
+	if len(services) > 0 {
+		fmt.Println(tui.SectionTitleStyle.Render("  Services"))
+		for _, svc := range services {
+			fmt.Println(tui.DimText.Render("  "+svc.Name+": ") + tui.BoldText.Render(svc.URL))
 		}
+		fmt.Println()
 	}
 
 	fmt.Println(tui.DimText.Render("  Run ") + tui.BoldText.Render("shopware-cli project dev stop") + tui.DimText.Render(" to stop it."))

--- a/internal/devtui/tab_overview.go
+++ b/internal/devtui/tab_overview.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +57,7 @@ type DiscoveredService struct {
 
 type servicesLoadedMsg struct {
 	services []DiscoveredService
+	webPort  int
 	err      error
 }
 
@@ -157,17 +161,25 @@ var ignoredServices = map[string]bool{
 	"database": true,
 }
 
-func NewOverviewModel(envType, shopURL, username, password, projectRoot string, exec executor.Executor, shopCfg *shop.Config) OverviewModel {
+// webServiceTargetPort is the container port the Shopware web server (the "web"
+// service) listens on. Its published host port determines the shop URL port.
+const webServiceTargetPort = 8000
+
+// deriveAdminURL returns the admin URL for the given shop URL by appending the
+// "admin" path segment.
+func deriveAdminURL(shopURL string) string {
 	adminURL := shopURL
 	if adminURL != "" && !strings.HasSuffix(adminURL, "/") {
 		adminURL += "/"
 	}
-	adminURL += "admin"
+	return adminURL + "admin"
+}
 
+func NewOverviewModel(envType, shopURL, username, password, projectRoot string, exec executor.Executor, shopCfg *shop.Config) OverviewModel {
 	return OverviewModel{
 		envType:     envType,
 		shopURL:     shopURL,
-		adminURL:    adminURL,
+		adminURL:    deriveAdminURL(shopURL),
 		username:    username,
 		password:    password,
 		projectRoot: projectRoot,
@@ -203,6 +215,10 @@ func (m OverviewModel) Update(msg tea.Msg) (OverviewModel, tea.Cmd) {
 		m.loading = false
 		m.services = msg.services
 		m.err = msg.err
+		if msg.webPort != 0 {
+			m.shopURL = ResolveShopURL(m.shopURL, msg.webPort)
+			m.adminURL = deriveAdminURL(m.shopURL)
+		}
 	case shopwareVersionLoadedMsg:
 		m.shopwareVersion = msg.version
 	case tea.KeyPressMsg:
@@ -514,15 +530,24 @@ type dockerComposePSOutput struct {
 	} `json:"Publishers"`
 }
 
+// DiscoverServices returns the auxiliary services published by the running
+// docker development environment.
 func DiscoverServices(ctx context.Context, projectRoot string) ([]DiscoveredService, error) {
+	services, _, err := DiscoverComposeServices(ctx, projectRoot)
+	return services, err
+}
+
+// DiscoverComposeServices parses `docker compose ps` once and returns both the
+// auxiliary services and the host port the web service's HTTP port (8000) is
+// published on. webPort is 0 when it cannot be determined (e.g. the environment
+// is down or the web container does not publish port 8000).
+func DiscoverComposeServices(ctx context.Context, projectRoot string) (services []DiscoveredService, webPort int, err error) {
 	cmd := exec.CommandContext(ctx, "docker", "compose", "ps", "--format", "json")
 	cmd.Dir = projectRoot
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("docker compose ps: %w", err)
+		return nil, 0, fmt.Errorf("docker compose ps: %w", err)
 	}
-
-	var services []DiscoveredService
 
 	type containerInfo struct {
 		service    string
@@ -544,6 +569,12 @@ func DiscoverServices(ctx context.Context, projectRoot string) ([]DiscoveredServ
 		for _, pub := range container.Publishers {
 			if pub.PublishedPort != 0 {
 				ports[pub.TargetPort] = pub.PublishedPort
+			}
+		}
+
+		if container.Service == "web" {
+			if port, ok := ports[webServiceTargetPort]; ok {
+				webPort = port
 			}
 		}
 
@@ -578,13 +609,30 @@ func DiscoverServices(ctx context.Context, projectRoot string) ([]DiscoveredServ
 		})
 	}
 
-	return services, nil
+	return services, webPort, nil
+}
+
+// ResolveShopURL rewrites the port in shopURL to webPort, the host port the web
+// container is actually published on. The configured URL is returned unchanged
+// when shopURL is empty, webPort is 0, or shopURL cannot be parsed.
+func ResolveShopURL(shopURL string, webPort int) string {
+	if shopURL == "" || webPort == 0 {
+		return shopURL
+	}
+
+	u, err := url.Parse(shopURL)
+	if err != nil || u.Host == "" {
+		return shopURL
+	}
+
+	u.Host = net.JoinHostPort(u.Hostname(), strconv.Itoa(webPort))
+	return u.String()
 }
 
 func discoverServices(projectRoot string) tea.Cmd {
 	return func() tea.Msg {
-		services, err := DiscoverServices(context.Background(), projectRoot)
-		return servicesLoadedMsg{services: services, err: err}
+		services, webPort, err := DiscoverComposeServices(context.Background(), projectRoot)
+		return servicesLoadedMsg{services: services, webPort: webPort, err: err}
 	}
 }
 

--- a/internal/devtui/tab_overview_test.go
+++ b/internal/devtui/tab_overview_test.go
@@ -48,6 +48,43 @@ func TestServicesLoadedMsg(t *testing.T) {
 	assert.Equal(t, "Shopware", updated.services[1].Name)
 }
 
+func TestServicesLoadedMsg_UpdatesPortFromWebService(t *testing.T) {
+	m := NewOverviewModel("docker", "http://127.0.0.1:8000", "", "", "/tmp/project", nil, nil)
+
+	updated, _ := m.Update(servicesLoadedMsg{webPort: 8002})
+	assert.Equal(t, "http://127.0.0.1:8002", updated.shopURL)
+	assert.Equal(t, "http://127.0.0.1:8002/admin", updated.adminURL)
+}
+
+func TestServicesLoadedMsg_KeepsCustomHostWhenUpdatingPort(t *testing.T) {
+	m := NewOverviewModel("docker", "http://foo.localhost:8000", "", "", "/tmp/project", nil, nil)
+
+	updated, _ := m.Update(servicesLoadedMsg{webPort: 8002})
+	assert.Equal(t, "http://foo.localhost:8002", updated.shopURL)
+	assert.Equal(t, "http://foo.localhost:8002/admin", updated.adminURL)
+}
+
+func TestServicesLoadedMsg_NoWebPortKeepsURL(t *testing.T) {
+	m := NewOverviewModel("docker", "http://127.0.0.1:8000", "", "", "/tmp/project", nil, nil)
+
+	updated, _ := m.Update(servicesLoadedMsg{})
+	assert.Equal(t, "http://127.0.0.1:8000", updated.shopURL)
+	assert.Equal(t, "http://127.0.0.1:8000/admin", updated.adminURL)
+}
+
+func TestResolveShopURL(t *testing.T) {
+	assert.Equal(t, "http://127.0.0.1:8002", ResolveShopURL("http://127.0.0.1:8000", 8002))
+	assert.Equal(t, "http://foo.localhost:8002", ResolveShopURL("http://foo.localhost:8000", 8002))
+	// URL without an explicit port still gets the discovered port applied.
+	assert.Equal(t, "http://foo.localhost:8002", ResolveShopURL("http://foo.localhost", 8002))
+	// HTTPS and paths are preserved.
+	assert.Equal(t, "https://shop.example.com:8443/", ResolveShopURL("https://shop.example.com/", 8443))
+
+	// Unchanged when there is nothing to resolve.
+	assert.Equal(t, "", ResolveShopURL("", 8002))
+	assert.Equal(t, "http://127.0.0.1:8000", ResolveShopURL("http://127.0.0.1:8000", 0))
+}
+
 func TestServicesLoadedMsg_WithError(t *testing.T) {
 	m := NewOverviewModel("docker", "http://localhost:8000", "", "", "/tmp/project", nil, nil)
 


### PR DESCRIPTION
## Summary
This change adds automatic detection and resolution of the web service's published port in Docker development environments. Instead of relying on a hardcoded port assumption, the CLI now discovers the actual port the web container is published on and updates the shop URL accordingly.

## Key Changes
- **New constant `webServiceTargetPort`**: Defines the container port (8000) that the Shopware web server listens on
- **New function `deriveAdminURL()`**: Extracted admin URL derivation logic into a reusable helper function
- **Enhanced `DiscoverComposeServices()`**: Refactored from `DiscoverServices()` to return both discovered services and the web service's published host port by parsing `docker compose ps` output
- **New function `ResolveShopURL()`**: Intelligently rewrites the port in a shop URL to match the discovered web container port, preserving hostname, scheme, and path
- **Updated `servicesLoadedMsg`**: Now includes `webPort` field to communicate the discovered port to the UI
- **Port resolution in `OverviewModel.Update()`**: Automatically updates shop URL and admin URL when services are loaded with a valid web port
- **Early port resolution in `project dev start`**: Resolves the shop URL before displaying it to the user, ensuring the correct port is shown
- **Comprehensive test coverage**: Added tests for URL resolution with various scenarios (custom hosts, HTTPS, paths, edge cases)

## Implementation Details
- The web service port detection happens during `docker compose ps` parsing, extracting the published port for the "web" service's target port 8000
- URL resolution uses Go's `net/url` package to safely parse and reconstruct URLs, preserving all components except the port
- The change is backward compatible: if no web port is discovered (environment down, port not published), the original URL is used unchanged
- Both the TUI and CLI startup now benefit from accurate port detection

https://claude.ai/code/session_01AP88zSbjgRHmN2qgETGmKt