### PR TITLE
ci: Update codecov integration and add network allowlist

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -27,8 +27,11 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            api.codecov.io:443
             api.github.com:443
+            cli.codecov.io:443
             github.com:443
+            ingest.codecov.io:443
             proxy.golang.org:443
             release-assets.githubusercontent.com:443
             storage.googleapis.com:443
@@ -59,9 +62,10 @@ jobs:
           COVERAGE_FILE: coverage.out
 
       - name: Upload code coverage
-        uses: actions/upload-code-coverage@v1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # ratchet:codecov/codecov-action@v7.0.0
         with:
-          file: coverage.xml
-          language: Go
-          label: code-coverage/go-test
-          fail-on-error: false
+          files: coverage.xml
+          flags: go-test
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow to use the official Codecov action with proper network configuration and modernized parameters.

## Key Changes
- **Network allowlist**: Added Codecov endpoints (`api.codecov.io`, `cli.codecov.io`, `ingest.codecov.io`) to the egress policy allowed endpoints
- **Action upgrade**: Replaced deprecated `actions/upload-code-coverage@v1` with `codecov/codecov-action@v7.0.0` (pinned to specific commit hash for security)
- **Parameter updates**: 
  - Changed `file` parameter to `files` (new action API)
  - Changed `language: Go` to `flags: go-test` (more flexible tagging)
  - Changed `label` parameter to `flags` (new action convention)
  - Renamed `fail-on-error` to `fail_ci_if_error` (snake_case convention)
- **Authentication**: Added `CODECOV_TOKEN` environment variable for improved upload reliability

## Implementation Details
The workflow now properly allows network communication with Codecov's infrastructure while maintaining the security posture of the egress policy. The action is pinned to a specific commit hash with a ratchet comment indicating the semantic version for easier future updates.

https://claude.ai/code/session_012UXA6qMneDtZeGE9JGrpGz