### PR TITLE
ci: bump Go to 1.26 and fix lint issues it surfaces

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
           check-latest: true
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
           check-latest: true
 

--- a/cmd/project/project_image_proxy.go
+++ b/cmd/project/project_image_proxy.go
@@ -110,8 +110,8 @@ If a file is not found locally, it proxies the request to the upstream server.`,
 		// transparently decompresses upstream responses. This ensures the
 		// cache always stores identity-encoded (uncompressed) content, avoiding
 		// double-compression when serving cache hits through the gzip handler.
-		defaultDirector := proxy.Director
-		proxy.Director = func(req *http.Request) {
+		defaultDirector := proxy.Director          //nolint:staticcheck // ReverseProxy.Director deprecated in Go 1.26; migrate to Rewrite
+		proxy.Director = func(req *http.Request) { //nolint:staticcheck // ReverseProxy.Director deprecated in Go 1.26; migrate to Rewrite
 			defaultDirector(req)
 			req.Header.Del("Accept-Encoding")
 		}

--- a/cmd/project/project_image_proxy_test.go
+++ b/cmd/project/project_image_proxy_test.go
@@ -37,8 +37,8 @@ func TestImageProxySVG(t *testing.T) {
 
 		proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
 
-		defaultDirector := proxy.Director
-		proxy.Director = func(req *http.Request) {
+		defaultDirector := proxy.Director          //nolint:staticcheck // ReverseProxy.Director deprecated in Go 1.26; migrate to Rewrite
+		proxy.Director = func(req *http.Request) { //nolint:staticcheck // ReverseProxy.Director deprecated in Go 1.26; migrate to Rewrite
 			defaultDirector(req)
 			req.Header.Del("Accept-Encoding")
 		}

--- a/internal/devtui/tab_overview.go
+++ b/internal/devtui/tab_overview.go
@@ -763,7 +763,7 @@ func renderSecurityEnd(eol, now time.Time) string {
 		c = tui.ErrorColor
 	case securityEndWarning:
 		c = tui.WarnColor
-	default:
+	case securityEndOK:
 		c = tui.SuccessColor
 	}
 
@@ -779,10 +779,10 @@ func securityEndRemaining(eol, now time.Time) string {
 		return "expired"
 	}
 	days := int(remaining / (24 * time.Hour))
-	switch {
-	case days == 0:
+	switch days {
+	case 0:
 		return "expires today"
-	case days == 1:
+	case 1:
 		return "1 day left"
 	default:
 		return fmt.Sprintf("%d days left", days)


### PR DESCRIPTION
## Problem

`go.mod` was raised to `go 1.26.4` in commit d51b518, but the CI workflows still install Go 1.25 with `GOTOOLCHAIN=local`. As a result **every PR against `next` currently fails** `lint` and `run` (go test) at package loading:

```
go: go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
```

## Fix

**1. Bump `go-version` 1.25 → 1.26** in the four workflows that install Go (`lint`, `go_test`, `smoke-test`, `release`), so the toolchain satisfies `go.mod`.

**2. Fix the lint issues that surface once lint can actually run on Go 1.26** (these were masked while the lint step was broken):

- `httputil.ReverseProxy.Director` is deprecated as of Go 1.26 → `staticcheck SA1019` in `cmd/project/project_image_proxy.go` (+ test). Suppressed with a targeted `//nolint` and a note to migrate to `Rewrite`. The migration is a behavioral change to proxy request handling (Host-header semantics differ between `NewSingleHostReverseProxy`'s director and `SetURL`), so it's intentionally left as a separate, reviewed follow-up rather than done blind here.
- `internal/devtui/tab_overview.go`: give `securityEndOK` an explicit `case` (`exhaustive`) and convert the day-count `switch` to a tagged switch (`QF1002`). Both behavior-preserving.

No other application code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)