### PR TITLE
feat: allow php-http/discovery composer plugin for new projects

### DIFF
--- a/internal/packagist/project_composer_json.go
+++ b/internal/packagist/project_composer_json.go
@@ -86,6 +86,7 @@ func GenerateComposerJson(ctx context.Context, opts ComposerJsonOptions) (string
 	require.set("symfony/flex", "~2")
 
 	allowPlugins := newOrderedMap()
+	allowPlugins.set("php-http/discovery", true)
 	allowPlugins.set("symfony/flex", true)
 	allowPlugins.set("symfony/runtime", true)
 

--- a/internal/packagist/project_composer_json_test.go
+++ b/internal/packagist/project_composer_json_test.go
@@ -153,4 +153,21 @@ func TestGenerateComposerJson(t *testing.T) {
 		err = json.Unmarshal([]byte(jsonStr), &data)
 		assert.NoError(t, err, "Generated JSON should be valid")
 	})
+
+	t.Run("allow-plugins includes php-http/discovery", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		jsonStr, err := GenerateComposerJson(ctx, ComposerJsonOptions{Version: "6.4.18.0"})
+		assert.NoError(t, err)
+
+		var data struct {
+			Config struct {
+				AllowPlugins map[string]bool `json:"allow-plugins"`
+			} `json:"config"`
+		}
+		assert.NoError(t, json.Unmarshal([]byte(jsonStr), &data))
+		assert.True(t, data.Config.AllowPlugins["php-http/discovery"], "allow-plugins should include php-http/discovery")
+		assert.True(t, data.Config.AllowPlugins["symfony/flex"], "allow-plugins should include symfony/flex")
+		assert.True(t, data.Config.AllowPlugins["symfony/runtime"], "allow-plugins should include symfony/runtime")
+	})
 }


### PR DESCRIPTION
The `php-http/discovery` composer plugin is commonly required by HTTP client libraries in the Shopware ecosystem. This PR adds it to the default `allow-plugins` list in `composer.json` generated for new projects, alongside `symfony/flex` and `symfony/runtime`.

**Changes:**
- `internal/packagist/project_composer_json.go`: Added `php-http/discovery` to `allow-plugins` config
- `internal/packagist/project_composer_json_test.go`: Added test to verify all allow-plugins entries