### PR TITLE
Remove follow logs from footer and rename LIVE to FOLLOWING in sources list

### DIFF
--- a/internal/devtui/model_view.go
+++ b/internal/devtui/model_view.go
@@ -101,7 +101,6 @@ func (m Model) renderDashboardFooter() string {
 			{Key: "↑/↓", Label: "Navigate"},
 			{Key: "enter", Label: "Select source"},
 			{Key: "pgup/pgdn", Label: "Scroll logs"},
-			{Key: "f", Label: "Follow logs"},
 			{Key: "tab", Label: "Next tab"},
 			{Key: "ctrl+c", Label: "Exit"},
 		}

--- a/internal/devtui/tab_instance.go
+++ b/internal/devtui/tab_instance.go
@@ -293,7 +293,7 @@ func (m InstanceModel) renderSidebar() string {
 					lipgloss.Center,
 					item,
 					" ",
-					activeBadgeStyle.Render("LIVE"),
+					activeBadgeStyle.Render("FOLLOWING"),
 				)
 			}
 

--- a/internal/devtui/tab_instance_test.go
+++ b/internal/devtui/tab_instance_test.go
@@ -378,7 +378,7 @@ func TestInstanceModel_View_ShowsActiveSourceAndLive(t *testing.T) {
 
 	view := m.View()
 	assert.Contains(t, view, "varnish")
-	assert.Contains(t, view, "LIVE")
+	assert.Contains(t, view, "FOLLOWING")
 	assert.Contains(t, view, "mysql")
 }
 

--- a/internal/tui/shortcuts_test.go
+++ b/internal/tui/shortcuts_test.go
@@ -35,7 +35,6 @@ func TestShortcutBarFit_NarrowSeparatorsOn120Columns(t *testing.T) {
 	assert.LessOrEqual(t, lipgloss.Width(bar), 120)
 	assert.Equal(t, 1, lipgloss.Height(bar))
 	// All shortcuts survive; only the separators shrink.
-	assert.Contains(t, bar, "Follow logs")
 	assert.Contains(t, bar, "Exit")
 }
 


### PR DESCRIPTION
### What was changed?
On Instance tab removed "Follow logs" from footer as we always follow logs while displaying them. 
Rename from `LIVE` to `FOLLOWING` indicator in the source list

### Why it was changed?
Since we are always following the logs user do not have to take any action and this toggle is obsolete. Renaming from `LIVE` to `FOLLOWING` makes it more clear for user.

### How it was tested?
Updated existing tests for Instance tab.

### Related issue
https://github.com/shopware/shopware-cli/issues/1113