### PR TITLE
Optimize token storage with offset-based windows instead of strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ devenv.local.nix
 /.gopath
 .soulforge
 .claude/scheduled_tasks.lock
+
+# Go test binaries
+*.test

--- a/internal/html/ast.go
+++ b/internal/html/ast.go
@@ -2,7 +2,10 @@
 // method (defined in format.go) that renders it back to its textual form.
 package html
 
-// Attribute represents an HTML attribute with key and value.
+// Attribute represents an HTML attribute with key and value. Like every
+// other node type it is stored in a NodeList as a pointer (*Attribute); its
+// Dump method therefore has a pointer receiver so a bare Attribute value does
+// not satisfy Node.
 type Attribute struct {
 	Key   string
 	Value string

--- a/internal/html/ast.go
+++ b/internal/html/ast.go
@@ -2,10 +2,9 @@
 // method (defined in format.go) that renders it back to its textual form.
 package html
 
-// Attribute represents an HTML attribute with key and value. Like every
-// other node type it is stored in a NodeList as a pointer (*Attribute); its
-// Dump method therefore has a pointer receiver so a bare Attribute value does
-// not satisfy Node.
+// Attribute represents an HTML attribute with key and value. Like the other
+// node types it lives in a NodeList as a pointer (*Attribute); its Dump method
+// has a pointer receiver, so a bare Attribute value does not satisfy Node.
 type Attribute struct {
 	Key   string
 	Value string

--- a/internal/html/format.go
+++ b/internal/html/format.go
@@ -15,7 +15,7 @@ var fromTextToEntities = []AttributeEntityEncodingFromTo{
 	{From: "\"", To: "&quot;"},
 }
 
-func (a Attribute) Dump(indent int) string {
+func (a *Attribute) Dump(indent int) string {
 	var builder strings.Builder
 	indentStr := indentConfig.GetIndent()
 

--- a/internal/html/lexer.go
+++ b/internal/html/lexer.go
@@ -435,7 +435,8 @@ func (l *lexer) lexTwigStmt() error {
 		l.pt.advance(1)
 	}
 	identEnd := l.pt.cur.Offset
-	if identEnd > identStart || identEnd > wsStart {
+	// Emit when there is an identifier or any leading whitespace to preserve.
+	if identEnd > wsStart {
 		l.emit(mkTok(tokTwigIdent, wsPos, identStart, identEnd-identStart, wsStart, identEnd-wsStart))
 	}
 

--- a/internal/html/lexer.go
+++ b/internal/html/lexer.go
@@ -2,7 +2,33 @@ package html
 
 import (
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
+
+// trimSpaceWindow returns the [offset,len) window of strings.TrimSpace applied
+// to src[off:off+n], matching its Unicode whitespace semantics exactly so a
+// token can carry the trimmed body as offsets rather than a computed string.
+func trimSpaceWindow(src string, off, n int) (int, int) {
+	sub := src[off : off+n]
+	start := 0
+	for start < len(sub) {
+		r, size := utf8.DecodeRuneInString(sub[start:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		start += size
+	}
+	end := len(sub)
+	for end > start {
+		r, size := utf8.DecodeLastRuneInString(sub[:end])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		end -= size
+	}
+	return off + start, end - start
+}
 
 // lexer scans the source into a stream of tokens. It interleaves HTML and Twig
 // recognition. Twig statement/expression/comment bodies are returned as a single
@@ -37,6 +63,26 @@ func (l *lexer) lex() ([]token, error) {
 
 func (l *lexer) emit(t token) {
 	l.tokens = append(l.tokens, t)
+}
+
+// mkTok builds a token from source [offset,len) windows for Lit and Raw. All
+// lexed literals are substrings of l.src, so callers pass offsets instead of
+// string slices — see the token type doc for why this stays pointer-free.
+func mkTok(typ tokenType, pos Pos, litOff, litLen, rawOff, rawLen int) token {
+	return token{
+		Type:   typ,
+		litOff: int32(litOff),
+		litLen: int32(litLen),
+		rawOff: int32(rawOff),
+		rawLen: int32(rawLen),
+		Pos:    pos,
+	}
+}
+
+// span builds a token whose Lit and Raw are the same [off,off+n) window, the
+// common case for text, tag names, and delimiters.
+func span(typ tokenType, pos Pos, off, n int) token {
+	return mkTok(typ, pos, off, n, off, n)
 }
 
 // remaining returns the unconsumed source.
@@ -114,14 +160,13 @@ func (l *lexer) lexContent() error {
 
 	if idx == -1 {
 		// Rest is all text.
-		l.emit(token{Type: tokText, Lit: rem, Raw: rem, Pos: startPos})
+		l.emit(span(tokText, startPos, startPos.Offset, len(rem)))
 		l.pt.advance(len(rem))
 		return nil
 	}
 
 	if idx > 0 {
-		text := rem[:idx]
-		l.emit(token{Type: tokText, Lit: text, Raw: text, Pos: startPos})
+		l.emit(span(tokText, startPos, startPos.Offset, idx))
 		l.pt.advance(idx)
 	}
 
@@ -177,8 +222,9 @@ func (l *lexer) lexHTMLComment() error {
 	}
 	end += 4 // adjust back to an index into rem
 	raw := rem[:end+3]
-	body := strings.TrimSpace(rem[4:end])
-	l.emit(token{Type: tokHTMLComment, Lit: body, Raw: raw, Pos: startPos})
+	rawOff := startPos.Offset
+	litOff, litLen := trimSpaceWindow(l.src, rawOff+4, end-4)
+	l.emit(mkTok(tokHTMLComment, startPos, litOff, litLen, rawOff, len(raw)))
 	l.pt.advance(len(raw))
 	return nil
 }
@@ -191,16 +237,15 @@ func (l *lexer) lexHTMLDoctype() error {
 	if end == -1 {
 		return &ParseError{Pos: startPos, Msg: "unterminated <!DOCTYPE>", Source: l.src}
 	}
-	raw := rem[:end+1]
-	l.emit(token{Type: tokHTMLDoctype, Lit: raw, Raw: raw, Pos: startPos})
-	l.pt.advance(len(raw))
+	l.emit(span(tokHTMLDoctype, startPos, startPos.Offset, end+1))
+	l.pt.advance(end + 1)
 	return nil
 }
 
 // lexHTMLOpenTag emits tokens for `<name attr="val" {% if x %}...{% endif %} ...>` or `... />`.
 func (l *lexer) lexHTMLOpenTag() error {
 	startPos := l.pt.pos()
-	l.emit(token{Type: tokHTMLOpenStart, Lit: "<", Raw: "<", Pos: startPos})
+	l.emit(span(tokHTMLOpenStart, startPos, startPos.Offset, 1))
 	l.pt.advance(1) // skip '<'
 
 	if err := l.lexHTMLTagName(); err != nil {
@@ -212,7 +257,7 @@ func (l *lexer) lexHTMLOpenTag() error {
 // lexHTMLCloseTag emits tokens for `</name>`.
 func (l *lexer) lexHTMLCloseTag() error {
 	startPos := l.pt.pos()
-	l.emit(token{Type: tokHTMLCloseStart, Lit: "</", Raw: "</", Pos: startPos})
+	l.emit(span(tokHTMLCloseStart, startPos, startPos.Offset, 2))
 	l.pt.advance(2)
 	l.skipASCIIWhitespace()
 	if err := l.lexHTMLTagName(); err != nil {
@@ -223,7 +268,7 @@ func (l *lexer) lexHTMLCloseTag() error {
 		return &ParseError{Pos: l.pt.pos(), Msg: "expected '>' for closing tag", Source: l.src}
 	}
 	endPos := l.pt.pos()
-	l.emit(token{Type: tokHTMLTagEnd, Lit: ">", Raw: ">", Pos: endPos})
+	l.emit(span(tokHTMLTagEnd, endPos, endPos.Offset, 1))
 	l.pt.advance(1)
 	return nil
 }
@@ -238,8 +283,7 @@ func (l *lexer) lexHTMLTagName() error {
 	for end < len(l.src) && isHTMLNameRune(l.src[end]) {
 		end++
 	}
-	name := l.src[start:end]
-	l.emit(token{Type: tokHTMLTagName, Lit: name, Raw: name, Pos: startPos})
+	l.emit(span(tokHTMLTagName, startPos, start, end-start))
 	l.pt.advance(end - start)
 	return nil
 }
@@ -261,13 +305,13 @@ func (l *lexer) lexHTMLAttrsAndClose() error {
 		}
 		if c == '>' {
 			pos := l.pt.pos()
-			l.emit(token{Type: tokHTMLTagEnd, Lit: ">", Raw: ">", Pos: pos})
+			l.emit(span(tokHTMLTagEnd, pos, pos.Offset, 1))
 			l.pt.advance(1)
 			return nil
 		}
 		if c == '/' && l.peekByte(1) == '>' {
 			pos := l.pt.pos()
-			l.emit(token{Type: tokHTMLSelfClose, Lit: "/>", Raw: "/>", Pos: pos})
+			l.emit(span(tokHTMLSelfClose, pos, pos.Offset, 2))
 			l.pt.advance(2)
 			return nil
 		}
@@ -314,20 +358,20 @@ func (l *lexer) lexHTMLAttr() error {
 		}
 		l.pt.advance(1)
 	}
-	name := l.src[start:l.pt.cur.Offset]
-	if name == "" {
+	nameEnd := l.pt.cur.Offset
+	if nameEnd == start {
 		// Unexpected character. Skip one byte to make progress and let the
 		// parser raise an error later.
 		l.pt.advance(1)
 		return nil
 	}
-	l.emit(token{Type: tokHTMLAttrName, Lit: name, Raw: name, Pos: startPos})
+	l.emit(span(tokHTMLAttrName, startPos, start, nameEnd-start))
 	l.skipASCIIWhitespace()
 	if l.peekByte(0) != '=' {
 		return nil
 	}
 	eqPos := l.pt.pos()
-	l.emit(token{Type: tokHTMLAttrEq, Lit: "=", Raw: "=", Pos: eqPos})
+	l.emit(span(tokHTMLAttrEq, eqPos, eqPos.Offset, 1))
 	l.pt.advance(1)
 	l.skipASCIIWhitespace()
 	return l.lexHTMLAttrValue()
@@ -344,12 +388,13 @@ func (l *lexer) lexHTMLAttrValue() error {
 		for l.pt.cur.Offset < len(l.src) && l.src[l.pt.cur.Offset] != quote {
 			l.pt.advance(1)
 		}
-		val := l.src[start:l.pt.cur.Offset]
+		valEnd := l.pt.cur.Offset
 		if l.pt.cur.Offset < len(l.src) && l.src[l.pt.cur.Offset] == quote {
 			l.pt.advance(1)
 		}
-		raw := l.src[rawStart:l.pt.cur.Offset]
-		l.emit(token{Type: tokHTMLAttrValue, Lit: val, Raw: raw, Pos: startPos, QuoteChar: quote})
+		t := mkTok(tokHTMLAttrValue, startPos, start, valEnd-start, rawStart, l.pt.cur.Offset-rawStart)
+		t.QuoteChar = quote
+		l.emit(t)
 		return nil
 	}
 	// Bareword.
@@ -361,8 +406,7 @@ func (l *lexer) lexHTMLAttrValue() error {
 		}
 		l.pt.advance(1)
 	}
-	val := l.src[start:l.pt.cur.Offset]
-	l.emit(token{Type: tokHTMLAttrValue, Lit: val, Raw: val, Pos: startPos, QuoteChar: 0})
+	l.emit(span(tokHTMLAttrValue, startPos, start, l.pt.cur.Offset-start))
 	return nil
 }
 
@@ -375,8 +419,9 @@ func (l *lexer) lexTwigStmt() error {
 		trimLeft = true
 		openLen = 3
 	}
-	openRaw := l.src[l.pt.cur.Offset : l.pt.cur.Offset+openLen]
-	l.emit(token{Type: tokTwigStmtOpen, Lit: openRaw, Raw: openRaw, Pos: openPos, TrimLeft: trimLeft})
+	openTok := span(tokTwigStmtOpen, openPos, l.pt.cur.Offset, openLen)
+	openTok.TrimLeft = trimLeft
+	l.emit(openTok)
 	l.pt.advance(openLen)
 
 	// Identifier (tag name) — capture any leading whitespace in Raw.
@@ -389,10 +434,9 @@ func (l *lexer) lexTwigStmt() error {
 	for l.pt.cur.Offset < len(l.src) && isTwigIdentRune(l.src[l.pt.cur.Offset]) {
 		l.pt.advance(1)
 	}
-	ident := l.src[identStart:l.pt.cur.Offset]
-	identRaw := l.src[wsStart:l.pt.cur.Offset]
-	if ident != "" || identRaw != "" {
-		l.emit(token{Type: tokTwigIdent, Lit: ident, Raw: identRaw, Pos: wsPos})
+	identEnd := l.pt.cur.Offset
+	if identEnd > identStart || identEnd > wsStart {
+		l.emit(mkTok(tokTwigIdent, wsPos, identStart, identEnd-identStart, wsStart, identEnd-wsStart))
 	}
 
 	bodyStart := l.pt.cur.Offset
@@ -401,9 +445,8 @@ func (l *lexer) lexTwigStmt() error {
 	if closeOffset == -1 {
 		return &ParseError{Pos: openPos, Msg: "unterminated {% ... %}", Source: l.src}
 	}
-	rawBody := l.src[bodyStart:closeOffset]
-	body := strings.TrimSpace(rawBody)
-	l.emit(token{Type: tokTwigRawExpr, Lit: body, Raw: rawBody, Pos: bodyPos})
+	litOff, litLen := trimSpaceWindow(l.src, bodyStart, closeOffset-bodyStart)
+	l.emit(mkTok(tokTwigRawExpr, bodyPos, litOff, litLen, bodyStart, closeOffset-bodyStart))
 	l.pt.advance(closeOffset - l.pt.cur.Offset)
 
 	closeLen := 2
@@ -411,8 +454,9 @@ func (l *lexer) lexTwigStmt() error {
 		closeLen = 3
 	}
 	closePos := l.pt.pos()
-	closeRaw := l.src[l.pt.cur.Offset : l.pt.cur.Offset+closeLen]
-	l.emit(token{Type: tokTwigStmtClose, Lit: closeRaw, Raw: closeRaw, Pos: closePos, TrimRight: trimRight})
+	closeTok := span(tokTwigStmtClose, closePos, l.pt.cur.Offset, closeLen)
+	closeTok.TrimRight = trimRight
+	l.emit(closeTok)
 	l.pt.advance(closeLen)
 	return nil
 }
@@ -426,7 +470,9 @@ func (l *lexer) lexTwigExpr() error {
 		trimLeft = true
 		openLen = 3
 	}
-	l.emit(token{Type: tokTwigExprOpen, Lit: l.src[l.pt.cur.Offset : l.pt.cur.Offset+openLen], Raw: l.src[l.pt.cur.Offset : l.pt.cur.Offset+openLen], Pos: openPos, TrimLeft: trimLeft})
+	openTok := span(tokTwigExprOpen, openPos, l.pt.cur.Offset, openLen)
+	openTok.TrimLeft = trimLeft
+	l.emit(openTok)
 	l.pt.advance(openLen)
 
 	bodyStart := l.pt.cur.Offset
@@ -435,15 +481,19 @@ func (l *lexer) lexTwigExpr() error {
 	if closeOffset == -1 {
 		return &ParseError{Pos: openPos, Msg: "unterminated {{ ... }}", Source: l.src}
 	}
-	rawBody := l.src[bodyStart:closeOffset]
-	body := rawBody
+	litEnd := closeOffset
 	if trimRight {
-		// trimRight strip: scanToTwigClose returns offset pointing at the '-' of '-}}'.
-		// Body should keep its leading/trailing spaces around the inner expression
-		// to mirror the original (the parser later strips when emitting).
-		body = strings.TrimSuffix(strings.TrimRight(body, " \t"), "-")
+		// scanToTwigClose returns the offset of the '-' in '-}}'. Mirror
+		// strings.TrimSuffix(strings.TrimRight(body, " \t"), "-"): drop trailing
+		// spaces/tabs, then one trailing '-'. Leading spaces are preserved.
+		for litEnd > bodyStart && (l.src[litEnd-1] == ' ' || l.src[litEnd-1] == '\t') {
+			litEnd--
+		}
+		if litEnd > bodyStart && l.src[litEnd-1] == '-' {
+			litEnd--
+		}
 	}
-	l.emit(token{Type: tokTwigRawExpr, Lit: body, Raw: rawBody, Pos: bodyPos})
+	l.emit(mkTok(tokTwigRawExpr, bodyPos, bodyStart, litEnd-bodyStart, bodyStart, closeOffset-bodyStart))
 	l.pt.advance(closeOffset - l.pt.cur.Offset)
 
 	closeLen := 2
@@ -451,7 +501,9 @@ func (l *lexer) lexTwigExpr() error {
 		closeLen = 3
 	}
 	closePos := l.pt.pos()
-	l.emit(token{Type: tokTwigExprClose, Lit: l.src[l.pt.cur.Offset : l.pt.cur.Offset+closeLen], Raw: l.src[l.pt.cur.Offset : l.pt.cur.Offset+closeLen], Pos: closePos, TrimRight: trimRight})
+	closeTok := span(tokTwigExprClose, closePos, l.pt.cur.Offset, closeLen)
+	closeTok.TrimRight = trimRight
+	l.emit(closeTok)
 	l.pt.advance(closeLen)
 	return nil
 }
@@ -465,7 +517,9 @@ func (l *lexer) lexTwigComment() error {
 		trimLeft = true
 		openLen = 3
 	}
-	l.emit(token{Type: tokTwigCommentOpen, Lit: l.src[l.pt.cur.Offset : l.pt.cur.Offset+openLen], Raw: l.src[l.pt.cur.Offset : l.pt.cur.Offset+openLen], Pos: openPos, TrimLeft: trimLeft})
+	openTok := span(tokTwigCommentOpen, openPos, l.pt.cur.Offset, openLen)
+	openTok.TrimLeft = trimLeft
+	l.emit(openTok)
 	l.pt.advance(openLen)
 
 	bodyStart := l.pt.cur.Offset
@@ -480,8 +534,7 @@ func (l *lexer) lexTwigComment() error {
 	if trimRight {
 		bodyEnd--
 	}
-	body := l.src[bodyStart:bodyEnd]
-	l.emit(token{Type: tokTwigCommentText, Lit: body, Raw: body, Pos: bodyPos})
+	l.emit(span(tokTwigCommentText, bodyPos, bodyStart, bodyEnd-bodyStart))
 	l.pt.advance(end)
 	// Cursor is at '#}'. The closer emission below backs up one byte when
 	// trimRight so the '-' becomes part of the close token's Raw.
@@ -495,7 +548,9 @@ func (l *lexer) lexTwigComment() error {
 		closeLen = 3
 		closePos.Offset--
 	}
-	l.emit(token{Type: tokTwigCommentClose, Lit: l.src[closeStart : closeStart+closeLen], Raw: l.src[closeStart : closeStart+closeLen], Pos: closePos, TrimRight: trimRight})
+	closeTok := span(tokTwigCommentClose, closePos, closeStart, closeLen)
+	closeTok.TrimRight = trimRight
+	l.emit(closeTok)
 	// Advance past '#}' (we're already at '#}').
 	l.pt.advance(2)
 	return nil

--- a/internal/html/lexer.go
+++ b/internal/html/lexer.go
@@ -21,7 +21,7 @@ func newLexer(src string) *lexer {
 	// src/5 (slightly generous) means the slice almost never has to grow, so we
 	// pay one right-sized allocation instead of one allocation plus a doubling
 	// copy. The +16 covers tiny inputs and the trailing EOF.
-	return &lexer{src: src, pt: posTracker{src: src, cur: Pos{Offset: 0, Line: 1}}, tokens: make([]token, 0, len(src)/6+16)}
+	return &lexer{src: src, pt: posTracker{src: src, cur: Pos{Offset: 0, Line: 1}}, tokens: make([]token, 0, len(src)/5+16)}
 }
 
 // lex scans the entire source and returns the token stream.

--- a/internal/html/lexer_test.go
+++ b/internal/html/lexer_test.go
@@ -44,9 +44,9 @@ func TestLexerStringLiteralAware(t *testing.T) {
 	assert.Equal(t, 5, len(toks))
 	assert.Equal(t, tokTwigStmtOpen, toks[0].Type)
 	assert.Equal(t, tokTwigIdent, toks[1].Type)
-	assert.Equal(t, "set", toks[1].Lit)
+	assert.Equal(t, "set", toks[1].Lit(src))
 	assert.Equal(t, tokTwigRawExpr, toks[2].Type)
-	assert.Contains(t, toks[2].Lit, `"contains %}"`)
+	assert.Contains(t, toks[2].Lit(src), `"contains %}"`)
 	assert.Equal(t, tokTwigStmtClose, toks[3].Type)
 }
 
@@ -65,5 +65,5 @@ func TestLexerWordBoundary(t *testing.T) {
 	toks, err := lex.lex()
 	assert.NoError(t, err)
 	assert.Equal(t, tokTwigIdent, toks[1].Type)
-	assert.Equal(t, "iff", toks[1].Lit, "identifier scan must respect word boundaries")
+	assert.Equal(t, "iff", toks[1].Lit(src), "identifier scan must respect word boundaries")
 }

--- a/internal/html/parser.go
+++ b/internal/html/parser.go
@@ -115,17 +115,14 @@ type parser struct {
 	// scratch is a single reused stack onto which parseNodesUntil builds each
 	// node list. Recursive calls share the backing array via a mark (the length
 	// at entry); collect() copies the [mark:] window into the node arena and
-	// rewinds. This replaces one append-grown slice per list — profiling's
-	// single largest remaining allocator — with a handful of grows for the whole
-	// parse.
+	// rewinds, so sibling lists reuse the same buffer.
 	scratch []Node
 
 	// nodeArena packs every collected child list end to end. collect() appends
 	// its scratch window here and returns a capped subslice, so the tree's many
 	// small children/body NodeLists share a few large backing arrays instead of
-	// one make() each (the largest allocator once attributes were slab-backed).
-	// A grown arena leaves earlier subslices pointing at the old backing array,
-	// which stays live and valid — same trade as the node slabs.
+	// one make() each. A grown arena leaves earlier subslices pointing at the old
+	// backing array, which stays live and valid — same as the node slabs.
 	nodeArena []Node
 }
 
@@ -243,12 +240,9 @@ func (p *parser) parseDocument() (NodeList, error) {
 		p.rawSlab = make([]RawNode, n)
 		p.elemSlab = make([]ElementNode, n)
 	}
-	// Storing attributes as *Attribute out of a slab turns what was one
-	// interface-boxing malloc per attribute — profiling's largest remaining
-	// allocator — into an amortized slab bump. The divisor is the measured
-	// token-per-attribute ratio on real templates (~1 attribute per 32
-	// tokens); slightly under-sizing keeps the initial slab from being zeroed
-	// memory the GC must scan, and newAttrNode grows it on demand if short.
+	// Attributes come out of a slab as *Attribute, replacing one
+	// interface-boxing alloc per attribute with a slab bump (~1 attribute per
+	// 32 tokens on real templates).
 	if n := len(toks)/32 + 8; n > 0 {
 		p.attrSlab = make([]Attribute, n)
 	}

--- a/internal/html/parser.go
+++ b/internal/html/parser.go
@@ -114,11 +114,19 @@ type parser struct {
 
 	// scratch is a single reused stack onto which parseNodesUntil builds each
 	// node list. Recursive calls share the backing array via a mark (the length
-	// at entry); collect() copies the [mark:] window into an exact-size NodeList
-	// and rewinds. This replaces one append-grown slice per list — profiling's
+	// at entry); collect() copies the [mark:] window into the node arena and
+	// rewinds. This replaces one append-grown slice per list — profiling's
 	// single largest remaining allocator — with a handful of grows for the whole
 	// parse.
 	scratch []Node
+
+	// nodeArena packs every collected child list end to end. collect() appends
+	// its scratch window here and returns a capped subslice, so the tree's many
+	// small children/body NodeLists share a few large backing arrays instead of
+	// one make() each (the largest allocator once attributes were slab-backed).
+	// A grown arena leaves earlier subslices pointing at the old backing array,
+	// which stays live and valid — same trade as the node slabs.
+	nodeArena []Node
 }
 
 func (p *parser) newRawNode() *RawNode {
@@ -177,18 +185,21 @@ func (p *parser) newAttrNode() *Attribute {
 	return a
 }
 
-// collect copies the scratch entries pushed since mark into an exact-size
-// NodeList and rewinds the scratch stack to mark for sibling reuse.
+// collect packs the scratch entries pushed since mark into the shared node
+// arena and rewinds the scratch stack to mark for sibling reuse. The returned
+// NodeList is a capped subslice of the arena, so a consumer that appends to it
+// (e.g. a linter growing node.Children) reallocates rather than overwriting the
+// next list packed behind it.
 func (p *parser) collect(mark int) NodeList {
 	n := len(p.scratch) - mark
 	if n == 0 {
 		p.scratch = p.scratch[:mark]
 		return nil
 	}
-	out := make(NodeList, n)
-	copy(out, p.scratch[mark:])
+	start := len(p.nodeArena)
+	p.nodeArena = append(p.nodeArena, p.scratch[mark:]...)
 	p.scratch = p.scratch[:mark]
-	return out
+	return p.nodeArena[start : start+n : start+n]
 }
 
 func (p *parser) peek(i int) token {
@@ -247,6 +258,9 @@ func (p *parser) parseDocument() (NodeList, error) {
 	// scratch only needs to hold one node list's worth at a time (collect()
 	// rewinds between siblings), so it stays small.
 	p.scratch = make([]Node, 0, len(toks)/16+16)
+	// The arena holds every collected node for the whole parse; size it from the
+	// combined raw+element+expression node estimate so it rarely has to grow.
+	p.nodeArena = make([]Node, 0, len(toks)/6+16)
 	nodes, _, err := p.parseNodesUntil(nodeContextTopLevel, "", nil)
 	return nodes, err
 }

--- a/internal/html/parser.go
+++ b/internal/html/parser.go
@@ -109,6 +109,8 @@ type parser struct {
 	elemN    int
 	exprSlab []TemplateExpressionNode
 	exprN    int
+	attrSlab []Attribute
+	attrN    int
 
 	// scratch is a single reused stack onto which parseNodesUntil builds each
 	// node list. Recursive calls share the backing array via a mark (the length
@@ -159,6 +161,20 @@ func (p *parser) newExprNode() *TemplateExpressionNode {
 	e := &p.exprSlab[p.exprN]
 	p.exprN++
 	return e
+}
+
+func (p *parser) newAttrNode() *Attribute {
+	if p.attrN >= len(p.attrSlab) {
+		n := len(p.attrSlab) * 2
+		if n < 16 {
+			n = 16
+		}
+		p.attrSlab = make([]Attribute, n)
+		p.attrN = 0
+	}
+	a := &p.attrSlab[p.attrN]
+	p.attrN++
+	return a
 }
 
 // collect copies the scratch entries pushed since mark into an exact-size
@@ -215,6 +231,15 @@ func (p *parser) parseDocument() (NodeList, error) {
 	if n := len(toks)/15 + 8; n > 0 {
 		p.rawSlab = make([]RawNode, n)
 		p.elemSlab = make([]ElementNode, n)
+	}
+	// Storing attributes as *Attribute out of a slab turns what was one
+	// interface-boxing malloc per attribute — profiling's largest remaining
+	// allocator — into an amortized slab bump. The divisor is the measured
+	// token-per-attribute ratio on real templates (~1 attribute per 32
+	// tokens); slightly under-sizing keeps the initial slab from being zeroed
+	// memory the GC must scan, and newAttrNode grows it on demand if short.
+	if n := len(toks)/32 + 8; n > 0 {
+		p.attrSlab = make([]Attribute, n)
 	}
 	if n := len(toks)/48 + 4; n > 0 {
 		p.exprSlab = make([]TemplateExpressionNode, n)
@@ -589,7 +614,9 @@ func (p *parser) parseElement(parentTagSpec *TagSpec) (*ElementNode, error) {
 		switch tk.Type {
 		case tokHTMLAttrName:
 			p.advance()
-			attr := Attribute{Key: tk.Lit}
+			attr := p.newAttrNode()
+			attr.Key = tk.Lit
+			attr.Value = ""
 			if p.peek(0).Type == tokHTMLAttrEq {
 				p.advance() // =
 				if p.peek(0).Type == tokHTMLAttrValue {

--- a/internal/html/parser.go
+++ b/internal/html/parser.go
@@ -402,7 +402,7 @@ func (p *parser) parseNodesUntil(ctx nodeContext, closeTag string, parentTagSpec
 			identTok := p.peek(1)
 			name := ""
 			if identTok.Type == tokTwigIdent {
-				name = identTok.Lit
+				name = identTok.Lit(p.source)
 			}
 
 			// Stop on parent's terminator/followers without consuming.
@@ -459,7 +459,7 @@ func (p *parser) parseNodesUntil(ctx nodeContext, closeTag string, parentTagSpec
 			p.advance() // {#
 			body := ""
 			if p.peek(0).Type == tokTwigCommentText {
-				body = p.advance().Lit
+				body = p.advance().Lit(p.source)
 			}
 			if p.peek(0).Type == tokTwigCommentClose {
 				trim.Right = p.peek(0).TrimRight
@@ -471,7 +471,7 @@ func (p *parser) parseNodesUntil(ctx nodeContext, closeTag string, parentTagSpec
 		case tokHTMLComment:
 			p.flushRaw(ctx, &rawBuf, rawStartPos)
 			p.scratch = append(p.scratch, &CommentNode{
-				Text: tk.Lit,
+				Text: tk.Lit(p.source),
 				Line: tk.Pos.Line,
 			})
 			p.advance()
@@ -493,7 +493,7 @@ func (p *parser) parseNodesUntil(ctx nodeContext, closeTag string, parentTagSpec
 			if ctx == nodeContextElementChildren {
 				// Peek the tag name.
 				nameTok := p.peek(1)
-				if nameTok.Type == tokHTMLTagName && nameTok.Lit == closeTag {
+				if nameTok.Type == tokHTMLTagName && nameTok.Lit(p.source) == closeTag {
 					p.flushRaw(ctx, &rawBuf, rawStartPos)
 					// Consume "</name>"
 					p.advance() // </
@@ -508,13 +508,13 @@ func (p *parser) parseNodesUntil(ctx nodeContext, closeTag string, parentTagSpec
 			if rawBuf.len() == 0 {
 				rawStartPos = tk.Pos
 			}
-			rawBuf.add(tk.Pos.Offset, len(tk.Raw))
+			rawBuf.add(tk.Pos.Offset, tk.RawLen())
 			p.advance()
 
 		case tokHTMLDoctype:
 			p.flushRaw(ctx, &rawBuf, rawStartPos)
 			dn := p.newRawNode()
-			dn.Text = tk.Raw
+			dn.Text = tk.Raw(p.source)
 			dn.Line = tk.Pos.Line
 			p.scratch = append(p.scratch, dn)
 			p.advance()
@@ -524,7 +524,7 @@ func (p *parser) parseNodesUntil(ctx nodeContext, closeTag string, parentTagSpec
 			if rawBuf.len() == 0 {
 				rawStartPos = tk.Pos
 			}
-			rawBuf.add(tk.Pos.Offset, len(tk.Lit))
+			rawBuf.add(tk.Pos.Offset, tk.LitLen())
 			p.advance()
 
 		default:
@@ -533,7 +533,7 @@ func (p *parser) parseNodesUntil(ctx nodeContext, closeTag string, parentTagSpec
 			if rawBuf.len() == 0 {
 				rawStartPos = tk.Pos
 			}
-			rawBuf.add(tk.Pos.Offset, len(tk.Raw))
+			rawBuf.add(tk.Pos.Offset, tk.RawLen())
 			p.advance()
 		}
 	}
@@ -555,7 +555,7 @@ func (p *parser) appendRawTokens(buf *rawSpan, openTok token) {
 	case tokTwigCommentOpen:
 		wantClose = tokTwigCommentClose
 	default:
-		buf.add(openTok.Pos.Offset, len(openTok.Raw))
+		buf.add(openTok.Pos.Offset, openTok.RawLen())
 		p.advance()
 		return
 	}
@@ -564,7 +564,7 @@ func (p *parser) appendRawTokens(buf *rawSpan, openTok token) {
 		if tk.Type == tokEOF {
 			return
 		}
-		buf.add(tk.Pos.Offset, len(tk.Raw))
+		buf.add(tk.Pos.Offset, tk.RawLen())
 		p.advance()
 		if tk.Type == wantClose {
 			return
@@ -592,7 +592,7 @@ func (p *parser) parseTemplateExpression() (*TemplateExpressionNode, error) {
 	// trim flags on the open/close delimiters round-trip via Trim so a
 	// `{{- x -}}` formats back as `{{- x -}}` and not `{{ x }}`.
 	en := p.newExprNode()
-	en.Expression = bodyTok.Raw
+	en.Expression = bodyTok.Raw(p.source)
 	en.Trim = TwigTrim{Left: openTok.TrimLeft, Right: closeTok.TrimRight}
 	en.Line = openTok.Pos.Line
 	return en, nil
@@ -614,7 +614,7 @@ func (p *parser) parseElement(parentTagSpec *TagSpec) (*ElementNode, error) {
 		return nil, errAt(p.source, p.filename, nameTok.Pos, "expected HTML tag name")
 	}
 	node := p.newElementNode()
-	node.Tag = nameTok.Lit
+	node.Tag = nameTok.Lit(p.source)
 	node.Attributes = NodeList{}
 	node.Children = NodeList{}
 	node.Line = openTok.Pos.Line
@@ -629,12 +629,12 @@ func (p *parser) parseElement(parentTagSpec *TagSpec) (*ElementNode, error) {
 		case tokHTMLAttrName:
 			p.advance()
 			attr := p.newAttrNode()
-			attr.Key = tk.Lit
+			attr.Key = tk.Lit(p.source)
 			attr.Value = ""
 			if p.peek(0).Type == tokHTMLAttrEq {
 				p.advance() // =
 				if p.peek(0).Type == tokHTMLAttrValue {
-					attr.Value = p.advance().Lit
+					attr.Value = p.advance().Lit(p.source)
 				}
 			}
 			node.Attributes = append(node.Attributes, attr)
@@ -648,7 +648,7 @@ func (p *parser) parseElement(parentTagSpec *TagSpec) (*ElementNode, error) {
 			// `{% if x %}data-y{% endif %}` (when `if` is somehow missing)
 			// or future Twig statements we don't yet recognize.
 			identTok := p.peek(1)
-			if identTok.Type == tokTwigIdent && identTok.Lit == "if" {
+			if identTok.Type == tokTwigIdent && identTok.Lit(p.source) == "if" {
 				if spec := lookupTag("if"); spec != nil {
 					ifNode, err := spec.Parse(p, tk)
 					if err != nil {
@@ -683,7 +683,7 @@ func (p *parser) parseElement(parentTagSpec *TagSpec) (*ElementNode, error) {
 			p.advance()
 			body := ""
 			if p.peek(0).Type == tokTwigCommentText {
-				body = p.advance().Lit
+				body = p.advance().Lit(p.source)
 			}
 			if p.peek(0).Type == tokTwigCommentClose {
 				trim.Right = p.peek(0).TrimRight

--- a/internal/html/parser_test.go
+++ b/internal/html/parser_test.go
@@ -118,7 +118,7 @@ func TestChangeElement(t *testing.T) {
 		n.Tag = "mt-select"
 		var newAttributes NodeList
 		for _, attr := range n.Attributes {
-			if attribute, ok := attr.(Attribute); ok {
+			if attribute, ok := attr.(*Attribute); ok {
 				if attribute.Key == "@update:value" {
 					attribute.Key = "@update:modelValue"
 				}

--- a/internal/html/pos.go
+++ b/internal/html/pos.go
@@ -42,14 +42,10 @@ type posTracker struct {
 	cur Pos
 }
 
-// advance moves the position forward by n bytes, counting any newlines in the
-// skipped span to keep Line current (column is derived lazily from the offset
-// only when an error needs it).
-//
-// Most calls advance by 1–2 bytes (a delimiter, bracket, or single char), so
-// the common case is a tiny span. Calling strings.Count there is dominated by
-// its call + SIMD-dispatch overhead, so small spans are scanned inline and only
-// larger runs (raw text, expression/comment bodies) go through the SIMD path.
+// advance moves the position forward by n bytes, counting newlines in the
+// skipped span to keep Line current (column is derived lazily from the offset).
+// Most calls advance by 1–2 bytes, where strings.Count's call overhead exceeds
+// the scan, so small spans are counted inline and only large runs use it.
 func (t *posTracker) advance(n int) {
 	end := t.cur.Offset + n
 	if end > len(t.src) {

--- a/internal/html/pos.go
+++ b/internal/html/pos.go
@@ -42,19 +42,33 @@ type posTracker struct {
 	cur Pos
 }
 
-// advance moves the position forward by n bytes. It counts any newlines in the
-// skipped span in one SIMD-accelerated pass (strings.Count) instead of looping
-// byte by byte, and no longer tracks column — column is derived lazily from the
-// offset only when an error needs it.
+// advance moves the position forward by n bytes, counting any newlines in the
+// skipped span to keep Line current (column is derived lazily from the offset
+// only when an error needs it).
+//
+// Most calls advance by 1–2 bytes (a delimiter, bracket, or single char), so
+// the common case is a tiny span. Calling strings.Count there is dominated by
+// its call + SIMD-dispatch overhead, so small spans are scanned inline and only
+// larger runs (raw text, expression/comment bodies) go through the SIMD path.
 func (t *posTracker) advance(n int) {
 	end := t.cur.Offset + n
 	if end > len(t.src) {
 		end = len(t.src)
 	}
-	if end <= t.cur.Offset {
+	off := t.cur.Offset
+	if end <= off {
 		return
 	}
-	t.cur.Line += strings.Count(t.src[t.cur.Offset:end], "\n")
+	span := t.src[off:end]
+	if len(span) <= 16 {
+		for i := 0; i < len(span); i++ {
+			if span[i] == '\n' {
+				t.cur.Line++
+			}
+		}
+	} else {
+		t.cur.Line += strings.Count(span, "\n")
+	}
 	t.cur.Offset = end
 }
 

--- a/internal/html/tag_block.go
+++ b/internal/html/tag_block.go
@@ -19,7 +19,7 @@ func parseBlockTag(p *parser, openTok token) (Node, error) {
 	openTrim := TwigTrim{Left: openTok.TrimLeft}
 	p.advance() // {%
 	identTok := p.advance()
-	if identTok.Type != tokTwigIdent || identTok.Lit != "block" {
+	if identTok.Type != tokTwigIdent || identTok.Lit(p.source) != "block" {
 		return nil, errAt(p.source, p.filename, identTok.Pos, "expected 'block' identifier")
 	}
 	bodyTok := p.advance()
@@ -35,7 +35,7 @@ func parseBlockTag(p *parser, openTok token) (Node, error) {
 	// Block name is the first whitespace-delimited token of the body. Scan for
 	// it directly rather than via strings.Fields, which would allocate a slice
 	// for the whole body just to read fields[0].
-	name := strings.TrimSpace(bodyTok.Lit)
+	name := strings.TrimSpace(bodyTok.Lit(p.source))
 	if i := strings.IndexFunc(name, func(r rune) bool {
 		return r == ' ' || r == '\t' || r == '\n' || r == '\r'
 	}); i != -1 {
@@ -75,7 +75,7 @@ func (p *parser) consumeEndTag(name string) (TwigTrim, error) {
 	trim := TwigTrim{Left: openTok.TrimLeft}
 	p.advance()
 	identTok := p.advance()
-	if identTok.Type != tokTwigIdent || identTok.Lit != name {
+	if identTok.Type != tokTwigIdent || identTok.Lit(p.source) != name {
 		return TwigTrim{}, errAt(p.source, p.filename, identTok.Pos, "expected '%s'", name)
 	}
 	// Body is usually empty; skip.

--- a/internal/html/tag_generic.go
+++ b/internal/html/tag_generic.go
@@ -172,7 +172,7 @@ func makeBlockTagParser(name, endTag string, followers []string) TagParseFunc {
 		// generic block tags — `{% for %}` is the only built-in user.
 		if reason == stopIfTerminator && supportsElse {
 			nameTok := p.peek(1)
-			if nameTok.Type != tokTwigIdent || nameTok.Lit != "else" {
+			if nameTok.Type != tokTwigIdent || nameTok.Lit(p.source) != "else" {
 				return nil, errAt(p.source, p.filename, nameTok.Pos, "expected {%% else %%} inside {%% %s %%}", name)
 			}
 			_, t, err := p.consumeStmtHeader("else")

--- a/internal/html/tag_if.go
+++ b/internal/html/tag_if.go
@@ -41,7 +41,7 @@ func parseIfTag(p *parser, openTok token) (Node, error) {
 		if nameTok.Type != tokTwigIdent {
 			return nil, errAt(p.source, p.filename, nameTok.Pos, "expected if-follower identifier")
 		}
-		switch nameTok.Lit {
+		switch nameTok.Lit(p.source) {
 		case "elseif":
 			cond, trim, err := p.consumeStmtHeader("elseif")
 			if err != nil {
@@ -66,7 +66,7 @@ func parseIfTag(p *parser, openTok token) (Node, error) {
 			elseChildren = body
 			reason = r
 		default:
-			return nil, errAt(p.source, p.filename, nameTok.Pos, "unexpected if-follower %q", nameTok.Lit)
+			return nil, errAt(p.source, p.filename, nameTok.Pos, "unexpected if-follower %q", nameTok.Lit(p.source))
 		}
 	}
 
@@ -97,12 +97,12 @@ func (p *parser) consumeStmtHeader(name string) (string, TwigTrim, error) {
 	trim := TwigTrim{Left: openTok.TrimLeft}
 	p.advance()
 	identTok := p.advance()
-	if identTok.Type != tokTwigIdent || identTok.Lit != name {
+	if identTok.Type != tokTwigIdent || identTok.Lit(p.source) != name {
 		return "", TwigTrim{}, errAt(p.source, p.filename, identTok.Pos, "expected '%s'", name)
 	}
 	body := ""
 	if p.peek(0).Type == tokTwigRawExpr {
-		body = strings.TrimSpace(p.advance().Lit)
+		body = strings.TrimSpace(p.advance().Lit(p.source))
 	}
 	closeTok := p.peek(0)
 	if closeTok.Type != tokTwigStmtClose {

--- a/internal/html/tag_parent.go
+++ b/internal/html/tag_parent.go
@@ -21,7 +21,7 @@ func parseParentTag(p *parser, openTok token) (Node, error) {
 	trim := TwigTrim{Left: openTok.TrimLeft}
 	p.advance() // {%
 	identTok := p.advance()
-	if identTok.Type != tokTwigIdent || identTok.Lit != "parent" {
+	if identTok.Type != tokTwigIdent || identTok.Lit(p.source) != "parent" {
 		return nil, errAt(p.source, p.filename, identTok.Pos, "expected 'parent'")
 	}
 	// Body must be empty or exactly "()" (optionally surrounded by
@@ -29,7 +29,7 @@ func parseParentTag(p *parser, openTok token) (Node, error) {
 	// malformed tags.
 	if p.peek(0).Type == tokTwigRawExpr {
 		bodyTok := p.advance()
-		if body := strings.TrimSpace(bodyTok.Lit); body != "" && body != "()" {
+		if body := strings.TrimSpace(bodyTok.Lit(p.source)); body != "" && body != "()" {
 			return nil, errAt(p.source, p.filename, bodyTok.Pos, "unexpected argument to parent: %q", body)
 		}
 	}

--- a/internal/html/tag_verbatim.go
+++ b/internal/html/tag_verbatim.go
@@ -59,11 +59,11 @@ func parseVerbatimTag(p *parser, openTok token) (Node, error) {
 		}
 		if tk.Type == tokTwigStmtOpen {
 			identTok := p.peek(1)
-			if identTok.Type == tokTwigIdent && identTok.Lit == "endverbatim" {
+			if identTok.Type == tokTwigIdent && identTok.Lit(p.source) == "endverbatim" {
 				break
 			}
 		}
-		body.WriteString(tk.Raw)
+		body.WriteString(tk.Raw(p.source))
 		p.advance()
 	}
 	closeTrim, err := p.consumeEndTag("endverbatim")

--- a/internal/html/tokens.go
+++ b/internal/html/tokens.go
@@ -32,14 +32,12 @@ const (
 
 // token is the unit produced by the lexer.
 //
-// Lit and Raw are stored as [offset,len) windows into the source string rather
-// than as string headers: every lexed literal is a substring of the source
-// (even the whitespace-trimmed bodies, since strings.TrimSpace/TrimRight return
-// subslices), so offsets lose no information. This keeps token pointer-free,
-// which matters because the token stream is one large slice — a pointer-free
-// element type is never scanned by the GC and its appends carry no write
-// barriers, the two costs that dominated lexing once the buffer was right-sized.
-// Recover the strings with the Lit(src)/Raw(src) accessors.
+// Lit and Raw are stored as [offset,len) windows into the source rather than as
+// strings: every lexed literal is a substring of the source (trimmed bodies
+// included, since strings.TrimSpace/TrimRight return subslices), so no
+// information is lost. Keeping token pointer-free means the token slice is not
+// GC-scanned and appends need no write barriers. Use the Lit(src)/Raw(src)
+// accessors to recover the strings.
 type token struct {
 	Type   tokenType
 	litOff int32
@@ -61,7 +59,6 @@ func (t token) Lit(src string) string { return src[t.litOff : t.litOff+t.litLen]
 // Raw returns the verbatim source slice the token was scanned from.
 func (t token) Raw(src string) string { return src[t.rawOff : t.rawOff+t.rawLen] }
 
-// LitLen and RawLen return the byte lengths of Lit and Raw without needing the
-// source (the common case where a caller only advances a buffer by the width).
+// LitLen and RawLen return the byte lengths of Lit and Raw without the source.
 func (t token) LitLen() int { return int(t.litLen) }
 func (t token) RawLen() int { return int(t.rawLen) }

--- a/internal/html/tokens.go
+++ b/internal/html/tokens.go
@@ -31,16 +31,37 @@ const (
 )
 
 // token is the unit produced by the lexer.
+//
+// Lit and Raw are stored as [offset,len) windows into the source string rather
+// than as string headers: every lexed literal is a substring of the source
+// (even the whitespace-trimmed bodies, since strings.TrimSpace/TrimRight return
+// subslices), so offsets lose no information. This keeps token pointer-free,
+// which matters because the token stream is one large slice — a pointer-free
+// element type is never scanned by the GC and its appends carry no write
+// barriers, the two costs that dominated lexing once the buffer was right-sized.
+// Recover the strings with the Lit(src)/Raw(src) accessors.
 type token struct {
-	Type tokenType
-	// Lit is the literal text from source. For tokHTMLAttrValue and tokHTMLComment
-	// it carries the decoded/inner content; Raw covers the verbatim slice.
-	Lit string
-	Raw string
-	Pos Pos
+	Type   tokenType
+	litOff int32
+	litLen int32
+	rawOff int32
+	rawLen int32
+	Pos    Pos
 	// TrimLeft/TrimRight apply to twig delimiters: {%- / -%} / {{- / -}} / {#- / -#}
 	TrimLeft  bool
 	TrimRight bool
 	// QuoteChar is set for tokHTMLAttrValue ('"', '\'', or 0 for bareword).
 	QuoteChar byte
 }
+
+// Lit returns the literal text of the token. For tokHTMLAttrValue and
+// tokHTMLComment it is the decoded/inner content; Raw is the verbatim slice.
+func (t token) Lit(src string) string { return src[t.litOff : t.litOff+t.litLen] }
+
+// Raw returns the verbatim source slice the token was scanned from.
+func (t token) Raw(src string) string { return src[t.rawOff : t.rawOff+t.rawLen] }
+
+// LitLen and RawLen return the byte lengths of Lit and Raw without needing the
+// source (the common case where a caller only advances a buffer by the width).
+func (t token) LitLen() int { return int(t.litLen) }
+func (t token) RawLen() int { return int(t.rawLen) }

--- a/internal/verifier/twiglinter/admintwiglinter/fix_alert.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_alert.go
@@ -41,7 +41,7 @@ func (a AlertFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					if attr.Key == "variant" {
 						switch attr.Value {
 						case "success":

--- a/internal/verifier/twiglinter/admintwiglinter/fix_button.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_button.go
@@ -48,7 +48,7 @@ func (b ButtonFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case "variant":
 						lower := strings.ToLower(attr.Value)
@@ -73,7 +73,7 @@ func (b ButtonFixer) Fix(nodes []html.Node) error {
 					case "router-link":
 						// Replace with @click event.
 						val := attr.Value
-						newAttrs = append(newAttrs, html.Attribute{
+						newAttrs = append(newAttrs, &html.Attribute{
 							Key:   "@click",
 							Value: fmt.Sprintf("this.$router.push('%s')", val),
 						})
@@ -87,7 +87,7 @@ func (b ButtonFixer) Fix(nodes []html.Node) error {
 			}
 
 			if addGhost {
-				newAttrs = append(newAttrs, html.Attribute{
+				newAttrs = append(newAttrs, &html.Attribute{
 					Key: "ghost",
 				})
 			}

--- a/internal/verifier/twiglinter/admintwiglinter/fix_card.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_card.go
@@ -44,7 +44,7 @@ func (c CardFixer) Fix(nodes []html.Node) error {
 			// Process attributes: remove aiBadge and contentPadding.
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case "aiBadge", "contentPadding":
 						if attr.Key == "aiBadge" {
@@ -66,7 +66,7 @@ func (c CardFixer) Fix(nodes []html.Node) error {
 				aiBadgeSlot := &html.ElementNode{
 					Tag: "slot",
 					Attributes: html.NodeList{
-						html.Attribute{Key: "name", Value: "title"},
+						&html.Attribute{Key: "name", Value: "title"},
 					},
 					Children: html.NodeList{
 						&html.ElementNode{Tag: "sw-ai-copilot-badge"},

--- a/internal/verifier/twiglinter/admintwiglinter/fix_checkbox_field.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_checkbox_field.go
@@ -45,18 +45,18 @@ func (c CheckboxFieldFixer) Fix(nodes []html.Node) error {
 			// Process attribute conversions.
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ColonValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{Key: ":checked", Value: attr.Value})
+						newAttrs = append(newAttrs, &html.Attribute{Key: ":checked", Value: attr.Value})
 					case VModelAttr, VModelValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{Key: "v-model:checked", Value: attr.Value})
+						newAttrs = append(newAttrs, &html.Attribute{Key: "v-model:checked", Value: attr.Value})
 					case "id", "ghostValue", "padded":
 						// remove these attributes without replacement
 					case "partlyChecked":
-						newAttrs = append(newAttrs, html.Attribute{Key: "partial"})
+						newAttrs = append(newAttrs, &html.Attribute{Key: "partial"})
 					case UpdateValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{Key: "@update:checked", Value: attr.Value})
+						newAttrs = append(newAttrs, &html.Attribute{Key: "@update:checked", Value: attr.Value})
 					default:
 						newAttrs = append(newAttrs, attr)
 					}
@@ -74,7 +74,7 @@ func (c CheckboxFieldFixer) Fix(nodes []html.Node) error {
 				if elem, ok := child.(*html.ElementNode); ok && elem.Tag == "template" {
 					// Handle label slot.
 					for _, a := range elem.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == "#label" || attr.Key == "v-slot:label" {
 								var sb strings.Builder
 								for _, inner := range elem.Children {
@@ -95,7 +95,7 @@ func (c CheckboxFieldFixer) Fix(nodes []html.Node) error {
 			}
 			node.Children = remainingChildren
 			if labelText != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: labelText,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_colorpicker.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_colorpicker.go
@@ -43,7 +43,7 @@ func (c ColorpickerFixer) Fix(nodes []html.Node) error {
 			var newAttrs html.NodeList
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ColonValueAttr:
 						attr.Key = ":model-value"
@@ -70,7 +70,7 @@ func (c ColorpickerFixer) Fix(nodes []html.Node) error {
 				if elem, ok := child.(*html.ElementNode); ok {
 					if elem.Tag == TemplateTag {
 						for _, a := range elem.Attributes {
-							if attr, ok := a.(html.Attribute); ok {
+							if attr, ok := a.(*html.Attribute); ok {
 								if attr.Key == LabelSlotAttr {
 									var sb strings.Builder
 									for _, inner := range elem.Children {
@@ -85,7 +85,7 @@ func (c ColorpickerFixer) Fix(nodes []html.Node) error {
 			}
 			node.Children = html.NodeList{}
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_datepicker.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_datepicker.go
@@ -44,7 +44,7 @@ func (d DatepickerFixer) Fix(nodes []html.Node) error {
 			// Update attribute names.
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ColonValueAttr:
 						attr.Key = ":model-value"
@@ -72,7 +72,7 @@ func (d DatepickerFixer) Fix(nodes []html.Node) error {
 				if elem, ok := child.(*html.ElementNode); ok {
 					if elem.Tag == TemplateTag {
 						for _, a := range elem.Attributes {
-							if attr, ok := a.(html.Attribute); ok {
+							if attr, ok := a.(*html.Attribute); ok {
 								if attr.Key == LabelSlotAttr {
 									var sb strings.Builder
 									for _, inner := range elem.Children {
@@ -91,7 +91,7 @@ func (d DatepickerFixer) Fix(nodes []html.Node) error {
 
 			node.Children = remainingChildren
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_email_field.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_email_field.go
@@ -43,7 +43,7 @@ func (e EmailFieldFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ValueAttr:
 						attr.Key = "model-value"
@@ -76,7 +76,7 @@ func (e EmailFieldFixer) Fix(nodes []html.Node) error {
 			for _, child := range node.Children {
 				if elem, ok := child.(*html.ElementNode); ok && elem.Tag == TemplateTag {
 					for _, a := range elem.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == LabelSlotAttr {
 								var sb strings.Builder
 								for _, inner := range elem.Children {
@@ -92,7 +92,7 @@ func (e EmailFieldFixer) Fix(nodes []html.Node) error {
 			}
 			node.Children = nil
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_external_link.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_external_link.go
@@ -40,7 +40,7 @@ func (e ExternalLinkFixer) Fix(nodes []html.Node) error {
 			var newAttrs html.NodeList
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					if attr.Key == "icon" {
 						continue
 					}

--- a/internal/verifier/twiglinter/admintwiglinter/fix_icon.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_icon.go
@@ -44,18 +44,18 @@ func (i IconFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch strings.ToLower(attr.Key) {
 					case "small":
 						// Replace "small" with size="16px"
-						newAttrs = append(newAttrs, html.Attribute{
+						newAttrs = append(newAttrs, &html.Attribute{
 							Key:   "size",
 							Value: "16px",
 						})
 						hasSize = true
 					case "large":
 						// Replace "large" with size="32px"
-						newAttrs = append(newAttrs, html.Attribute{
+						newAttrs = append(newAttrs, &html.Attribute{
 							Key:   "size",
 							Value: "32px",
 						})
@@ -75,7 +75,7 @@ func (i IconFixer) Fix(nodes []html.Node) error {
 
 			// If no size related prop is set, add default size="24px"
 			if !hasSize {
-				newAttrs = append(newAttrs, html.Attribute{
+				newAttrs = append(newAttrs, &html.Attribute{
 					Key:   "size",
 					Value: "24px",
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_number_field.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_number_field.go
@@ -43,10 +43,10 @@ func (n NumberFieldFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ColonValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{
+						newAttrs = append(newAttrs, &html.Attribute{
 							Key:   ":model-value",
 							Value: attr.Value,
 						})
@@ -54,7 +54,7 @@ func (n NumberFieldFixer) Fix(nodes []html.Node) error {
 						attr.Key = VModelAttr
 						newAttrs = append(newAttrs, attr)
 					case "@update:value":
-						newAttrs = append(newAttrs, html.Attribute{
+						newAttrs = append(newAttrs, &html.Attribute{
 							Key:   "@change",
 							Value: attr.Value,
 						})
@@ -73,7 +73,7 @@ func (n NumberFieldFixer) Fix(nodes []html.Node) error {
 			for _, child := range node.Children {
 				if elem, ok := child.(*html.ElementNode); ok && elem.Tag == TemplateTag {
 					for _, a := range elem.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == LabelSlotAttr {
 								var sb strings.Builder
 								for _, inner := range elem.Children {
@@ -90,7 +90,7 @@ func (n NumberFieldFixer) Fix(nodes []html.Node) error {
 			}
 			node.Children = remainingChildren
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_passwordfield.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_passwordfield.go
@@ -44,7 +44,7 @@ func (p PasswordFieldFixer) Fix(nodes []html.Node) error {
 			var newAttrs html.NodeList
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case "value":
 						attr.Key = "model-value"
@@ -79,7 +79,7 @@ func (p PasswordFieldFixer) Fix(nodes []html.Node) error {
 			for _, child := range node.Children {
 				if elem, ok := child.(*html.ElementNode); ok && elem.Tag == "template" {
 					for _, a := range elem.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == "#label" {
 								var sb strings.Builder
 								for _, inner := range elem.Children {
@@ -104,13 +104,13 @@ func (p PasswordFieldFixer) Fix(nodes []html.Node) error {
 			// Remove original children after processing slots
 			node.Children = nil
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})
 			}
 			if hint != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "hint",
 					Value: hint,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_progress_bar.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_progress_bar.go
@@ -41,7 +41,7 @@ func (p ProgressBarFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ValueAttr:
 						attr.Key = ModelValueAttr

--- a/internal/verifier/twiglinter/admintwiglinter/fix_select_field.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_select_field.go
@@ -48,22 +48,22 @@ func (s SelectFieldFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ColonValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{Key: ":model-value", Value: attr.Value})
+						newAttrs = append(newAttrs, &html.Attribute{Key: ":model-value", Value: attr.Value})
 					case VModelValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{Key: "v-model", Value: attr.Value})
+						newAttrs = append(newAttrs, &html.Attribute{Key: "v-model", Value: attr.Value})
 					case ":aside":
 						// Remove aside prop.
 					case ":options":
 						// Convert options format: replace "name" with "label" and "id" with "value"
 						converted := strings.ReplaceAll(attr.Value, "name", "label")
 						converted = strings.ReplaceAll(converted, "id", "value")
-						newAttrs = append(newAttrs, html.Attribute{Key: ":options", Value: converted})
+						newAttrs = append(newAttrs, &html.Attribute{Key: ":options", Value: converted})
 						optionsSet = true
 					case UpdateValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{Key: UpdateModelValueAttr, Value: attr.Value})
+						newAttrs = append(newAttrs, &html.Attribute{Key: UpdateModelValueAttr, Value: attr.Value})
 					default:
 						newAttrs = append(newAttrs, attr)
 					}
@@ -86,7 +86,7 @@ func (s SelectFieldFixer) Fix(nodes []html.Node) error {
 					// Convert label slot to label prop.
 					if elem.Tag == TemplateTag {
 						for _, a := range elem.Attributes {
-							if attr, ok := a.(html.Attribute); ok {
+							if attr, ok := a.(*html.Attribute); ok {
 								if attr.Key == LabelSlotAttr || attr.Key == "v-slot:label" {
 									var sb strings.Builder
 									for _, inner := range elem.Children {
@@ -103,7 +103,7 @@ func (s SelectFieldFixer) Fix(nodes []html.Node) error {
 						opt := make(map[string]interface{})
 						// Get option value from attributes.
 						for _, a := range elem.Attributes {
-							if attr, ok := a.(html.Attribute); ok {
+							if attr, ok := a.(*html.Attribute); ok {
 								switch attr.Key {
 								case ColonValueAttr, VModelValueAttr:
 									expressionKey := fmt.Sprintf("%s:%d", expressionObjectPrefix, expressionObjectKey)
@@ -142,7 +142,7 @@ func (s SelectFieldFixer) Fix(nodes []html.Node) error {
 
 			// If label slot was set, add label attribute.
 			if labelText != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: labelText,
 				})
@@ -159,7 +159,7 @@ func (s SelectFieldFixer) Fix(nodes []html.Node) error {
 						json = strings.ReplaceAll(json, "\""+replacementKey+"\"", fmt.Sprintf("(%s)", expression))
 					}
 
-					node.Attributes = append(node.Attributes, html.Attribute{
+					node.Attributes = append(node.Attributes, &html.Attribute{
 						Key:   ":options",
 						Value: json,
 					})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_switch.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_switch.go
@@ -43,14 +43,14 @@ func (s SwitchFixer) Fix(nodes []html.Node) error {
 			// Process attribute conversions.
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case "noMarginTop":
-						newAttrs = append(newAttrs, html.Attribute{Key: "removeTopMargin"})
+						newAttrs = append(newAttrs, &html.Attribute{Key: "removeTopMargin"})
 					case SizeAttr, "id", "ghostValue", "padded", "partlyChecked":
 						// remove these attributes
 					case ValueAttr:
-						newAttrs = append(newAttrs, html.Attribute{Key: "checked", Value: attr.Value})
+						newAttrs = append(newAttrs, &html.Attribute{Key: "checked", Value: attr.Value})
 					case VModelValueAttr:
 						attr.Key = VModelAttr
 						newAttrs = append(newAttrs, attr)
@@ -71,7 +71,7 @@ func (s SwitchFixer) Fix(nodes []html.Node) error {
 				// Check if child is a slot element.
 				if elem, ok := child.(*html.ElementNode); ok && elem.Tag == TemplateTag {
 					for _, a := range elem.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == LabelSlotAttr {
 								var sb strings.Builder
 								for _, inner := range elem.Children {
@@ -93,7 +93,7 @@ func (s SwitchFixer) Fix(nodes []html.Node) error {
 			node.Children = remainingChildren
 			// If label slot found, add label attribute.
 			if labelText != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: labelText,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_text_field.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_text_field.go
@@ -43,7 +43,7 @@ func (t TextFieldFixer) Fix(nodes []html.Node) error {
 			// Process attributes conversion.
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ValueAttr:
 						attr.Key = ModelValueAttr
@@ -84,7 +84,7 @@ func (t TextFieldFixer) Fix(nodes []html.Node) error {
 			for _, child := range node.Children {
 				if elem, ok := child.(*html.ElementNode); ok && elem.Tag == TemplateTag {
 					for _, a := range elem.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == LabelSlotAttr {
 								var sb strings.Builder
 								for _, inner := range elem.Children {
@@ -101,7 +101,7 @@ func (t TextFieldFixer) Fix(nodes []html.Node) error {
 			}
 			node.Children = remainingChildren
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_textareafield.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_textareafield.go
@@ -43,7 +43,7 @@ func (t TextareaFieldFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ValueAttr:
 						attr.Key = ModelValueAttr
@@ -70,7 +70,7 @@ func (t TextareaFieldFixer) Fix(nodes []html.Node) error {
 			for _, child := range node.Children {
 				if element, ok := child.(*html.ElementNode); ok && element.Tag == TemplateTag {
 					for _, a := range element.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == LabelSlotAttr {
 								var sb strings.Builder
 								for _, inner := range element.Children {
@@ -89,7 +89,7 @@ func (t TextareaFieldFixer) Fix(nodes []html.Node) error {
 			node.Children = remainingChildren
 
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fix_url_field.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fix_url_field.go
@@ -43,7 +43,7 @@ func (u UrlFieldFixer) Fix(nodes []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case ValueAttr:
 						attr.Key = ModelValueAttr
@@ -70,7 +70,7 @@ func (u UrlFieldFixer) Fix(nodes []html.Node) error {
 			for _, child := range node.Children {
 				if elem, ok := child.(*html.ElementNode); ok && elem.Tag == TemplateTag {
 					for _, a := range elem.Attributes {
-						if attr, ok := a.(html.Attribute); ok {
+						if attr, ok := a.(*html.Attribute); ok {
 							if attr.Key == LabelSlotAttr {
 								var sb strings.Builder
 								for _, inner := range elem.Children {
@@ -92,7 +92,7 @@ func (u UrlFieldFixer) Fix(nodes []html.Node) error {
 			// Remove all children; label was processed, and hint slot is dropped.
 			node.Children = remainingChildren
 			if label != "" {
-				node.Attributes = append(node.Attributes, html.Attribute{
+				node.Attributes = append(node.Attributes, &html.Attribute{
 					Key:   "label",
 					Value: label,
 				})

--- a/internal/verifier/twiglinter/admintwiglinter/fixer_popover.go
+++ b/internal/verifier/twiglinter/admintwiglinter/fixer_popover.go
@@ -45,7 +45,7 @@ func (p PopoverFixer) Fix(node []html.Node) error {
 
 			for _, attrNode := range node.Attributes {
 				// Check if the attribute is an html.Attribute
-				if attr, ok := attrNode.(html.Attribute); ok {
+				if attr, ok := attrNode.(*html.Attribute); ok {
 					switch attr.Key {
 					case "v-if":
 						attr.Key = ":isOpened"
@@ -63,7 +63,7 @@ func (p PopoverFixer) Fix(node []html.Node) error {
 			}
 
 			if !hasVIf {
-				newAttrs = append(newAttrs, html.Attribute{
+				newAttrs = append(newAttrs, &html.Attribute{
 					Key:   ":isOpened",
 					Value: "true",
 				})

--- a/internal/verifier/twiglinter/storefronttwiglinter/image.go
+++ b/internal/verifier/twiglinter/storefronttwiglinter/image.go
@@ -23,7 +23,7 @@ func (i ImageAltCheck) Check(nodes []html.Node) []validation.CheckResult {
 		var altValue string
 
 		for _, attr := range node.Attributes {
-			attrElement, ok := attr.(html.Attribute)
+			attrElement, ok := attr.(*html.Attribute)
 			if !ok {
 				continue
 			}

--- a/internal/verifier/twiglinter/storefronttwiglinter/link.go
+++ b/internal/verifier/twiglinter/storefronttwiglinter/link.go
@@ -22,7 +22,7 @@ func (l LinkCheck) Check(nodes []html.Node) []validation.CheckResult {
 		var href, target, rel string
 
 		for _, attr := range node.Attributes {
-			attrElement, ok := attr.(html.Attribute)
+			attrElement, ok := attr.(*html.Attribute)
 			if !ok {
 				continue
 			}

--- a/internal/verifier/twiglinter/storefronttwiglinter/style.go
+++ b/internal/verifier/twiglinter/storefronttwiglinter/style.go
@@ -23,7 +23,7 @@ func (s StyleFixer) Check(nodes []html.Node) []validation.CheckResult {
 		}
 
 		for _, attr := range node.Attributes {
-			attrElement, ok := attr.(html.Attribute)
+			attrElement, ok := attr.(*html.Attribute)
 
 			if ok && attrElement.Key == "style" {
 				errors = append(errors, validation.CheckResult{


### PR DESCRIPTION
## Summary
Refactors the lexer's token representation to store literal and raw text as `[offset, length)` windows into the source string rather than as separate string allocations. This reduces memory overhead and GC pressure while maintaining the same functionality.

## Key Changes

### Token Storage Optimization
- **tokens.go**: Changed `token` struct from storing `Lit` and `Raw` as strings to storing them as `litOff`, `litLen`, `rawOff`, `rawLen` int32 fields
  - Added `Lit(src)` and `Raw(src)` accessor methods to recover strings from offsets
  - Added `LitLen()` and `RawLen()` helper methods
  - Tokens are now pointer-free, eliminating GC scanning and write barriers on token slice appends

### Lexer Refactoring
- **lexer.go**: 
  - Added `trimSpaceWindow()` function to compute trimmed text windows using Unicode semantics (matching `strings.TrimSpace` behavior) without allocating new strings
  - Added `mkTok()` helper to construct tokens from offset windows
  - Added `span()` helper for the common case where Lit and Raw are identical
  - Updated all token emission sites to use offset-based construction instead of string slicing
  - Adjusted token slice pre-allocation from `len(src)/6+16` to `len(src)/5+16` for better sizing

### Parser Updates
- **parser.go**:
  - Added `nodeArena` field to pack all collected child node lists end-to-end, replacing individual `make()` calls per list
  - Added `attrSlab` and `newAttrNode()` for attribute allocation pooling
  - Updated `collect()` to append scratch entries to the shared arena instead of allocating new slices
  - Pre-allocate arena and attribute slab based on token count estimates
  - Updated all token field accesses to use `Lit(p.source)` and `Raw(p.source)` accessors

### Position Tracking Optimization
- **pos.go**: Optimized `advance()` to count newlines inline for small spans (≤16 bytes) before falling back to `strings.Count()` for larger spans, reducing call overhead

### Type Changes
- **ast.go**: Changed `Attribute` to be stored as pointers in NodeLists (matching other node types)
- Updated all fixer and checker code to use `*Attribute` type assertions and pointer construction

### Test Updates
- **lexer_test.go**: Updated test assertions to call `Lit(src)` accessor instead of accessing string field directly

## Implementation Details
- All lexed literals are substrings of the source, so no information is lost by storing offsets
- The `trimSpaceWindow()` function precisely mirrors `strings.TrimSpace` semantics using Unicode character classification
- Token slices remain GC-efficient since tokens are now pointer-free (no write barriers needed)
- Node arena packing reduces allocations for typical templates with many small child lists
- Backward compatible: accessor methods provide the same string interface as before

https://claude.ai/code/session_014hFsBmAJdopn5FqsejcGJu