### PR TITLE
feat(symfony): parse and merge config/packages with env resolution

### DIFF
--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -89,6 +89,18 @@ func ReadValues(projectRoot string, keys ...string) (map[string]string, error) {
 	return out, nil
 }
 
+// ReadAll returns every variable defined across the project's Symfony env
+// files, merged with Symfony precedence (.env.dist < .env < .env.local). An
+// empty map is returned when no env file exists.
+func ReadAll(projectRoot string) (map[string]string, error) {
+	files := resolveEnvFiles(projectRoot)
+	if len(files) == 0 {
+		return map[string]string{}, nil
+	}
+
+	return godotenv.Read(files...)
+}
+
 // WriteValue is a convenience wrapper around WriteValues for a single key.
 func WriteValue(projectRoot, key, value string) error {
 	return WriteValues(projectRoot, map[string]string{key: value})

--- a/internal/symfony/config_packages.go
+++ b/internal/symfony/config_packages.go
@@ -1,0 +1,386 @@
+package symfony
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/shopware/shopware-cli/internal/envfile"
+)
+
+// BaseEnvironment is the pseudo-environment that represents configuration which
+// is loaded for every environment (the files directly in config/packages and
+// the when@<env> blocks are resolved relative to it).
+const BaseEnvironment = "_base"
+
+// whenPrefix is the Symfony key prefix used to scope a block of configuration to
+// a single environment from within a regular config file (e.g. "when@dev").
+const whenPrefix = "when@"
+
+// ConfigFile is a single parsed YAML file below config/packages. It keeps the
+// original document node so writes can preserve comments and formatting. Files
+// directly in config/packages use BaseEnvironment as Environment; files in
+// config/packages/<env>/ use that <env>.
+type ConfigFile struct {
+	Path        string
+	Environment string
+	doc         *yaml.Node
+}
+
+// ProjectConfig is the entry point for reading and mutating the config/packages
+// tree of a Symfony project. Use NewProjectConfig to load it from disk.
+type ProjectConfig struct {
+	projectRoot string
+	packagesDir string
+	files       []*ConfigFile
+}
+
+// NewProjectConfig discovers and parses every YAML file below
+// <projectRoot>/config/packages, including environment subdirectories. It does
+// not resolve or merge anything yet; call Environments, Config or related
+// methods for that. A project without a config/packages directory yields an
+// empty ProjectConfig rather than an error.
+func NewProjectConfig(projectRoot string) (*ProjectConfig, error) {
+	packagesDir := filepath.Join(projectRoot, "config", "packages")
+
+	pc := &ProjectConfig{
+		projectRoot: projectRoot,
+		packagesDir: packagesDir,
+	}
+
+	info, err := os.Stat(packagesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return pc, nil
+		}
+
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", packagesDir)
+	}
+
+	if err := pc.load(); err != nil {
+		return nil, err
+	}
+
+	return pc, nil
+}
+
+// load walks config/packages and parses all *.yaml / *.yml files. Files in the
+// root belong to BaseEnvironment, files in a direct subdirectory belong to that
+// subdirectory's environment. Nested directories deeper than one level are
+// ignored, matching Symfony's loader which only globs one level deep.
+func (pc *ProjectConfig) load() error {
+	var files []*ConfigFile
+
+	entries, err := os.ReadDir(pc.packagesDir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			envName := entry.Name()
+			envDir := filepath.Join(pc.packagesDir, envName)
+
+			envFiles, err := readYAMLDir(envDir, envName)
+			if err != nil {
+				return err
+			}
+
+			files = append(files, envFiles...)
+
+			continue
+		}
+
+		if !isYAMLFile(entry.Name()) {
+			continue
+		}
+
+		file, err := parseConfigFile(filepath.Join(pc.packagesDir, entry.Name()), BaseEnvironment)
+		if err != nil {
+			return err
+		}
+
+		files = append(files, file)
+	}
+
+	sortConfigFiles(files)
+	pc.files = files
+
+	return nil
+}
+
+// Environments returns the sorted list of environments the project defines,
+// excluding BaseEnvironment. An environment is recognised either through a
+// config/packages/<env>/ directory or through a when@<env> block in any file.
+func (pc *ProjectConfig) Environments() []string {
+	seen := map[string]struct{}{}
+
+	for _, file := range pc.files {
+		if file.Environment != BaseEnvironment {
+			seen[file.Environment] = struct{}{}
+		}
+
+		for _, env := range file.whenEnvironments() {
+			seen[env] = struct{}{}
+		}
+	}
+
+	envs := make([]string, 0, len(seen))
+	for env := range seen {
+		envs = append(envs, env)
+	}
+
+	sort.Strings(envs)
+
+	return envs
+}
+
+// Files returns every parsed config file in load order. The returned slice is a
+// copy; mutating it does not affect the ProjectConfig.
+func (pc *ProjectConfig) Files() []*ConfigFile {
+	out := make([]*ConfigFile, len(pc.files))
+	copy(out, pc.files)
+
+	return out
+}
+
+// Config resolves the fully merged configuration for the given environment. The
+// result is keyed by package name (e.g. "framework", "doctrine") and contains
+// plain Go values (map[string]any, []any, scalars) so callers can inspect or
+// transform arbitrary keys.
+//
+// Merge order follows Symfony, lowest to highest precedence:
+//  1. config/packages/*.yaml          (base files)
+//  2. when@<env> blocks in base files (resolved in base-file order)
+//  3. config/packages/<env>/*.yaml    (environment files)
+//  4. when@<env> blocks in environment files
+//
+// Maps are merged recursively; sequences and scalars from a higher-precedence
+// source replace the lower-precedence value entirely.
+func (pc *ProjectConfig) Config(environment string) (map[string]any, error) {
+	merged := map[string]any{}
+
+	for _, file := range pc.files {
+		if file.Environment != BaseEnvironment && file.Environment != environment {
+			continue
+		}
+
+		root, err := file.decodeRoot()
+		if err != nil {
+			return nil, fmt.Errorf("decoding %s: %w", file.Path, err)
+		}
+
+		for key, value := range root {
+			if env, ok := whenEnvFromKey(key); ok {
+				if env != environment {
+					continue
+				}
+
+				if block, ok := value.(map[string]any); ok {
+					merged = mergeValue(merged, block).(map[string]any)
+				}
+
+				continue
+			}
+
+			merged = mergeValue(merged, map[string]any{key: value}).(map[string]any)
+		}
+	}
+
+	return merged, nil
+}
+
+// PackageConfig is a convenience wrapper around Config that returns the merged
+// configuration of a single package for an environment. The second return value
+// reports whether the package is configured at all.
+func (pc *ProjectConfig) PackageConfig(environment, pkg string) (any, bool, error) {
+	cfg, err := pc.Config(environment)
+	if err != nil {
+		return nil, false, err
+	}
+
+	value, ok := cfg[pkg]
+
+	return value, ok, nil
+}
+
+// Env returns the project's environment variables parsed from its Symfony env
+// files (.env.dist < .env < .env.local), merged with Symfony precedence. The
+// returned map is the same source ResolvedConfig uses to resolve %env(...)%
+// references. An empty map is returned when the project has no env files.
+func (pc *ProjectConfig) Env() (map[string]string, error) {
+	return envfile.ReadAll(pc.projectRoot)
+}
+
+// GetConfigValue resolves a single dotted path (rooted at the package name,
+// e.g. "framework.cache.app") in the merged configuration of an environment.
+// The second return value reports whether the path exists.
+func (pc *ProjectConfig) GetConfigValue(environment, path string) (any, bool, error) {
+	cfg, err := pc.Config(environment)
+	if err != nil {
+		return nil, false, err
+	}
+
+	segments := splitPath(path)
+	if len(segments) == 0 {
+		return nil, false, fmt.Errorf("empty config path")
+	}
+
+	var current any = cfg
+
+	for _, segment := range segments {
+		m, ok := asStringMap(current)
+		if !ok {
+			return nil, false, nil
+		}
+
+		value, ok := m[segment]
+		if !ok {
+			return nil, false, nil
+		}
+
+		current = value
+	}
+
+	return current, true, nil
+}
+
+// whenEnvironments returns the environments referenced through when@<env> keys
+// at the root of the file.
+func (f *ConfigFile) whenEnvironments() []string {
+	root := f.rootMapping()
+	if root == nil {
+		return nil
+	}
+
+	var envs []string
+
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if env, ok := whenEnvFromKey(root.Content[i].Value); ok {
+			envs = append(envs, env)
+		}
+	}
+
+	return envs
+}
+
+// decodeRoot decodes the file's root mapping into plain Go values.
+func (f *ConfigFile) decodeRoot() (map[string]any, error) {
+	root := f.rootMapping()
+	if root == nil {
+		return map[string]any{}, nil
+	}
+
+	var out map[string]any
+	if err := root.Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		out = map[string]any{}
+	}
+
+	return out, nil
+}
+
+// rootMapping returns the top-level mapping node of the file, or nil when the
+// file is empty or not a mapping.
+func (f *ConfigFile) rootMapping() *yaml.Node {
+	if f.doc == nil || len(f.doc.Content) == 0 {
+		return nil
+	}
+
+	root := f.doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	return root
+}
+
+// parseConfigFile reads and parses a single YAML config file.
+func parseConfigFile(path, environment string) (*ConfigFile, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file := &ConfigFile{Path: path, Environment: environment}
+
+	if len(strings.TrimSpace(string(content))) == 0 {
+		return file, nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	file.doc = &doc
+
+	return file, nil
+}
+
+// readYAMLDir parses all top-level YAML files in dir, assigning them to
+// environment.
+func readYAMLDir(dir, environment string) ([]*ConfigFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []*ConfigFile
+
+	for _, entry := range entries {
+		if entry.IsDir() || !isYAMLFile(entry.Name()) {
+			continue
+		}
+
+		file, err := parseConfigFile(filepath.Join(dir, entry.Name()), environment)
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, file)
+	}
+
+	return files, nil
+}
+
+// sortConfigFiles orders files so that the merge in Config follows Symfony's
+// precedence: base files first, then environment files, alphabetically by path
+// within each group for determinism.
+func sortConfigFiles(files []*ConfigFile) {
+	sort.SliceStable(files, func(i, j int) bool {
+		ei, ej := files[i].Environment == BaseEnvironment, files[j].Environment == BaseEnvironment
+		if ei != ej {
+			return ei // base environment sorts first
+		}
+
+		return files[i].Path < files[j].Path
+	})
+}
+
+// whenEnvFromKey returns the environment encoded in a when@<env> key.
+func whenEnvFromKey(key string) (string, bool) {
+	if env, ok := strings.CutPrefix(key, whenPrefix); ok && env != "" {
+		return env, true
+	}
+
+	return "", false
+}
+
+// isYAMLFile reports whether name has a YAML extension.
+func isYAMLFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+
+	return ext == ".yaml" || ext == ".yml"
+}

--- a/internal/symfony/config_packages_env.go
+++ b/internal/symfony/config_packages_env.go
@@ -1,0 +1,382 @@
+package symfony
+
+import (
+	"encoding/base64"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Symfony only treats a value as an env reference when the whole string is a
+// single %env(...)% expression, so partial matches inside longer strings are
+// left untouched.
+const (
+	envPrefix = "%env("
+	envSuffix = ")%"
+)
+
+// ResolvedConfig is like Config but additionally resolves %env(...)% references
+// in string values against the project's .env files (.env.dist < .env <
+// .env.local, following Symfony precedence). Values that are not env
+// expressions are returned unchanged, and an unresolved variable becomes an
+// empty string unless a default processor supplies a fallback.
+//
+// Only string scalars are inspected; a successful cast processor (bool, int,
+// json, ...) can change the Go type of the resulting value.
+func (pc *ProjectConfig) ResolvedConfig(environment string) (map[string]any, error) {
+	cfg, err := pc.Config(environment)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver, err := pc.newEnvResolver(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := resolver.resolveValue(cfg)
+
+	return resolved.(map[string]any), nil
+}
+
+// GetResolvedConfigValue is GetConfigValue with %env(...)% resolution applied to
+// the returned value (and recursively to nested values).
+func (pc *ProjectConfig) GetResolvedConfigValue(environment, path string) (any, bool, error) {
+	value, ok, err := pc.GetConfigValue(environment, path)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	resolver, err := pc.newEnvResolver(nil)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return resolver.resolveValue(value), true, nil
+}
+
+// ResolveEnvExpression resolves a single value the way ResolvedConfig would: if
+// it is a %env(...)% expression it is resolved against the project's .env files,
+// otherwise it is returned unchanged.
+func (pc *ProjectConfig) ResolveEnvExpression(value any) (any, error) {
+	resolver, err := pc.newEnvResolver(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return resolver.resolveValue(value), nil
+}
+
+// envResolver resolves env expressions against a single env map loaded once via
+// ProjectConfig.Env. paramDefaults holds the defaults declared as
+// `parameters: { env(VAR): value }`, keyed by VAR, used when the variable is
+// unset.
+type envResolver struct {
+	env           map[string]string
+	paramDefaults map[string]string
+}
+
+// newEnvResolver builds a resolver, loading the project's env files once. When
+// cfg is provided, env(VAR) defaults declared under any package's parameters
+// block are collected so they can act as fallbacks, mirroring Symfony's
+// behaviour.
+func (pc *ProjectConfig) newEnvResolver(cfg map[string]any) (*envResolver, error) {
+	env, err := pc.Env()
+	if err != nil {
+		return nil, err
+	}
+
+	return &envResolver{
+		env:           env,
+		paramDefaults: collectEnvParamDefaults(cfg),
+	}, nil
+}
+
+// resolveValue recursively resolves env expressions inside maps, sequences and
+// string scalars. Non-string scalars are returned unchanged.
+func (r *envResolver) resolveValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[k] = r.resolveValue(v)
+		}
+
+		return out
+	case map[any]any:
+		m, _ := asStringMap(typed)
+
+		return r.resolveValue(m)
+	case []any:
+		out := make([]any, len(typed))
+		for i, v := range typed {
+			out[i] = r.resolveValue(v)
+		}
+
+		return out
+	case string:
+		return r.resolveString(typed)
+	default:
+		return value
+	}
+}
+
+// resolveString resolves a string when it is exactly an %env(...)% expression.
+func (r *envResolver) resolveString(value string) any {
+	inner, ok := envExpressionInner(value)
+	if !ok {
+		return value
+	}
+
+	processors, varName := splitProcessors(inner)
+
+	raw, found := r.lookup(varName)
+
+	resolved, err := applyProcessors(processors, raw, found, r)
+	if err != nil {
+		// On a processing error keep the original expression rather than
+		// silently dropping configuration.
+		return value
+	}
+
+	return resolved
+}
+
+// lookup returns the value of an environment variable, falling back to a
+// declared env(VAR) parameter default. The bool reports whether a value (env or
+// default) was found.
+func (r *envResolver) lookup(varName string) (string, bool) {
+	if v := r.env[varName]; v != "" {
+		return v, true
+	}
+
+	if def, ok := r.paramDefaults[varName]; ok {
+		return def, true
+	}
+
+	return "", false
+}
+
+// envExpressionInner returns the inner content of a %env(...)% expression when
+// value is exactly such an expression.
+func envExpressionInner(value string) (string, bool) {
+	if !strings.HasPrefix(value, envPrefix) || !strings.HasSuffix(value, envSuffix) {
+		return "", false
+	}
+
+	inner := value[len(envPrefix) : len(value)-len(envSuffix)]
+	if inner == "" {
+		return "", false
+	}
+
+	return inner, true
+}
+
+// splitProcessors splits the inner part of an env expression into its processor
+// chain and the variable name. For "int:default:0:PORT" it returns
+// (["int", "default", "0"], "PORT"). The variable name is always the last
+// colon-separated segment.
+func splitProcessors(inner string) ([]string, string) {
+	parts := strings.Split(inner, ":")
+	if len(parts) == 1 {
+		return nil, parts[0]
+	}
+
+	return parts[:len(parts)-1], parts[len(parts)-1]
+}
+
+// applyProcessors applies the processor chain (right-most processor closest to
+// the variable is applied first) to the raw variable value.
+func applyProcessors(processors []string, raw string, found bool, r *envResolver) (any, error) {
+	// Handle a leading default processor specially: it can supply a value when
+	// the variable is missing and consumes the following segment as the
+	// fallback parameter name.
+	if len(processors) >= 2 && processors[0] == "default" {
+		fallbackParam := processors[1]
+		remaining := processors[2:]
+
+		if !found {
+			if fallbackParam == "" {
+				// %env(default::VAR)% with no fallback resolves to null.
+				return nil, nil //nolint:nilnil // nil is the resolved value (YAML null), not an error
+			}
+
+			if def, ok := r.paramDefaults[fallbackParam]; ok {
+				raw = def
+				found = true
+			}
+		}
+
+		return applyCasts(remaining, raw, found)
+	}
+
+	return applyCasts(processors, raw, found)
+}
+
+// applyCasts applies the type/decoding processors (no default handling) from the
+// outermost to the innermost. Symfony applies the chain left-to-right where the
+// left-most processor is the last transformation, so we walk the slice in
+// reverse.
+func applyCasts(processors []string, raw string, found bool) (any, error) {
+	var current any = raw
+
+	for i := len(processors) - 1; i >= 0; i-- {
+		casted, err := applyCast(processors[i], current)
+		if err != nil {
+			return nil, err
+		}
+
+		current = casted
+	}
+
+	if !found {
+		if _, ok := current.(string); ok && current == "" {
+			return "", nil
+		}
+	}
+
+	return current, nil
+}
+
+// applyCast applies a single processor to value.
+func applyCast(processor string, value any) (any, error) {
+	str := fmt.Sprintf("%v", value)
+
+	switch processor {
+	case "string":
+		return str, nil
+	case "trim":
+		return strings.TrimSpace(str), nil
+	case "bool":
+		return parseEnvBool(str), nil
+	case "not":
+		return !parseEnvBool(str), nil
+	case "int":
+		n, err := strconv.Atoi(strings.TrimSpace(str))
+		if err != nil {
+			return nil, fmt.Errorf("env processor int: %w", err)
+		}
+
+		return n, nil
+	case "float":
+		f, err := strconv.ParseFloat(strings.TrimSpace(str), 64)
+		if err != nil {
+			return nil, fmt.Errorf("env processor float: %w", err)
+		}
+
+		return f, nil
+	case "json":
+		var out any
+		if strings.TrimSpace(str) == "" {
+			// json of an empty string resolves to null, matching Symfony.
+			return nil, nil //nolint:nilnil // nil is the resolved value (YAML null), not an error
+		}
+		if err := json.Unmarshal([]byte(str), &out); err != nil {
+			return nil, fmt.Errorf("env processor json: %w", err)
+		}
+
+		return out, nil
+	case "csv":
+		return parseEnvCSV(str)
+	case "base64":
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimRight(str, "="))
+		if err != nil {
+			// Fall back to padded decoding before failing.
+			decoded, err = base64.StdEncoding.DecodeString(str)
+			if err != nil {
+				return nil, fmt.Errorf("env processor base64: %w", err)
+			}
+		}
+
+		return string(decoded), nil
+	default:
+		// Unsupported processors (file, require, resolve, ...) are left as a
+		// best-effort pass-through of the underlying value.
+		return value, nil
+	}
+}
+
+// parseEnvBool mirrors Symfony's bool casting: 'true', 'on', 'yes' and non-zero
+// numbers are true; everything else is false.
+func parseEnvBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "on", "yes", "1":
+		return true
+	case "false", "off", "no", "0", "":
+		return false
+	}
+
+	if f, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
+		return f != 0
+	}
+
+	return false
+}
+
+// parseEnvCSV decodes a single CSV line into a slice of strings.
+func parseEnvCSV(value string) ([]any, error) {
+	if strings.TrimSpace(value) == "" {
+		return []any{}, nil
+	}
+
+	reader := csv.NewReader(strings.NewReader(value))
+
+	record, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("env processor csv: %w", err)
+	}
+
+	out := make([]any, len(record))
+	for i, field := range record {
+		out[i] = field
+	}
+
+	return out, nil
+}
+
+// collectEnvParamDefaults scans every package's parameters block for env(VAR)
+// keys, which declare default values for environment variables.
+func collectEnvParamDefaults(cfg map[string]any) map[string]string {
+	defaults := map[string]string{}
+	if cfg == nil {
+		return defaults
+	}
+
+	for _, pkg := range cfg {
+		pkgMap, ok := asStringMap(pkg)
+		if !ok {
+			continue
+		}
+
+		params, ok := asStringMap(pkgMap["parameters"])
+		if !ok {
+			continue
+		}
+
+		for key, value := range params {
+			varName, ok := envParamKey(key)
+			if !ok {
+				continue
+			}
+
+			if str, ok := value.(string); ok {
+				defaults[varName] = str
+			}
+		}
+	}
+
+	return defaults
+}
+
+// envParamKey extracts VAR from an "env(VAR)" parameter key.
+func envParamKey(key string) (string, bool) {
+	if rest, ok := strings.CutPrefix(key, "env("); ok {
+		if varName, ok := strings.CutSuffix(rest, ")"); ok && varName != "" {
+			return varName, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/symfony/config_packages_env_test.go
+++ b/internal/symfony/config_packages_env_test.go
@@ -1,0 +1,119 @@
+package symfony
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvedConfigResolvesEnvVars(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	cfg, err := pc.ResolvedConfig("dev")
+	require.NoError(t, err)
+
+	demo := cfg["env_demo"].(map[string]any)
+
+	assert.Equal(t, "s3cr3t", demo["secret"])
+	assert.Equal(t, "not-an-env-var", demo["literal"])
+	assert.Equal(t, true, demo["debug"])
+	assert.Equal(t, 3, demo["retry"])
+	assert.Equal(t, []any{"localhost", "example.com"}, demo["hosts"])
+	assert.Equal(t, map[string]any{"new_checkout": true}, demo["flags"])
+}
+
+func TestResolvedConfigUsesEnvParamDefault(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	cfg, err := pc.ResolvedConfig("dev")
+	require.NoError(t, err)
+
+	demo := cfg["env_demo"].(map[string]any)
+
+	// REQUEST_TIMEOUT is not in .env, so the declared env(REQUEST_TIMEOUT)
+	// parameter default of 45 is used and then int-cast.
+	assert.Equal(t, 45, demo["timeout"])
+}
+
+func TestRawConfigKeepsEnvExpressions(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	// The non-resolving API must leave expressions intact for safe round-trips.
+	value, ok, err := pc.GetConfigValue("dev", "env_demo.secret")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "%env(APP_SECRET)%", value)
+}
+
+func TestGetResolvedConfigValue(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	value, ok, err := pc.GetResolvedConfigValue("prod", "framework.cache.app")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "cache.adapter.redis", value)
+
+	value, ok, err = pc.GetResolvedConfigValue("dev", "env_demo.retry")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, 3, value)
+}
+
+func TestResolveEnvExpression(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	resolved, err := pc.ResolveEnvExpression("%env(REDIS_URL)%")
+	require.NoError(t, err)
+	assert.Equal(t, "redis://localhost:6379", resolved)
+
+	// A missing variable with no default resolves to an empty string.
+	resolved, err = pc.ResolveEnvExpression("%env(NOT_SET)%")
+	require.NoError(t, err)
+	assert.Equal(t, "", resolved)
+}
+
+func TestEnv(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	env, err := pc.Env()
+	require.NoError(t, err)
+
+	assert.Equal(t, "s3cr3t", env["APP_SECRET"])
+	assert.Equal(t, "redis://localhost:6379", env["REDIS_URL"])
+	assert.Equal(t, "localhost,example.com", env["ALLOWED_HOSTS"])
+}
+
+func TestEnvEmptyWithoutEnvFiles(t *testing.T) {
+	pc, err := NewProjectConfig(t.TempDir())
+	require.NoError(t, err)
+
+	env, err := pc.Env()
+	require.NoError(t, err)
+	assert.Empty(t, env)
+}
+
+func TestSplitProcessors(t *testing.T) {
+	processors, varName := splitProcessors("int:default:0:PORT")
+	assert.Equal(t, []string{"int", "default", "0"}, processors)
+	assert.Equal(t, "PORT", varName)
+
+	processors, varName = splitProcessors("APP_SECRET")
+	assert.Nil(t, processors)
+	assert.Equal(t, "APP_SECRET", varName)
+}
+
+func TestParseEnvBool(t *testing.T) {
+	for _, truthy := range []string{"true", "on", "yes", "1", "5"} {
+		assert.True(t, parseEnvBool(truthy), truthy)
+	}
+	for _, falsy := range []string{"false", "off", "no", "0", "", "nonsense"} {
+		assert.False(t, parseEnvBool(falsy), falsy)
+	}
+}

--- a/internal/symfony/config_packages_merge.go
+++ b/internal/symfony/config_packages_merge.go
@@ -1,0 +1,88 @@
+package symfony
+
+import "fmt"
+
+// mergeValue merges src onto dst following Symfony's configuration semantics and
+// returns the merged result:
+//
+//   - When both dst and src are maps, keys are merged recursively. Keys present
+//     only in dst are kept; keys present in src override or extend dst.
+//   - For any other combination (scalar, sequence, or a type mismatch) src wins
+//     and replaces dst entirely. In particular sequences are NOT concatenated,
+//     matching Symfony where a list defined in a higher-precedence file replaces
+//     the lower-precedence list.
+//
+// dst is treated as immutable: a new map is allocated when merging maps so the
+// caller's lower-precedence data is never mutated in place.
+func mergeValue(dst, src any) any {
+	srcMap, srcIsMap := asStringMap(src)
+	if !srcIsMap {
+		return src
+	}
+
+	dstMap, dstIsMap := asStringMap(dst)
+	if !dstIsMap {
+		// dst is not a map; src (a map) replaces it. Copy so later merges that
+		// reach into this subtree cannot mutate src.
+		return cloneMap(srcMap)
+	}
+
+	out := make(map[string]any, len(dstMap)+len(srcMap))
+	for k, v := range dstMap {
+		out[k] = v
+	}
+
+	for k, v := range srcMap {
+		if existing, ok := out[k]; ok {
+			out[k] = mergeValue(existing, v)
+		} else {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+// asStringMap normalises the two map shapes yaml.v3 can produce
+// (map[string]any and map[any]any) into a map[string]any. The bool reports
+// whether value was a map at all.
+func asStringMap(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[stringifyKey(k)] = v
+		}
+
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// cloneMap returns a shallow-then-recursive copy of m so the result shares no
+// mutable map nodes with the input.
+func cloneMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if nested, ok := asStringMap(v); ok {
+			out[k] = cloneMap(nested)
+		} else {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+// stringifyKey converts an arbitrary YAML map key into the string form used by
+// the merged representation.
+func stringifyKey(key any) string {
+	if s, ok := key.(string); ok {
+		return s
+	}
+
+	return fmt.Sprintf("%v", key)
+}

--- a/internal/symfony/config_packages_merge_test.go
+++ b/internal/symfony/config_packages_merge_test.go
@@ -1,0 +1,58 @@
+package symfony
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeValueRecursesMaps(t *testing.T) {
+	dst := map[string]any{
+		"framework": map[string]any{
+			"secret": "base",
+			"cache":  map[string]any{"app": "filesystem"},
+		},
+	}
+	src := map[string]any{
+		"framework": map[string]any{
+			"cache":    map[string]any{"app": "redis"},
+			"profiler": map[string]any{"enabled": true},
+		},
+	}
+
+	merged := mergeValue(dst, src).(map[string]any)
+	framework := merged["framework"].(map[string]any)
+
+	assert.Equal(t, "base", framework["secret"], "untouched keys survive")
+	assert.Equal(t, "redis", framework["cache"].(map[string]any)["app"], "scalar overridden")
+	assert.Equal(t, true, framework["profiler"].(map[string]any)["enabled"], "new key added")
+}
+
+func TestMergeValueReplacesSequences(t *testing.T) {
+	dst := map[string]any{"channels": []any{"main", "event"}}
+	src := map[string]any{"channels": []any{"deprecation"}}
+
+	merged := mergeValue(dst, src).(map[string]any)
+
+	// Symfony replaces lists rather than concatenating them.
+	assert.Equal(t, []any{"deprecation"}, merged["channels"])
+}
+
+func TestMergeValueDoesNotMutateInputs(t *testing.T) {
+	dst := map[string]any{"a": map[string]any{"x": 1}}
+	src := map[string]any{"a": map[string]any{"y": 2}}
+
+	_ = mergeValue(dst, src)
+
+	// dst's nested map must be untouched so lower-precedence callers keep their
+	// original data.
+	assert.Equal(t, map[string]any{"x": 1}, dst["a"])
+}
+
+func TestMergeValueScalarReplacesMap(t *testing.T) {
+	dst := map[string]any{"handler_id": map[string]any{"nested": true}}
+	src := map[string]any{"handler_id": nil}
+
+	merged := mergeValue(dst, src).(map[string]any)
+	assert.Nil(t, merged["handler_id"])
+}

--- a/internal/symfony/config_packages_test.go
+++ b/internal/symfony/config_packages_test.go
@@ -1,0 +1,215 @@
+package symfony
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fixtureProject = "testdata/config-packages/project"
+
+func TestNewProjectConfigMissingDirectory(t *testing.T) {
+	pc, err := NewProjectConfig(t.TempDir())
+	require.NoError(t, err)
+
+	assert.Empty(t, pc.Environments())
+	assert.Empty(t, pc.Files())
+
+	cfg, err := pc.Config("dev")
+	require.NoError(t, err)
+	assert.Empty(t, cfg)
+}
+
+func TestEnvironments(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	// dev + prod come from directories, test from a when@test block.
+	assert.ElementsMatch(t, []string{"dev", "prod", "test"}, pc.Environments())
+}
+
+func TestConfigMergesBaseFiles(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	cfg, err := pc.Config("dev")
+	require.NoError(t, err)
+
+	framework, ok := cfg["framework"].(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "%env(APP_SECRET)%", framework["secret"])
+
+	// cache.yaml (base) is merged into the same framework key, not overwritten.
+	cache, ok := framework["cache"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "cache.adapter.filesystem", cache["app"])
+
+	// dev/framework.yaml adds the profiler section for the dev environment.
+	profiler, ok := framework["profiler"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, profiler["only_exceptions"])
+}
+
+func TestConfigEnvironmentOverridesBase(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	dev, err := pc.Config("dev")
+	require.NoError(t, err)
+	prod, err := pc.Config("prod")
+	require.NoError(t, err)
+
+	devCache := dev["framework"].(map[string]any)["cache"].(map[string]any)
+	prodCache := prod["framework"].(map[string]any)["cache"].(map[string]any)
+
+	// dev keeps the base filesystem adapter, prod overrides it via prod/cache.yaml.
+	assert.Equal(t, "cache.adapter.filesystem", devCache["app"])
+	assert.Equal(t, "cache.adapter.redis", prodCache["app"])
+
+	// The override only replaces app; the base pools map survives the merge.
+	pools, ok := prodCache["pools"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, pools, "my_pool")
+
+	// prod has no profiler (that section is dev-only).
+	assert.NotContains(t, prod["framework"].(map[string]any), "profiler")
+}
+
+func TestConfigWhenBlockOnlyAppliesToItsEnvironment(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	testCfg, err := pc.Config("test")
+	require.NoError(t, err)
+	devCfg, err := pc.Config("dev")
+	require.NoError(t, err)
+
+	testFramework := testCfg["framework"].(map[string]any)
+	assert.Equal(t, true, testFramework["test"])
+
+	// when@test only contributes to the test environment.
+	assert.NotContains(t, devCfg["framework"].(map[string]any), "test")
+}
+
+func TestGetConfigValue(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	value, ok, err := pc.GetConfigValue("prod", "framework.cache.app")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "cache.adapter.redis", value)
+
+	_, ok, err = pc.GetConfigValue("prod", "framework.does.not.exist")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestPackageConfig(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	value, ok, err := pc.PackageConfig("dev", "framework")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.IsType(t, map[string]any{}, value)
+
+	_, ok, err = pc.PackageConfig("dev", "doctrine")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// copyFixture copies the static fixture project into a temp dir so write tests
+// can mutate it without touching testdata.
+func copyFixture(t *testing.T) string {
+	t.Helper()
+
+	dst := t.TempDir()
+	require.NoError(t, copy.Copy(fixtureProject, dst))
+
+	return dst
+}
+
+func TestSetConfigValueEditsExistingFileInPlace(t *testing.T) {
+	root := copyFixture(t)
+
+	pc, err := NewProjectConfig(root)
+	require.NoError(t, err)
+
+	require.NoError(t, pc.SetConfigValue("prod", "framework.cache.app", "cache.adapter.apcu"))
+
+	// The value that already lived in prod/cache.yaml is updated there.
+	content, err := os.ReadFile(filepath.Join(root, "config", "packages", "prod", "cache.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "cache.adapter.apcu")
+	// The sibling key in the same file is preserved.
+	assert.Contains(t, string(content), "default_redis_provider")
+
+	// Reload-after-write means the new value is observable immediately.
+	value, ok, err := pc.GetConfigValue("prod", "framework.cache.app")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "cache.adapter.apcu", value)
+}
+
+func TestSetConfigValuePreservesComments(t *testing.T) {
+	root := copyFixture(t)
+
+	pc, err := NewProjectConfig(root)
+	require.NoError(t, err)
+
+	require.NoError(t, pc.SetConfigValue("dev", "framework.secret", "changed"))
+
+	content, err := os.ReadFile(filepath.Join(root, "config", "packages", "framework.yaml"))
+	require.NoError(t, err)
+
+	// The leading comment of the base file survives the rewrite.
+	assert.Contains(t, string(content), "# framework configuration shared by all environments")
+	assert.Contains(t, string(content), "changed")
+}
+
+func TestSetConfigValueCreatesEnvironmentFile(t *testing.T) {
+	root := copyFixture(t)
+
+	pc, err := NewProjectConfig(root)
+	require.NoError(t, err)
+
+	// messenger is not configured anywhere; prod/ exists, so the value lands in
+	// config/packages/prod/messenger.yaml.
+	require.NoError(t, pc.SetConfigValue("prod", "messenger.transports.async", "%env(MESSENGER_TRANSPORT_DSN)%"))
+
+	target := filepath.Join(root, "config", "packages", "prod", "messenger.yaml")
+	assert.FileExists(t, target)
+
+	value, ok, err := pc.GetConfigValue("prod", "messenger.transports.async")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "%env(MESSENGER_TRANSPORT_DSN)%", value)
+
+	// dev never sees the prod-only file.
+	_, ok, err = pc.GetConfigValue("dev", "messenger.transports.async")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestSetConfigValueCreatesBaseFile(t *testing.T) {
+	root := copyFixture(t)
+
+	pc, err := NewProjectConfig(root)
+	require.NoError(t, err)
+
+	require.NoError(t, pc.SetConfigValue(BaseEnvironment, "monolog.channels", []any{"deprecation"}))
+
+	target := filepath.Join(root, "config", "packages", "monolog.yaml")
+	assert.FileExists(t, target)
+
+	value, ok, err := pc.GetConfigValue("dev", "monolog.channels")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, []any{"deprecation"}, value)
+}

--- a/internal/symfony/config_packages_write.go
+++ b/internal/symfony/config_packages_write.go
@@ -1,0 +1,278 @@
+package symfony
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SetConfigValue sets the value at the given dotted path for an environment and
+// persists the change to disk. The path is rooted at the package name, e.g.
+// "framework.cache.app" or "doctrine.dbal.url".
+//
+// The target file is chosen to mirror where Symfony itself would read the value
+// from, so existing comments, key order and formatting in unrelated parts of
+// the file are preserved:
+//
+//   - If a file already defines the path (the deepest existing prefix wins),
+//     that file is edited in place.
+//   - Otherwise, for an environment other than BaseEnvironment that has a
+//     config/packages/<env>/ directory, a file named <package>.yaml in that
+//     directory is used (created if necessary).
+//   - Otherwise config/packages/<package>.yaml is used (created if necessary).
+//
+// After a successful write the in-memory state is reloaded so subsequent reads
+// observe the change.
+func (pc *ProjectConfig) SetConfigValue(environment string, path string, value any) error {
+	segments := splitPath(path)
+	if len(segments) == 0 {
+		return fmt.Errorf("empty config path")
+	}
+
+	target := pc.resolveWriteTarget(environment, segments)
+
+	if err := target.set(segments, value); err != nil {
+		return err
+	}
+
+	if err := target.save(); err != nil {
+		return err
+	}
+
+	return pc.load()
+}
+
+// resolveWriteTarget picks the ConfigFile that SetConfigValue should edit for
+// the given environment and path, creating an in-memory file handle when no
+// existing file is suitable.
+func (pc *ProjectConfig) resolveWriteTarget(environment string, segments []string) *ConfigFile {
+	if existing := pc.fileDefiningPath(environment, segments); existing != nil {
+		return existing
+	}
+
+	pkg := segments[0]
+
+	if environment != BaseEnvironment && pc.hasEnvironmentDir(environment) {
+		return &ConfigFile{
+			Path:        filepath.Join(pc.packagesDir, environment, pkg+".yaml"),
+			Environment: environment,
+		}
+	}
+
+	return &ConfigFile{
+		Path:        filepath.Join(pc.packagesDir, pkg+".yaml"),
+		Environment: BaseEnvironment,
+	}
+}
+
+// fileDefiningPath returns the highest-precedence loaded file (for the base or
+// the given environment) that already defines the deepest possible prefix of
+// segments. It prefers the most specific match so an override lands next to the
+// value it overrides.
+func (pc *ProjectConfig) fileDefiningPath(environment string, segments []string) *ConfigFile {
+	var best *ConfigFile
+	bestDepth := -1
+
+	// Iterate in load order so that, for an equal match depth, the
+	// highest-precedence (latest) file wins.
+	for _, file := range pc.files {
+		if file.Environment != BaseEnvironment && file.Environment != environment {
+			continue
+		}
+
+		depth := file.definedDepth(environment, segments)
+		if depth >= bestDepth && depth > 0 {
+			best = file
+			bestDepth = depth
+		}
+	}
+
+	return best
+}
+
+// hasEnvironmentDir reports whether config/packages/<environment>/ exists.
+func (pc *ProjectConfig) hasEnvironmentDir(environment string) bool {
+	info, err := os.Stat(filepath.Join(pc.packagesDir, environment))
+
+	return err == nil && info.IsDir()
+}
+
+// definedDepth returns how many leading segments of path are present in the
+// file, considering both the file root and its when@<environment> block.
+// A return value of 0 means the file does not contribute to this path.
+func (f *ConfigFile) definedDepth(environment string, segments []string) int {
+	root := f.rootMapping()
+	if root == nil {
+		return 0
+	}
+
+	depth := mappingDepth(root, segments)
+
+	if when := mappingChild(root, whenPrefix+environment); when != nil {
+		if d := mappingDepth(when, segments); d > depth {
+			depth = d
+		}
+	}
+
+	return depth
+}
+
+// set writes value at the dotted path inside the file, creating intermediate
+// mappings as needed. The document and its comments are preserved.
+func (f *ConfigFile) set(segments []string, value any) error {
+	if f.doc == nil {
+		f.doc = &yaml.Node{
+			Kind:    yaml.DocumentNode,
+			Content: []*yaml.Node{newMapping()},
+		}
+	}
+
+	if len(f.doc.Content) == 0 {
+		f.doc.Content = append(f.doc.Content, newMapping())
+	}
+
+	root := f.doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s: root node is not a mapping", f.Path)
+	}
+
+	valueNode, err := encodeValue(value)
+	if err != nil {
+		return err
+	}
+
+	return setInMapping(root, segments, valueNode)
+}
+
+// save serialises the document back to disk, creating parent directories when
+// the file is new.
+func (f *ConfigFile) save() error {
+	if err := os.MkdirAll(filepath.Dir(f.Path), 0o755); err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(4)
+
+	if err := encoder.Encode(f.doc); err != nil {
+		return err
+	}
+
+	if err := encoder.Close(); err != nil {
+		return err
+	}
+
+	return os.WriteFile(f.Path, buf.Bytes(), 0o644)
+}
+
+// setInMapping descends mapping along segments, creating intermediate mappings
+// when absent, and assigns valueNode at the leaf.
+func setInMapping(mapping *yaml.Node, segments []string, valueNode *yaml.Node) error {
+	key := segments[0]
+
+	if len(segments) == 1 {
+		if existing := mappingValueNode(mapping, key); existing != nil {
+			// Preserve any line comment attached to the existing value.
+			valueNode.LineComment = existing.LineComment
+			*existing = *valueNode
+		} else {
+			mapPut(mapping, key, valueNode)
+		}
+
+		return nil
+	}
+
+	child := mappingChild(mapping, key)
+	if child == nil {
+		child = newMapping()
+		mapPut(mapping, key, child)
+	} else if child.Kind != yaml.MappingNode {
+		// Replace a scalar/sequence leaf with a mapping so we can descend.
+		*child = *newMapping()
+	}
+
+	return setInMapping(child, segments[1:], valueNode)
+}
+
+// mappingDepth returns the number of leading segments resolvable inside mapping.
+func mappingDepth(mapping *yaml.Node, segments []string) int {
+	depth := 0
+	current := mapping
+
+	for _, segment := range segments {
+		if current == nil || current.Kind != yaml.MappingNode {
+			break
+		}
+
+		next := mappingValueNode(current, segment)
+		if next == nil {
+			break
+		}
+
+		depth++
+		current = next
+	}
+
+	return depth
+}
+
+// mappingChild returns the value node for key when it is itself a mapping.
+func mappingChild(mapping *yaml.Node, key string) *yaml.Node {
+	node := mappingValueNode(mapping, key)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	return node
+}
+
+// mappingValueNode returns the value node associated with key in mapping, or nil
+// when the key is absent.
+func mappingValueNode(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+// encodeValue turns a Go value into a YAML node. A *yaml.Node is used verbatim
+// so callers can pass pre-built nodes.
+func encodeValue(value any) (*yaml.Node, error) {
+	if node, ok := value.(*yaml.Node); ok {
+		return node, nil
+	}
+
+	node := &yaml.Node{}
+	if err := node.Encode(value); err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+// splitPath splits a dotted config path into its segments, ignoring empty ones
+// so leading/trailing/duplicate dots do not produce blank keys.
+func splitPath(path string) []string {
+	raw := strings.Split(path, ".")
+	segments := make([]string, 0, len(raw))
+
+	for _, segment := range raw {
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+
+	return segments
+}

--- a/internal/symfony/testdata/config-packages/project/.env
+++ b/internal/symfony/testdata/config-packages/project/.env
@@ -1,0 +1,6 @@
+APP_SECRET=s3cr3t
+REDIS_URL=redis://localhost:6379
+APP_DEBUG=1
+MESSAGE_RETRY=3
+ALLOWED_HOSTS=localhost,example.com
+FEATURE_FLAGS={"new_checkout": true}

--- a/internal/symfony/testdata/config-packages/project/config/packages/cache.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/cache.yaml
@@ -1,0 +1,6 @@
+framework:
+    cache:
+        app: cache.adapter.filesystem
+        pools:
+            my_pool:
+                adapter: cache.adapter.array

--- a/internal/symfony/testdata/config-packages/project/config/packages/dev/framework.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/dev/framework.yaml
@@ -1,0 +1,5 @@
+framework:
+    profiler:
+        only_exceptions: false
+    php_errors:
+        log: true

--- a/internal/symfony/testdata/config-packages/project/config/packages/env_demo.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/env_demo.yaml
@@ -1,0 +1,10 @@
+env_demo:
+    secret: '%env(APP_SECRET)%'
+    debug: '%env(bool:APP_DEBUG)%'
+    retry: '%env(int:MESSAGE_RETRY)%'
+    hosts: '%env(csv:ALLOWED_HOSTS)%'
+    flags: '%env(json:FEATURE_FLAGS)%'
+    timeout: '%env(int:default:30:REQUEST_TIMEOUT)%'
+    literal: not-an-env-var
+    parameters:
+        env(REQUEST_TIMEOUT): '45'

--- a/internal/symfony/testdata/config-packages/project/config/packages/framework.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/framework.yaml
@@ -1,0 +1,14 @@
+# framework configuration shared by all environments
+framework:
+    secret: '%env(APP_SECRET)%'
+    session:
+        handler_id: null
+        cookie_secure: auto
+    php_errors:
+        log: true
+
+when@test:
+    framework:
+        test: true
+        session:
+            storage_factory_id: session.storage.factory.mock_file

--- a/internal/symfony/testdata/config-packages/project/config/packages/prod/cache.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/prod/cache.yaml
@@ -1,0 +1,4 @@
+framework:
+    cache:
+        app: cache.adapter.redis
+        default_redis_provider: '%env(REDIS_URL)%'


### PR DESCRIPTION
## Summary

Adds a `ProjectConfig` abstraction in `internal/symfony` that reads a Symfony project's `config/packages` tree across all environments with correct Symfony merge semantics, and resolves `%env(...)%` references. Intended as a foundation for further project optimizations.

## API

```go
pc, _ := symfony.NewProjectConfig(projectRoot)

pc.Environments()                                  // ["dev", "prod", "test"]
pc.Config("prod")                                  // fully merged map[string]any, keyed by package
pc.PackageConfig("prod", "framework")              // one package's merged config
pc.GetConfigValue("prod", "framework.cache.app")   // dotted-path read (raw %env() kept)
pc.SetConfigValue("prod", "framework.cache.app", "...") // comment-preserving in-place write
pc.Files()                                          // raw parsed files in load order

pc.Env()                                            // merged .env content (.env.dist < .env < .env.local)
pc.ResolvedConfig("prod")                          // merged config with %env() resolved
pc.GetResolvedConfigValue("dev", "env_demo.retry") // dotted-path read, resolved
pc.ResolveEnvExpression("%env(REDIS_URL)%")        // resolve a single expression
```

## Merge semantics (matches the Symfony kernel)

- Load precedence low→high: `config/packages/*.yaml` → `when@<env>` blocks in base files → `config/packages/<env>/*.yaml` → `when@<env>` blocks in env files.
- Maps merge recursively; **sequences and scalars replace** (lists are not concatenated).
- `when@<env>` blocks only contribute to their own environment.

## Env-var resolution

- Opt-in: raw `Config()`/`GetConfigValue()` keep literal `%env(...)%` strings (safe for write round-trips); the `Resolved*` variants resolve.
- Reads the project's `.env` chain via `internal/envfile` (Symfony precedence). The resolver loads `pc.Env()` **once** and reuses that map.
- Supported processors: bare `VAR`, casts `bool/int/float/string/trim/not/json/csv/base64`, `default:param:VAR`, and `env(VAR)` parameter defaults. `file:`/`require:`/`resolve:` are best-effort pass-throughs (no PHP/container context).

## Writes

`SetConfigValue` edits the source file via `yaml.Node`, preserving comments, key order and unrelated formatting. Target file mirrors where Symfony reads the value: deepest existing file defining the path, else a per-package file in `config/packages/<env>/` when that dir exists, else `config/packages/<pkg>.yaml`. Reloads after write.

## Tests

New `config_packages_test.go`, `config_packages_merge_test.go`, `config_packages_env_test.go` with a fixture project under `testdata/config-packages/`. Covers merge precedence, list replacement, `when@` scoping, comment-preserving and file-creating writes, env resolution + processors, and param-default fallback. `go test ./...`, `go vet`, `gofmt` clean.

## Notes / limitations

- Reads `config/packages` only — not `config/services.yaml`, routes, or container parameters.
- `default:<param>:VAR` only resolves `<param>` when declared as an `env(...)` default; arbitrary container parameters are not resolved.