### PR TITLE
Add windows binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,11 +16,8 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     ignore:
       - goos: linux
-        goarch: '386'
-      - goos: windows
         goarch: '386'
 
 archives:
@@ -30,9 +27,6 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-    format_overrides:
-      - goos: windows
-        formats: [ zip ]
     files:
       - LICENSE
       - completions/*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,8 +16,11 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     ignore:
       - goos: linux
+        goarch: '386'
+      - goos: windows
         goarch: '386'
 
 archives:
@@ -27,6 +30,9 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [ zip ]
     files:
       - LICENSE
       - completions/*

--- a/cmd/project/project_worker.go
+++ b/cmd/project/project_worker.go
@@ -104,21 +104,7 @@ var projectWorkerCmd = &cobra.Command{
 					cmd.Env = append(os.Environ(), fmt.Sprintf("MESSENGER_CONSUMER_NAME=%s-%d", baseName, index))
 					cmd.WaitDelay = time.Second
 					cmd.Cancel = func() error {
-						if gracefulStopLimit > 0 {
-							if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
-								return err
-							}
-
-							now := time.Now()
-
-							for time.Since(now) < time.Second*time.Duration(gracefulStopLimit) {
-								if isProcessStopped(cmd.Process) {
-									return os.ErrProcessDone
-								}
-								time.Sleep(time.Millisecond * 250)
-							}
-						}
-						return cmd.Process.Kill()
+						return gracefulStop(cmd, gracefulStopLimit)
 					}
 
 					if err := cmd.Run(); err != nil {
@@ -156,8 +142,4 @@ func cancelOnTermination(ctx context.Context, cancel context.CancelFunc) {
 		logging.FromContext(ctx).Infof("received signal %v\n", sig.String())
 		cancel()
 	}()
-}
-
-func isProcessStopped(p *os.Process) bool {
-	return errors.Is(p.Signal(syscall.Signal(0)), os.ErrProcessDone)
 }

--- a/cmd/project/project_worker_unix.go
+++ b/cmd/project/project_worker_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package project
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// gracefulStop sends SIGTERM and waits up to gracefulStopLimit seconds for the process to exit before killing it. A limit of 0 kills immediately.
+func gracefulStop(cmd *exec.Cmd, gracefulStopLimit uint) error {
+	if gracefulStopLimit > 0 {
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			return err
+		}
+
+		deadline := time.Now().Add(time.Second * time.Duration(gracefulStopLimit))
+		for time.Now().Before(deadline) {
+			if isProcessStopped(cmd.Process) {
+				return os.ErrProcessDone
+			}
+			time.Sleep(time.Millisecond * 250)
+		}
+	}
+
+	return cmd.Process.Kill()
+}
+
+func isProcessStopped(p *os.Process) bool {
+	return errors.Is(p.Signal(syscall.Signal(0)), os.ErrProcessDone)
+}

--- a/cmd/project/project_worker_windows.go
+++ b/cmd/project/project_worker_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package project
+
+import "os/exec"
+
+// gracefulStop kills the process immediately. Windows console child processes cannot receive SIGTERM, so graceful termination is not possible;
+func gracefulStop(cmd *exec.Cmd, _ uint) error {
+	return cmd.Process.Kill()
+}


### PR DESCRIPTION
**Add Windows support**

Adds Windows as a release target and fixes the one runtime path that broke on Windows.

**Why**

No Windows binary was ever published. I personally know some developers building extensions on Windows, so having a windows bianry to use would be nice here. 

**Not changed (verified fine on Windows)**
`root.go` and `project_image_proxy.go` register `SIGINT`/`os.Interrupt` (delivered on Ctrl+C on Windows) alongside `SIGTERM`. Ctrl+C cleanup works as-is.

**Known limitations**
- `--graceful-stop-limit` degrades to an immediate kill on Windows.
- No CI coverage on `windows-latest` yet. CI is still Linux-only, so nothing guards against future Windows regressions. Should I add this as well?