### PR TITLE
Measure duration time from start till end of setup guide

### DIFF
--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -274,7 +274,7 @@ func (m Model) saveSetupGuide() (tea.Model, tea.Cmd) {
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 		defer cancel()
 		tracking.Track(ctx, "migration_wizard_completed", map[string]string{
-			"duration_ms": strconv.FormatInt(duration.Milliseconds(), 10),
+			"took":        strconv.FormatInt(int64(duration.Seconds()), 10),
 			"php_version": phpVersion,
 		})
 		return nil

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -2,6 +2,7 @@ package devtui
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"charm.land/bubbles/v2/textinput"
@@ -11,6 +12,7 @@ import (
 	"github.com/shopware/shopware-cli/internal/envfile"
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/tracking"
 )
 
 func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -266,7 +268,15 @@ func (m Model) saveSetupGuide() (tea.Model, tea.Cmd) {
 	m.setupGuide.deploymentHelperAdded = changed
 
 	m.setupGuide.step = setupStepDone
-	return m, nil
+	duration := time.Since(m.setupGuide.startedAt)
+	return m, func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+		tracking.Track(ctx, "migration_wizard_completed", map[string]string{
+			"duration_ms": strconv.FormatInt(duration.Milliseconds(), 10),
+		})
+		return nil
+	}
 }
 
 // mergeLocalProfilerSecrets copies profiler credential fields from the

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -269,11 +269,13 @@ func (m Model) saveSetupGuide() (tea.Model, tea.Cmd) {
 
 	m.setupGuide.step = setupStepDone
 	duration := time.Since(m.setupGuide.startedAt)
+	phpVersion := m.setupGuide.phpVersions[m.setupGuide.phpCursor]
 	return m, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 		defer cancel()
 		tracking.Track(ctx, "migration_wizard_completed", map[string]string{
 			"duration_ms": strconv.FormatInt(duration.Milliseconds(), 10),
+			"php_version": phpVersion,
 		})
 		return nil
 	}

--- a/internal/devtui/setup_guide.go
+++ b/internal/devtui/setup_guide.go
@@ -3,6 +3,7 @@ package devtui
 import (
 	"path/filepath"
 	"slices"
+	"time"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -31,6 +32,7 @@ type setupGuide struct {
 	password              textinput.Model
 	passwordErr           string
 	credFocus             credFocus
+	startedAt             time.Time
 
 	err error
 }
@@ -149,6 +151,7 @@ func (sg *setupGuide) updateWelcome(msg tea.KeyPressMsg) (setupGuide, tea.Cmd) {
 		sg.confirmYes = !sg.confirmYes
 	case keyEnter:
 		if sg.confirmYes {
+			sg.startedAt = time.Now()
 			sg.step = setupStepAdminUser
 			return sg.focusAdminCred(credFocusUsername)
 		}

--- a/internal/devtui/setup_guide_test.go
+++ b/internal/devtui/setup_guide_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -406,4 +407,17 @@ func TestSetupGuideStepNumbering(t *testing.T) {
 	assert.Equal(t, 3, sg.stepNum(setupStepReview))
 	assert.Equal(t, 0, sg.stepNum(setupStepWelcome))
 	assert.Equal(t, 0, sg.stepNum(setupStepDone))
+}
+
+func TestSetupGuideWelcome_EnterSetsStartedAt(t *testing.T) {
+	sg := newSetupGuide("")
+	sg.confirmYes = true
+
+	before := time.Now()
+	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	after := time.Now()
+
+	assert.False(t, next.startedAt.IsZero(), "startedAt should be set after Enter on welcome")
+	assert.False(t, next.startedAt.Before(before), "startedAt should not be before test start")
+	assert.False(t, next.startedAt.After(after), "startedAt should not be after test end")
 }


### PR DESCRIPTION
**Goal**
We want to measure how much time user took from start of the setup guide till it's finished. 

**How was it solved?**
- We set `startedAt` time when users press `Enter` to start setup
- On the last step when the config is saved successfully, we calculate duration time and emit new `setup_wizard_completed` event with `duration_ms` as payload.