### PR TITLE
fix(symfony): address config/packages review feedback (#1142)

### DIFF
--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -93,7 +93,15 @@ func ReadValues(projectRoot string, keys ...string) (map[string]string, error) {
 // files, merged with Symfony precedence (.env.dist < .env < .env.local). An
 // empty map is returned when no env file exists.
 func ReadAll(projectRoot string) (map[string]string, error) {
-	files := resolveEnvFiles(projectRoot)
+	return ReadAllForEnvironment(projectRoot, "")
+}
+
+// ReadAllForEnvironment is like ReadAll but additionally layers the
+// environment-specific files on top, following Symfony precedence
+// (.env.dist < .env < .env.local < .env.<env> < .env.<env>.local). An empty
+// environment behaves exactly like ReadAll.
+func ReadAllForEnvironment(projectRoot, environment string) (map[string]string, error) {
+	files := resolveEnvFilesForEnvironment(projectRoot, environment)
 	if len(files) == 0 {
 		return map[string]string{}, nil
 	}
@@ -145,11 +153,22 @@ func WriteValues(projectRoot string, values map[string]string) error {
 }
 
 func resolveEnvFiles(projectRoot string) []string {
+	return resolveEnvFilesForEnvironment(projectRoot, "")
+}
+
+func resolveEnvFilesForEnvironment(projectRoot, environment string) []string {
 	candidates := []string{
 		filepath.Join(projectRoot, ".env.dist"),
 		filepath.Join(projectRoot, ".env"),
 		filepath.Join(projectRoot, ".env.local"),
 	}
+	if environment != "" {
+		candidates = append(candidates,
+			filepath.Join(projectRoot, ".env."+environment),
+			filepath.Join(projectRoot, ".env."+environment+".local"),
+		)
+	}
+
 	var found []string
 	for _, p := range candidates {
 		if _, err := os.Stat(p); err == nil {

--- a/internal/symfony/config_packages.go
+++ b/internal/symfony/config_packages.go
@@ -173,25 +173,25 @@ func (pc *ProjectConfig) Config(environment string) (map[string]any, error) {
 			continue
 		}
 
-		root, err := file.decodeRoot()
+		entries, err := file.orderedEntries()
 		if err != nil {
 			return nil, fmt.Errorf("decoding %s: %w", file.Path, err)
 		}
 
-		for key, value := range root {
-			if env, ok := whenEnvFromKey(key); ok {
+		for _, entry := range entries {
+			if env, ok := whenEnvFromKey(entry.key); ok {
 				if env != environment {
 					continue
 				}
 
-				if block, ok := value.(map[string]any); ok {
+				if block, ok := entry.value.(map[string]any); ok {
 					merged = mergeValue(merged, block).(map[string]any)
 				}
 
 				continue
 			}
 
-			merged = mergeValue(merged, map[string]any{key: value}).(map[string]any)
+			merged = mergeValue(merged, map[string]any{entry.key: entry.value}).(map[string]any)
 		}
 	}
 
@@ -229,6 +229,11 @@ func (pc *ProjectConfig) GetConfigValue(environment, path string) (any, bool, er
 		return nil, false, err
 	}
 
+	return getConfigValue(cfg, path)
+}
+
+// getConfigValue resolves a dotted path inside an already-merged config map.
+func getConfigValue(cfg map[string]any, path string) (any, bool, error) {
 	segments := splitPath(path)
 	if len(segments) == 0 {
 		return nil, false, fmt.Errorf("empty config path")
@@ -272,23 +277,34 @@ func (f *ConfigFile) whenEnvironments() []string {
 	return envs
 }
 
-// decodeRoot decodes the file's root mapping into plain Go values.
-func (f *ConfigFile) decodeRoot() (map[string]any, error) {
+// configEntry is a single top-level key/value pair of a config file, decoded
+// into plain Go values while keeping its document position.
+type configEntry struct {
+	key   string
+	value any
+}
+
+// orderedEntries decodes the file's root mapping into key/value pairs in
+// document order, so when@<env> overrides merge after the base keys that
+// precede them in the file.
+func (f *ConfigFile) orderedEntries() ([]configEntry, error) {
 	root := f.rootMapping()
 	if root == nil {
-		return map[string]any{}, nil
+		return nil, nil
 	}
 
-	var out map[string]any
-	if err := root.Decode(&out); err != nil {
-		return nil, err
+	entries := make([]configEntry, 0, len(root.Content)/2)
+
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		var value any
+		if err := root.Content[i+1].Decode(&value); err != nil {
+			return nil, err
+		}
+
+		entries = append(entries, configEntry{key: root.Content[i].Value, value: value})
 	}
 
-	if out == nil {
-		out = map[string]any{}
-	}
-
-	return out, nil
+	return entries, nil
 }
 
 // rootMapping returns the top-level mapping node of the file, or nil when the

--- a/internal/symfony/config_packages_env.go
+++ b/internal/symfony/config_packages_env.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/shopware/shopware-cli/internal/envfile"
 )
 
 // Symfony only treats a value as an env reference when the whole string is a
@@ -18,10 +20,11 @@ const (
 )
 
 // ResolvedConfig is like Config but additionally resolves %env(...)% references
-// in string values against the project's .env files (.env.dist < .env <
-// .env.local, following Symfony precedence). Values that are not env
-// expressions are returned unchanged, and an unresolved variable becomes an
-// empty string unless a default processor supplies a fallback.
+// in string values against the project's .env files for that environment
+// (.env.dist < .env < .env.local < .env.<env> < .env.<env>.local, following
+// Symfony precedence). Values that are not env expressions are returned
+// unchanged, and an unresolved variable becomes an empty string unless a
+// default processor supplies a fallback.
 //
 // Only string scalars are inspected; a successful cast processor (bool, int,
 // json, ...) can change the Go type of the resulting value.
@@ -31,7 +34,7 @@ func (pc *ProjectConfig) ResolvedConfig(environment string) (map[string]any, err
 		return nil, err
 	}
 
-	resolver, err := pc.newEnvResolver(cfg)
+	resolver, err := pc.newEnvResolver(environment, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -44,12 +47,17 @@ func (pc *ProjectConfig) ResolvedConfig(environment string) (map[string]any, err
 // GetResolvedConfigValue is GetConfigValue with %env(...)% resolution applied to
 // the returned value (and recursively to nested values).
 func (pc *ProjectConfig) GetResolvedConfigValue(environment, path string) (any, bool, error) {
-	value, ok, err := pc.GetConfigValue(environment, path)
+	cfg, err := pc.Config(environment)
+	if err != nil {
+		return nil, false, err
+	}
+
+	value, ok, err := getConfigValue(cfg, path)
 	if err != nil || !ok {
 		return nil, ok, err
 	}
 
-	resolver, err := pc.newEnvResolver(nil)
+	resolver, err := pc.newEnvResolver(environment, cfg)
 	if err != nil {
 		return nil, false, err
 	}
@@ -61,7 +69,7 @@ func (pc *ProjectConfig) GetResolvedConfigValue(environment, path string) (any, 
 // it is a %env(...)% expression it is resolved against the project's .env files,
 // otherwise it is returned unchanged.
 func (pc *ProjectConfig) ResolveEnvExpression(value any) (any, error) {
-	resolver, err := pc.newEnvResolver(nil)
+	resolver, err := pc.newEnvResolver("", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -78,12 +86,12 @@ type envResolver struct {
 	paramDefaults map[string]string
 }
 
-// newEnvResolver builds a resolver, loading the project's env files once. When
-// cfg is provided, env(VAR) defaults declared under any package's parameters
-// block are collected so they can act as fallbacks, mirroring Symfony's
-// behaviour.
-func (pc *ProjectConfig) newEnvResolver(cfg map[string]any) (*envResolver, error) {
-	env, err := pc.Env()
+// newEnvResolver builds a resolver, loading the project's env files for the
+// given environment once. When cfg is provided, env(VAR) defaults declared in
+// the top-level parameters block are collected so they can act as fallbacks,
+// mirroring Symfony's behaviour.
+func (pc *ProjectConfig) newEnvResolver(environment string, cfg map[string]any) (*envResolver, error) {
+	env, err := envfile.ReadAllForEnvironment(pc.projectRoot, environment)
 	if err != nil {
 		return nil, err
 	}
@@ -337,33 +345,25 @@ func parseEnvCSV(value string) ([]any, error) {
 }
 
 // collectEnvParamDefaults scans every package's parameters block for env(VAR)
-// keys, which declare default values for environment variables.
+// keys, which declare default values for environment variables. Symfony
+// declares them in the top-level parameters: section, which the merged config
+// exposes as the "parameters" key.
 func collectEnvParamDefaults(cfg map[string]any) map[string]string {
 	defaults := map[string]string{}
-	if cfg == nil {
+
+	params, ok := asStringMap(cfg["parameters"])
+	if !ok {
 		return defaults
 	}
 
-	for _, pkg := range cfg {
-		pkgMap, ok := asStringMap(pkg)
+	for key, value := range params {
+		varName, ok := envParamKey(key)
 		if !ok {
 			continue
 		}
 
-		params, ok := asStringMap(pkgMap["parameters"])
-		if !ok {
-			continue
-		}
-
-		for key, value := range params {
-			varName, ok := envParamKey(key)
-			if !ok {
-				continue
-			}
-
-			if str, ok := value.(string); ok {
-				defaults[varName] = str
-			}
+		if str, ok := value.(string); ok {
+			defaults[varName] = str
 		}
 	}
 

--- a/internal/symfony/config_packages_env_test.go
+++ b/internal/symfony/config_packages_env_test.go
@@ -64,6 +64,38 @@ func TestGetResolvedConfigValue(t *testing.T) {
 	assert.Equal(t, 3, value)
 }
 
+func TestGetResolvedConfigValueAgreesWithResolvedConfig(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	// timeout resolves via a top-level env(REQUEST_TIMEOUT) default; the
+	// single-value API must apply the same default as ResolvedConfig.
+	cfg, err := pc.ResolvedConfig("dev")
+	require.NoError(t, err)
+	want := cfg["env_demo"].(map[string]any)["timeout"]
+
+	got, ok, err := pc.GetResolvedConfigValue("dev", "env_demo.timeout")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, want, got)
+	assert.Equal(t, 45, got)
+}
+
+func TestResolvedConfigLayersEnvironmentEnvFile(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	// .env.prod overrides REDIS_URL; dev keeps the base .env value.
+	prod, err := pc.ResolvedConfig("prod")
+	require.NoError(t, err)
+	prodCache := prod["framework"].(map[string]any)["cache"].(map[string]any)
+	assert.Equal(t, "redis://prod-host:6379", prodCache["default_redis_provider"])
+
+	devValue, err := pc.ResolveEnvExpression("%env(REDIS_URL)%")
+	require.NoError(t, err)
+	assert.Equal(t, "redis://localhost:6379", devValue)
+}
+
 func TestResolveEnvExpression(t *testing.T) {
 	pc, err := NewProjectConfig(fixtureProject)
 	require.NoError(t, err)

--- a/internal/symfony/config_packages_test.go
+++ b/internal/symfony/config_packages_test.go
@@ -96,6 +96,21 @@ func TestConfigWhenBlockOnlyAppliesToItsEnvironment(t *testing.T) {
 	assert.NotContains(t, devCfg["framework"].(map[string]any), "test")
 }
 
+func TestConfigWhenBlockOverridesBaseKeyInSameFile(t *testing.T) {
+	pc, err := NewProjectConfig(fixtureProject)
+	require.NoError(t, err)
+
+	// logging.yaml declares `logging: { level: info }` followed by a when@dev
+	// override. The override must win for dev regardless of map iteration order.
+	dev, err := pc.Config("dev")
+	require.NoError(t, err)
+	prod, err := pc.Config("prod")
+	require.NoError(t, err)
+
+	assert.Equal(t, "debug", dev["logging"].(map[string]any)["level"])
+	assert.Equal(t, "info", prod["logging"].(map[string]any)["level"])
+}
+
 func TestGetConfigValue(t *testing.T) {
 	pc, err := NewProjectConfig(fixtureProject)
 	require.NoError(t, err)
@@ -212,4 +227,29 @@ func TestSetConfigValueCreatesBaseFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, []any{"deprecation"}, value)
+}
+
+func TestSetConfigValueWritesIntoMatchingWhenBlock(t *testing.T) {
+	root := copyFixture(t)
+
+	pc, err := NewProjectConfig(root)
+	require.NoError(t, err)
+
+	// framework.test exists only inside framework.yaml's when@test block, so the
+	// write must update that block rather than leaking a root-level key.
+	require.NoError(t, pc.SetConfigValue("test", "framework.test", false))
+
+	content, err := os.ReadFile(filepath.Join(root, "config", "packages", "framework.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "when@test:")
+
+	testValue, ok, err := pc.GetConfigValue("test", "framework.test")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, false, testValue)
+
+	// dev never had framework.test and must not gain it from this write.
+	_, ok, err = pc.GetConfigValue("dev", "framework.test")
+	require.NoError(t, err)
+	assert.False(t, ok)
 }

--- a/internal/symfony/config_packages_test.go
+++ b/internal/symfony/config_packages_test.go
@@ -253,3 +253,26 @@ func TestSetConfigValueWritesIntoMatchingWhenBlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
+
+func TestSetConfigValueWritesIntoWhenBlockOnEqualDepth(t *testing.T) {
+	root := copyFixture(t)
+
+	pc, err := NewProjectConfig(root)
+	require.NoError(t, err)
+
+	// mailer.dsn exists at both the root and the when@prod block of mailer.yaml.
+	// For prod the when@prod value is effective, so the write must update it
+	// there rather than the root (which would stay shadowed).
+	require.NoError(t, pc.SetConfigValue("prod", "mailer.dsn", "smtp://updated"))
+
+	prodValue, ok, err := pc.GetConfigValue("prod", "mailer.dsn")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "smtp://updated", prodValue)
+
+	// dev resolves to the untouched root value.
+	devValue, ok, err := pc.GetConfigValue("dev", "mailer.dsn")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "smtp://localhost", devValue)
+}

--- a/internal/symfony/config_packages_write.go
+++ b/internal/symfony/config_packages_write.go
@@ -39,43 +39,62 @@ func (pc *ProjectConfig) SetConfigValue(environment string, path string, value a
 		return err
 	}
 
-	if err := target.save(); err != nil {
+	if err := target.file.save(); err != nil {
 		return err
 	}
 
 	return pc.load()
 }
 
-// resolveWriteTarget picks the ConfigFile that SetConfigValue should edit for
-// the given environment and path, creating an in-memory file handle when no
-// existing file is suitable.
-func (pc *ProjectConfig) resolveWriteTarget(environment string, segments []string) *ConfigFile {
-	if existing := pc.fileDefiningPath(environment, segments); existing != nil {
-		return existing
+// writeTarget is the resolved destination of a SetConfigValue: the file to edit
+// and, when non-empty, the when@<whenEnv> block inside it the value belongs to.
+type writeTarget struct {
+	file    *ConfigFile
+	whenEnv string
+}
+
+// set writes value into the target, descending into the when@<env> block first
+// when the target points at one.
+func (t writeTarget) set(segments []string, value any) error {
+	if t.whenEnv == "" {
+		return t.file.set(segments, value)
+	}
+
+	return t.file.setUnderWhen(t.whenEnv, segments, value)
+}
+
+// resolveWriteTarget picks where SetConfigValue should write for the given
+// environment and path, creating an in-memory file handle when no existing file
+// is suitable.
+func (pc *ProjectConfig) resolveWriteTarget(environment string, segments []string) writeTarget {
+	if target, ok := pc.fileDefiningPath(environment, segments); ok {
+		return target
 	}
 
 	pkg := segments[0]
 
 	if environment != BaseEnvironment && pc.hasEnvironmentDir(environment) {
-		return &ConfigFile{
+		return writeTarget{file: &ConfigFile{
 			Path:        filepath.Join(pc.packagesDir, environment, pkg+".yaml"),
 			Environment: environment,
-		}
+		}}
 	}
 
-	return &ConfigFile{
+	return writeTarget{file: &ConfigFile{
 		Path:        filepath.Join(pc.packagesDir, pkg+".yaml"),
 		Environment: BaseEnvironment,
-	}
+	}}
 }
 
 // fileDefiningPath returns the highest-precedence loaded file (for the base or
 // the given environment) that already defines the deepest possible prefix of
 // segments. It prefers the most specific match so an override lands next to the
-// value it overrides.
-func (pc *ProjectConfig) fileDefiningPath(environment string, segments []string) *ConfigFile {
-	var best *ConfigFile
-	bestDepth := -1
+// value it overrides, and reports whether that match lives in the file's
+// when@<env> block so the write stays scoped to the right environment.
+func (pc *ProjectConfig) fileDefiningPath(environment string, segments []string) (writeTarget, bool) {
+	var best writeTarget
+	found := false
+	bestDepth := 0
 
 	// Iterate in load order so that, for an equal match depth, the
 	// highest-precedence (latest) file wins.
@@ -84,14 +103,20 @@ func (pc *ProjectConfig) fileDefiningPath(environment string, segments []string)
 			continue
 		}
 
-		depth := file.definedDepth(environment, segments)
-		if depth >= bestDepth && depth > 0 {
-			best = file
+		depth, underWhen := file.definedDepth(environment, segments)
+		if depth > 0 && depth >= bestDepth {
+			whenEnv := ""
+			if underWhen {
+				whenEnv = environment
+			}
+
+			best = writeTarget{file: file, whenEnv: whenEnv}
 			bestDepth = depth
+			found = true
 		}
 	}
 
-	return best
+	return best, found
 }
 
 // hasEnvironmentDir reports whether config/packages/<environment>/ exists.
@@ -102,28 +127,70 @@ func (pc *ProjectConfig) hasEnvironmentDir(environment string) bool {
 }
 
 // definedDepth returns how many leading segments of path are present in the
-// file, considering both the file root and its when@<environment> block.
-// A return value of 0 means the file does not contribute to this path.
-func (f *ConfigFile) definedDepth(environment string, segments []string) int {
+// file and whether that deepest match lives in the file's when@<environment>
+// block rather than at the document root. A depth of 0 means the file does not
+// contribute to this path.
+func (f *ConfigFile) definedDepth(environment string, segments []string) (int, bool) {
 	root := f.rootMapping()
 	if root == nil {
-		return 0
+		return 0, false
 	}
 
 	depth := mappingDepth(root, segments)
+	underWhen := false
 
 	if when := mappingChild(root, whenPrefix+environment); when != nil {
 		if d := mappingDepth(when, segments); d > depth {
 			depth = d
+			underWhen = true
 		}
 	}
 
-	return depth
+	return depth, underWhen
 }
 
 // set writes value at the dotted path inside the file, creating intermediate
 // mappings as needed. The document and its comments are preserved.
 func (f *ConfigFile) set(segments []string, value any) error {
+	root, err := f.rootNode()
+	if err != nil {
+		return err
+	}
+
+	valueNode, err := encodeValue(value)
+	if err != nil {
+		return err
+	}
+
+	return setInMapping(root, segments, valueNode)
+}
+
+// setUnderWhen writes value at the dotted path inside the file's when@<env>
+// block, creating the block when it does not exist yet, so the value stays
+// scoped to that environment.
+func (f *ConfigFile) setUnderWhen(env string, segments []string, value any) error {
+	root, err := f.rootNode()
+	if err != nil {
+		return err
+	}
+
+	when := mappingChild(root, whenPrefix+env)
+	if when == nil {
+		when = newMapping()
+		mapPut(root, whenPrefix+env, when)
+	}
+
+	valueNode, err := encodeValue(value)
+	if err != nil {
+		return err
+	}
+
+	return setInMapping(when, segments, valueNode)
+}
+
+// rootNode returns the document's root mapping, creating an empty document and
+// mapping when the file is new or empty.
+func (f *ConfigFile) rootNode() (*yaml.Node, error) {
 	if f.doc == nil {
 		f.doc = &yaml.Node{
 			Kind:    yaml.DocumentNode,
@@ -137,15 +204,10 @@ func (f *ConfigFile) set(segments []string, value any) error {
 
 	root := f.doc.Content[0]
 	if root.Kind != yaml.MappingNode {
-		return fmt.Errorf("%s: root node is not a mapping", f.Path)
+		return nil, fmt.Errorf("%s: root node is not a mapping", f.Path)
 	}
 
-	valueNode, err := encodeValue(value)
-	if err != nil {
-		return err
-	}
-
-	return setInMapping(root, segments, valueNode)
+	return root, nil
 }
 
 // save serialises the document back to disk, creating parent directories when

--- a/internal/symfony/config_packages_write.go
+++ b/internal/symfony/config_packages_write.go
@@ -140,7 +140,11 @@ func (f *ConfigFile) definedDepth(environment string, segments []string) (int, b
 	underWhen := false
 
 	if when := mappingChild(root, whenPrefix+environment); when != nil {
-		if d := mappingDepth(when, segments); d > depth {
+		// The when@<env> block has higher precedence than the root for this
+		// environment, so an equal-depth match there is the effective value and
+		// is where the write must land — otherwise the existing when@ value
+		// would keep shadowing a root-level write.
+		if d := mappingDepth(when, segments); d > 0 && d >= depth {
 			depth = d
 			underWhen = true
 		}

--- a/internal/symfony/testdata/config-packages/project/.env.prod
+++ b/internal/symfony/testdata/config-packages/project/.env.prod
@@ -1,0 +1,1 @@
+REDIS_URL=redis://prod-host:6379

--- a/internal/symfony/testdata/config-packages/project/config/packages/env_demo.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/env_demo.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(REQUEST_TIMEOUT): '45'
+
 env_demo:
     secret: '%env(APP_SECRET)%'
     debug: '%env(bool:APP_DEBUG)%'
@@ -6,5 +9,3 @@ env_demo:
     flags: '%env(json:FEATURE_FLAGS)%'
     timeout: '%env(int:default:30:REQUEST_TIMEOUT)%'
     literal: not-an-env-var
-    parameters:
-        env(REQUEST_TIMEOUT): '45'

--- a/internal/symfony/testdata/config-packages/project/config/packages/logging.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/logging.yaml
@@ -1,0 +1,6 @@
+logging:
+    level: info
+
+when@dev:
+    logging:
+        level: debug

--- a/internal/symfony/testdata/config-packages/project/config/packages/mailer.yaml
+++ b/internal/symfony/testdata/config-packages/project/config/packages/mailer.yaml
@@ -1,0 +1,6 @@
+mailer:
+    dsn: smtp://localhost
+
+when@prod:
+    mailer:
+        dsn: smtp://prod-relay


### PR DESCRIPTION
Follow-up to #1142, which was merged before the Codex review feedback was addressed. Fixes all 5 P2 findings from that review.

## Fixes

1. **Preserve YAML order when merging when blocks** (`config_packages.go`)
   `Config()` iterated a decoded `map[string]any`, so a `when@<env>` override and its matching base key in the same file merged in arbitrary order — `Config("dev")` could be nondeterministic. Now decodes the root mapping in document order via the `yaml.Node` so overrides that follow their base key always win.

2. **Keep writes inside matching `when` blocks** (`config_packages_write.go`)
   When the existing value lived only in a file's `when@<env>` block, `SetConfigValue` wrote the path at the document root — the `when@` value still shadowed it and the root key leaked into other environments. The write target now records whether the match is under a `when@<env>` block and writes into that block (creating it if needed).

3. **Load environment-specific env files** (`envfile.go`, `config_packages_env.go`)
   Resolution only read `.env.dist/.env/.env.local`. Added `envfile.ReadAllForEnvironment`, and `ResolvedConfig(env)`/`GetResolvedConfigValue(env, …)` now layer `.env.<env>` and `.env.<env>.local` on top (Symfony precedence). `Env()` (no environment) is unchanged.

4. **Build the single-value resolver with config defaults** (`config_packages_env.go`)
   `GetResolvedConfigValue` built the resolver with `nil` config, so it skipped `env(VAR)` defaults that `ResolvedConfig` applies — the two APIs disagreed. It now resolves the merged config once and reuses it for both the lookup and the resolver.

5. **Read env defaults from top-level parameters** (`config_packages_env.go`)
   `collectEnvParamDefaults` searched for a `parameters` map nested inside each package, but Symfony declares env defaults in the top-level `parameters:` section. Now reads from the merged `parameters` key.

## Tests

Adds a regression test per fix (when-override ordering, write-into-when-block scoping, env-specific file layering, resolver-API agreement, top-level param defaults) plus fixture files (`logging.yaml`, `.env.prod`, top-level `parameters` in `env_demo.yaml`). `go test ./...`, `go vet`, `golangci-lint`, and `gofmt` all clean; suite passes under `-shuffle=on`.