### PR TITLE
feat: add shopware/conflicts composer repository to generated composer.json

### DIFF
--- a/internal/flexmigrator/composer.go
+++ b/internal/flexmigrator/composer.go
@@ -62,6 +62,13 @@ func MigrateComposerJson(project string) error {
 		})
 	}
 
+	if !composerJson.Repositories.HasRepository("https://shopware.github.io/conflicts/") {
+		composerJson.Repositories = append(composerJson.Repositories, packagist.ComposerJsonRepository{
+			Type: "composer",
+			URL:  "https://shopware.github.io/conflicts/",
+		})
+	}
+
 	composerJson.Scripts = map[string]any{
 		"auto-scripts": map[string]string{
 			"assets:install": "symfony-cmd",

--- a/internal/flexmigrator/composer_test.go
+++ b/internal/flexmigrator/composer_test.go
@@ -92,6 +92,7 @@ func TestMigrateComposerJson(t *testing.T) {
 		// Verify repository configuration
 		assert.True(t, migratedComposer.Repositories.HasRepository("custom/plugins/*"))
 		assert.True(t, migratedComposer.Repositories.HasRepository("custom/plugins/*/packages/*"))
+		assert.True(t, migratedComposer.Repositories.HasRepository("https://shopware.github.io/conflicts/"))
 
 		// Verify scripts configuration
 		autoScripts, ok := migratedComposer.Scripts["auto-scripts"].(map[string]interface{})
@@ -105,6 +106,47 @@ func TestMigrateComposerJson(t *testing.T) {
 		postUpdateCmd, ok := migratedComposer.Scripts["post-update-cmd"].([]interface{})
 		require.True(t, ok)
 		assert.Contains(t, postUpdateCmd, "@auto-scripts")
+	})
+
+	t.Run("existing conflicts repository is not duplicated", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+
+		initialComposer := &packagist.ComposerJson{
+			Name: "shopware/project",
+			Require: packagist.ComposerPackageLink{
+				"shopware/core": "6.5.0.0",
+			},
+			Repositories: packagist.ComposerJsonRepositories{
+				{
+					Type: "composer",
+					URL:  "https://shopware.github.io/conflicts/",
+				},
+			},
+			Config: map[string]any{
+				"allow-plugins": map[string]any{},
+			},
+			Scripts: map[string]any{},
+			Extra:   map[string]any{},
+		}
+
+		composerFile := filepath.Join(tempDir, "composer.json")
+		content, err := json.MarshalIndent(initialComposer, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(composerFile, content, 0o644))
+
+		require.NoError(t, MigrateComposerJson(tempDir))
+
+		migratedComposer, err := packagist.ReadComposerJson(composerFile)
+		require.NoError(t, err)
+
+		count := 0
+		for _, repo := range migratedComposer.Repositories {
+			if repo.URL == "https://shopware.github.io/conflicts/" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count)
 	})
 
 	t.Run("non-existent composer.json", func(t *testing.T) {

--- a/internal/packagist/project_composer_json.go
+++ b/internal/packagist/project_composer_json.go
@@ -128,7 +128,11 @@ func GenerateComposerJson(ctx context.Context, opts ComposerJsonOptions) (string
 	repo3.set("url", "custom/static-plugins/*")
 	repo3.set("options", symlinkOptions)
 
-	composer.set("repositories", []*orderedMap{repo1, repo2, repo3})
+	repo4 := newOrderedMap()
+	repo4.set("type", "composer")
+	repo4.set("url", "https://shopware.github.io/conflicts/")
+
+	composer.set("repositories", []*orderedMap{repo1, repo2, repo3, repo4})
 	psr4 := newOrderedMap()
 	psr4.set("App\\", "src/")
 	autoload := newOrderedMap()

--- a/internal/packagist/project_composer_json_test.go
+++ b/internal/packagist/project_composer_json_test.go
@@ -36,6 +36,29 @@ func TestGenerateComposerJson(t *testing.T) {
 		assert.NoError(t, err, "Generated JSON should be valid")
 	})
 
+	t.Run("contains shopware conflicts repository", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		jsonStr, err := GenerateComposerJson(ctx, ComposerJsonOptions{Version: "6.4.18.0"})
+		assert.NoError(t, err)
+
+		var data struct {
+			Repositories []struct {
+				Type string `json:"type"`
+				URL  string `json:"url"`
+			} `json:"repositories"`
+		}
+		assert.NoError(t, json.Unmarshal([]byte(jsonStr), &data))
+
+		found := false
+		for _, repo := range data.Repositories {
+			if repo.Type == "composer" && repo.URL == "https://shopware.github.io/conflicts/" {
+				found = true
+			}
+		}
+		assert.True(t, found, "repositories should contain the shopware conflicts composer repository")
+	})
+
 	t.Run("with elasticsearch", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()


### PR DESCRIPTION
### Why

The `shopware/conflicts` package will be served from a composer repository hosted on GitHub Pages (`https://shopware.github.io/conflicts/`), and shopware/platform is adding that repository to its own composer.json. Since composer only honors `repositories` defined in the root package, projects created or migrated by shopware-cli need the entry themselves.

### What

- `project create` (`packagist.GenerateComposerJson`): the generated composer.json now always contains the conflicts composer repository alongside the existing `path` repositories.
- Flex migration (`flexmigrator.MigrateComposerJson`): adds the repository when it is missing, guarded by `HasRepository` so an existing entry is not duplicated.
- Tests for both paths, including a case that verifies the repository appears exactly once when it already exists before migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)