### PR TITLE
Handle missing extension icon gracefully during resize

### DIFF
--- a/internal/extension/icon.go
+++ b/internal/extension/icon.go
@@ -21,6 +21,11 @@ func ResizeExtensionIcon(ctx context.Context, ext Extension) error {
 
 	file, err := os.Open(iconPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			logging.FromContext(ctx).Infof("Extension icon %s does not exist, skipping resize", iconPath)
+			return nil // No icon to resize
+		}
+
 		return fmt.Errorf("cannot open icon: %w", err)
 	}
 

--- a/internal/extension/icon_test.go
+++ b/internal/extension/icon_test.go
@@ -16,6 +16,15 @@ func TestResizeExtensionIcon(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("icon path is set but file does not exist", func(t *testing.T) {
+		tempDir := t.TempDir()
+		iconPath := filepath.Join(tempDir, "missing.png")
+
+		ext := &mockExtension{iconPath: iconPath}
+		err := ResizeExtensionIcon(getTestContext(), ext)
+		assert.NoError(t, err)
+	})
+
 	t.Run("icon is smaller than 56x56", func(t *testing.T) {
 		tempDir := t.TempDir()
 		iconPath := filepath.Join(tempDir, "icon.png")


### PR DESCRIPTION
## Summary
Updated the extension icon resize functionality to gracefully handle cases where an icon path is configured but the file does not exist, instead of treating this as an error.

## Changes
- **`internal/extension/icon.go`**: Added check for `os.IsNotExist` error when opening the icon file. If the file doesn't exist, log an informational message and return `nil` instead of propagating the error.
- **`internal/extension/icon_test.go`**: Added test case to verify that `ResizeExtensionIcon` returns no error when the icon path is set but the file is missing.

## Implementation Details
The change distinguishes between two error scenarios:
- **File not found**: Logged as info and treated as non-fatal (no icon to resize)
- **Other errors**: Still propagated as errors (permission denied, etc.)

This allows extensions with optional icon configurations to proceed without failure when the icon file is absent.

https://claude.ai/code/session_01QoDXNL7vBGFv1TBUSmha9Q