### PR TITLE
Remove steps badge from migration wizard view

### DIFF
--- a/internal/devtui/migration_wizard_test.go
+++ b/internal/devtui/migration_wizard_test.go
@@ -347,7 +347,6 @@ func TestMigrationWizardViewSteps(t *testing.T) {
 	sg.step = migrationStepAdminUser
 	sg.username.Focus()
 	view = sg.viewContent()
-	assert.Contains(t, view, "Step")
 	assert.Contains(t, view, "Choose a username")
 	assert.Contains(t, view, "Choose a password")
 
@@ -397,16 +396,6 @@ func TestMigrationWizardDockerPHPAdvancesToReview(t *testing.T) {
 
 	next, _ := sg.update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
 	assert.Equal(t, migrationStepReview, next.step)
-}
-
-func TestMigrationWizardStepNumbering(t *testing.T) {
-	sg := newMigrationWizard("")
-	assert.Equal(t, 3, sg.totalSteps())
-	assert.Equal(t, 1, sg.stepNum(migrationStepAdminUser))
-	assert.Equal(t, 2, sg.stepNum(migrationStepDockerPHP))
-	assert.Equal(t, 3, sg.stepNum(migrationStepReview))
-	assert.Equal(t, 0, sg.stepNum(migrationStepWelcome))
-	assert.Equal(t, 0, sg.stepNum(migrationStepDone))
 }
 
 func TestMigrationWizardWelcome_EnterSetsStartedAt(t *testing.T) {

--- a/internal/devtui/migration_wizard_view.go
+++ b/internal/devtui/migration_wizard_view.go
@@ -1,7 +1,6 @@
 package devtui
 
 import (
-	"fmt"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -23,33 +22,6 @@ func (sg migrationWizard) viewContent() string {
 		return sg.viewDone()
 	}
 	return ""
-}
-
-func stepBadge(stepNum, totalSteps int) string {
-	return tui.TextBadge(fmt.Sprintf("Step %d/%d", stepNum, totalSteps))
-}
-
-// totalSteps returns the number of numbered wizard steps:
-// admin account, PHP version, review.
-func (sg migrationWizard) totalSteps() int {
-	return 3
-}
-
-// stepNum returns the 1-based index of the given wizard step within the
-// currently active step sequence. Steps outside the numbered sequence
-// (welcome, done) return 0.
-func (sg migrationWizard) stepNum(step migrationStep) int {
-	switch step {
-	case migrationStepAdminUser:
-		return 1
-	case migrationStepDockerPHP:
-		return 2
-	case migrationStepReview:
-		return 3
-	case migrationStepWelcome, migrationStepDone:
-		return 0
-	}
-	return 0
 }
 
 func (sg migrationWizard) viewWelcome() string {
@@ -88,8 +60,6 @@ func (sg migrationWizard) viewWelcome() string {
 
 func (sg migrationWizard) viewAdminUser() string {
 	var b strings.Builder
-	b.WriteString(stepBadge(sg.stepNum(migrationStepAdminUser), sg.totalSteps()))
-	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Admin Account"))
 	b.WriteString("\n")
 	b.WriteString(tui.DimStyle.Render("The login for your local Shopware admin panel and API."))
@@ -105,8 +75,6 @@ func (sg migrationWizard) viewAdminUser() string {
 
 func (sg migrationWizard) viewDockerPHP() string {
 	var b strings.Builder
-	b.WriteString(stepBadge(sg.stepNum(migrationStepDockerPHP), sg.totalSteps()))
-	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Docker Configuration"))
 	b.WriteString("\n")
 	b.WriteString(tui.DimStyle.Render("Select the PHP version for your Docker containers."))
@@ -128,8 +96,6 @@ func (sg migrationWizard) viewDockerPHP() string {
 func (sg migrationWizard) viewReview() string {
 	c := sg.currentConfig()
 	var b strings.Builder
-	b.WriteString(stepBadge(sg.stepNum(migrationStepReview), sg.totalSteps()))
-	b.WriteString("\n\n")
 	b.WriteString(tui.TitleStyle.Render("Review Configuration"))
 	b.WriteString("\n")
 	b.WriteString(tui.DimStyle.Render("The following configuration will be written."))


### PR DESCRIPTION
Related to #1113 

Changes:
 - Remove steps 1-3 badge from migration wizard view
 - Remove obsolete test and assertion