### PR TITLE
Change indicator color and remove "follow on/off" badge

### DIFF
--- a/internal/devtui/styles.go
+++ b/internal/devtui/styles.go
@@ -22,6 +22,9 @@ var (
 	helpStyle = lipgloss.NewStyle().
 			Foreground(tui.MutedColor)
 
+	brandColor = lipgloss.NewStyle().
+			Foreground(tui.BrandColor)
+
 	activeBadgeStyle = lipgloss.NewStyle().
 				Foreground(tui.SuccessColor).
 				Bold(true)

--- a/internal/devtui/tab_instance.go
+++ b/internal/devtui/tab_instance.go
@@ -204,9 +204,9 @@ func (m InstanceModel) renderSidebar() string {
 			src := m.sources[i]
 			indicator := tui.DimStyle.Render("·")
 			if i == m.active {
-				indicator = activeBadgeStyle.Render("●")
+				indicator = brandColor.Render("●")
 			} else if src.kind == sourceProcess && (src.lineChan != nil || src.process != nil) && !src.dead {
-				indicator = activeBadgeStyle.Render("●")
+				indicator = brandColor.Render("●")
 			}
 
 			item := lipgloss.JoinHorizontal(lipgloss.Center, indicator, " ", src.name)
@@ -262,11 +262,6 @@ func (m InstanceModel) renderContent() string {
 		}
 	}
 
-	followBadge := warningBadgeStyle.Render("FOLLOW OFF")
-	if m.follow {
-		followBadge = activeBadgeStyle.Render("FOLLOW ON")
-	}
-
 	headerText := lipgloss.NewStyle().
 		Foreground(tui.TextColor).
 		Bold(true).
@@ -276,7 +271,6 @@ func (m InstanceModel) renderContent() string {
 	if kindLabel != "" {
 		header += " " + tui.TextBadge(kindLabel)
 	}
-	header += " " + followBadge
 
 	return contentPanelStyle.Render(
 		lipgloss.JoinVertical(

--- a/internal/devtui/tab_instance_test.go
+++ b/internal/devtui/tab_instance_test.go
@@ -213,29 +213,6 @@ func TestInstanceModel_ActiveProcessSourceName(t *testing.T) {
 		"sources without a Process should not be reported as process sources")
 }
 
-func TestInstanceModel_View_FollowBadgeOn(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
-	m.SetSize(120, 40)
-	m.follow = true
-
-	var view string
-	assert.NotPanics(t, func() {
-		view = m.View()
-	})
-	assert.Contains(t, view, "FOLLOW ON")
-	assert.NotContains(t, view, "FOLLOW OFF")
-}
-
-func TestInstanceModel_View_FollowBadgeOff(t *testing.T) {
-	m := NewInstanceModel("/tmp", false)
-	m.SetSize(120, 40)
-	m.follow = false
-
-	view := m.View()
-	assert.Contains(t, view, "FOLLOW OFF")
-	assert.NotContains(t, view, "FOLLOW ON")
-}
-
 func TestInstanceModel_View_NoSourceSelected(t *testing.T) {
 	m := NewInstanceModel("/tmp", false)
 	m.SetSize(120, 40)


### PR DESCRIPTION
This PR relates to https://github.com/shopware/shopware-cli/issues/1113:

- Remove "FOLLOW ON/OFF" badge from content part of the panel (incl. removing obsolete tests)
- Change indicator dot color from `SuccessColor` (green) to `brandColor` (blue).