### PR TITLE
Restore bunx alias in base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -28,6 +28,8 @@ RUN <<EOF
         jq \
         bash
 
+    ln -s /usr/local/bin/bun /usr/local/bin/bunx
+
     ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
     ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack


### PR DESCRIPTION
## What

Follow-up to #1146. The Codex review on that PR flagged that copying only `/usr/local/bin/bun` from `oven/bun:alpine` drops the `bunx` command — upstream ships it as a `bunx -> bun` symlink. Hooks or CI jobs calling `bunx ...` would fail with `bunx: not found`.

## Fix

Recreate the `bunx -> bun` symlink in the base image, mirroring the upstream `oven/bun` layout (an 18-byte symlink, so no extra image weight).

## Verified

Built for PHP 8.3 and confirmed both commands resolve:

```
/usr/local/bin/bunx -> /usr/local/bin/bun
bun:  1.3.14
bunx: 1.3.14
```