### PR TITLE
Replace Wolfi base image with official php-cli-alpine

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,65 +1,63 @@
-FROM ghcr.io/shyim/wolfi-php/base:latest
 ARG PHP_VERSION=8.3
+ARG NODE_VERSION=22
+
+FROM node:${NODE_VERSION}-alpine AS node
+
+FROM php:${PHP_VERSION}-cli-alpine
+
+ARG NODE_VERSION
 
 LABEL org.opencontainers.image.source=https://github.com/shopware/shopware-cli
+
 COPY --from=composer/composer:2-bin /composer /usr/bin/composer
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/bin/install-php-extensions
+COPY --from=oven/bun:alpine /usr/local/bin/bun /usr/local/bin/bun
+COPY --link --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 RUN <<EOF
     set -euxo pipefail
 
     apk add --no-cache \
         git \
-        nodejs-22 \
-        npm \
-        bun \
+        libstdc++ \
         gettext \
         openssh-client \
-        openssh-keyscan \
-        openssh-keygen \
-        openssh-keysign \
         rsync \
         patch \
         jq \
-        bash \
-        php-${PHP_VERSION} \
-        php-${PHP_VERSION}-fileinfo \
-        php-${PHP_VERSION}-openssl \
-        php-${PHP_VERSION}-ctype \
-        php-${PHP_VERSION}-curl \
-        php-${PHP_VERSION}-xml \
-        php-${PHP_VERSION}-dom \
-        php-${PHP_VERSION}-phar \
-        php-${PHP_VERSION}-simplexml \
-        php-${PHP_VERSION}-xmlreader \
-        php-${PHP_VERSION}-xmlwriter \
-        php-${PHP_VERSION}-bcmath \
-        php-${PHP_VERSION}-iconv \
-        php-${PHP_VERSION}-gd \
-        php-${PHP_VERSION}-intl \
-        php-${PHP_VERSION}-pdo \
-        php-${PHP_VERSION}-pdo_mysql \
-        php-${PHP_VERSION}-mysqlnd \
-        php-${PHP_VERSION}-mbstring \
-        php-${PHP_VERSION}-pcntl \
-        php-${PHP_VERSION}-sockets \
-        php-${PHP_VERSION}-bz2 \
-        php-${PHP_VERSION}-gmp \
-        php-${PHP_VERSION}-soap \
-        php-${PHP_VERSION}-zip \
-        php-${PHP_VERSION}-sodium \
-        php-${PHP_VERSION}-redis \
-        php-${PHP_VERSION}-amqp
+        bash
 
-    if [ "$(printf '%s\n' "8.5" "${PHP_VERSION}" | sort -V | head -n1)" != "8.5" ]; then
-        apk add --no-cache php-${PHP_VERSION}-opcache
+    ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+    ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+    ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
+
+    node --version
+    npm --version
+
+    INSTALLED_NODE_VERSION=$(node -e "console.log(process.versions.node.substring(0,2))")
+    if [ "$INSTALLED_NODE_VERSION" != "$NODE_VERSION" ]; then
+        echo "ERROR: Installed Node.js version ($INSTALLED_NODE_VERSION) does not match expected version ($NODE_VERSION)"
+        exit 1
     fi
 
-    apk add --no-cache gettext
-    cp /usr/bin/envsubst /envsubst
-    apk del gettext
-    mv /envsubst /usr/bin/envsubst
+    install-php-extensions \
+        bcmath \
+        gd \
+        intl \
+        pdo_mysql \
+        pcntl \
+        sockets \
+        bz2 \
+        gmp \
+        soap \
+        zip \
+        sodium \
+        redis \
+        amqp \
+        opcache
 
-    echo 'memory_limit=512M' > /etc/php/conf.d/docker.ini
+    echo 'memory_limit=512M' > "$PHP_INI_DIR/conf.d/docker.ini"
 EOF
 
 COPY internal/verifier/js /opt/verifier/js


### PR DESCRIPTION
## What

Rebuild `Dockerfile.base` on the official `php:${PHP_VERSION}-cli-alpine` image instead of the Wolfi image (`ghcr.io/shyim/wolfi-php/base`).

## Changes

- **Base image**: `ghcr.io/shyim/wolfi-php/base:latest` → `php:${PHP_VERSION}-cli-alpine`.
- **PHP extensions**: installed via [`mlocati/docker-php-extension-installer`](https://github.com/mlocati/docker-php-extension-installer) instead of Wolfi's `apk add php-${VERSION}-<ext>`. The php-cli image already bundles the common ones (fileinfo, openssl, ctype, curl, dom/xml/simplexml/xmlreader/xmlwriter, phar, iconv, pdo, mbstring, sodium); only the extras are added: `bcmath gd intl pdo_mysql pcntl sockets bz2 gmp soap zip sodium redis amqp opcache`. The old PHP 8.5 opcache special-case is no longer needed.
- **Node**: pinned by copying from `node:${NODE_VERSION}-alpine` (default `22`), matching the [shopware/docker](https://github.com/shopware/docker) approach, instead of Alpine's `nodejs` package. Requires `libstdc++` in the apk list since the copied binary links against it.
- **bun**: copied from `oven/bun:alpine` (not available in Alpine repos).
- **envsubst**: comes directly from the `gettext` package; dropped the old copy-out/`apk del` dance.

## Verified

- Builds for PHP 8.3 and 8.5 (multi-stage, BuildKit).
- Runtime check: `node v22`, `npm`, `npx`, `corepack`, `bun`, all PHP extensions loaded, and the verifier tools (php-cs-fixer etc.) install correctly.