### PR TITLE
Check if docker is running for project create command

### DIFF
--- a/internal/system/setup.go
+++ b/internal/system/setup.go
@@ -65,6 +65,11 @@ func CheckProjectDependencies(ctx context.Context, useDocker bool, phpConstraint
 	if useDocker && !IsInsideContainer() {
 		if _, err := exec.LookPath("docker"); err != nil {
 			missing = append(missing, MissingDependency{Name: "Docker", Reason: "not installed"})
+		} else {
+			cmd := exec.CommandContext(ctx, "docker", "info")
+			if err := cmd.Run(); err != nil {
+				missing = append(missing, MissingDependency{Name: "Docker", Reason: "not running"})
+			}
 		}
 		return missing
 	}
@@ -120,13 +125,19 @@ func RenderMissingDependencies(useDocker bool, missing []MissingDependency) stri
 	arrow := tui.GreenText.Render("→")
 	insideContainer := IsInsideContainer()
 
-	if insideContainer {
+	dockerOnlyMissing := useDocker && len(missing) == 1 && missing[0].Name == "Docker"
+	switch {
+	case dockerOnlyMissing && missing[0].Reason == "not running":
+		b.WriteString(tui.BoldText.Render("Start Docker and try again."))
+	case dockerOnlyMissing && missing[0].Reason == "not installed":
+		b.WriteString(tui.BoldText.Render("Install Docker and try again."))
+	case insideContainer:
 		b.WriteString(tui.BoldText.Render("To create a Shopware project from inside this container, install:"))
 		b.WriteString("\n\n")
 		b.WriteString("  " + arrow + " " + tui.BoldText.Render("PHP 8.2+ and Composer") + "\n")
 		b.WriteString("    PHP:      " + tui.BlueText.Render("https://www.php.net/downloads.php") + "\n")
 		b.WriteString("    Composer: " + tui.BlueText.Render("https://getcomposer.org/") + "\n")
-	} else {
+	default:
 		b.WriteString(tui.BoldText.Render("To create a Shopware project, install one of:"))
 		b.WriteString("\n\n")
 		b.WriteString("  " + arrow + " " + tui.RecommendedText.Render("Docker") + " " + tui.DimText.Render("(recommended)") + "\n")

--- a/internal/system/setup_test.go
+++ b/internal/system/setup_test.go
@@ -13,3 +13,31 @@ func TestCheckIncompatibilities(t *testing.T) {
 		assert.Empty(t, incompatibilities)
 	})
 }
+
+func TestRenderMissingDependencies(t *testing.T) {
+	t.Run("docker not running shows start message", func(t *testing.T) {
+		out := RenderMissingDependencies(true, []MissingDependency{
+			{Name: "Docker", Reason: "not running"},
+		})
+		assert.Contains(t, out, "Start Docker and try again.")
+		assert.NotContains(t, out, "install one of")
+	})
+
+	t.Run("docker not installed shows install message", func(t *testing.T) {
+		out := RenderMissingDependencies(true, []MissingDependency{
+			{Name: "Docker", Reason: "not installed"},
+		})
+		assert.Contains(t, out, "Install Docker and try again.")
+		assert.NotContains(t, out, "install one of")
+	})
+
+	t.Run("missing php and composer shows install links", func(t *testing.T) {
+		out := RenderMissingDependencies(false, []MissingDependency{
+			{Name: "PHP 8.2+", Reason: "not installed"},
+			{Name: "Composer", Reason: "not installed"},
+		})
+		assert.Contains(t, out, "install one of")
+		assert.Contains(t, out, "https://www.php.net/downloads.php")
+		assert.Contains(t, out, "https://getcomposer.org/")
+	})
+}


### PR DESCRIPTION
### What was changed?
Currently, the `project create` command only checks whether Docker is installed on the host machine:

<img width="2772" height="1852" alt="no docker" src="https://github.com/user-attachments/assets/a2f9e35e-6d26-4ed7-a253-d6fdf092debb" />

If Docker is installed but not running, the user sees a raw/unhandled error instead:

<img width="2772" height="1852" alt="no check" src="https://github.com/user-attachments/assets/60c1b0b1-811e-498f-9ab6-bc473ccac775" />

The change is about displaying proper message when user selected Docker as environment and does not have Docker installed or running.

### Why it was changed?
We want to display to users clear and actionable errors. Additional check was applied and now we cover `docker not installed` and `docker not running` cases. Together with this change displayed message was updated to inform only what is missing and how to solve it.


| <img width="553" height="427" alt="not-installed" src="https://github.com/user-attachments/assets/8874bda7-4969-4295-92c9-825ba04d7fc2" /> | <img width="553" height="427" alt="not-running" src="https://github.com/user-attachments/assets/c4c9a50d-6077-44eb-beaf-832ef29a42ea" /> |
|---|---|




### How it was tested?
Added `TestRenderMissingDependencies` that covers `Docker not installed` and `Docker not running`. Additionally added test for `PHP 8.2+ not installed` and `Composer not installed` cases.