### PR TITLE
Refactor dependency validation into reusable helper

### DIFF
--- a/cmd/project/project_create_validate.go
+++ b/cmd/project/project_create_validate.go
@@ -29,8 +29,6 @@ func validateAndPreflight(ctx context.Context, opts *createOptions, releases []p
 
 	phpConstraint := packagist.PHPConstraintForShopwareVersion(releases, chosenVersion)
 
-	missingDeps := system.CheckProjectDependencies(ctx, opts.useDocker, phpConstraint)
-
 	validDeployments := map[string]bool{
 		packagist.DeploymentNone:         true,
 		packagist.DeploymentDeployer:     true,
@@ -50,9 +48,9 @@ func validateAndPreflight(ctx context.Context, opts *createOptions, releases []p
 		return "", nil, fmt.Errorf("invalid CI system: %s. Valid options: none, github, gitlab", opts.selectedCI)
 	}
 
-	if len(missingDeps) > 0 {
-		fmt.Fprintln(os.Stderr, system.RenderMissingDependencies(opts.useDocker, missingDeps))
-		return "", nil, fmt.Errorf("missing required dependencies")
+	dockerHint := "Then re-run with " + tui.BoldText.Render("--docker")
+	if err := system.ValidateProjectDependencies(ctx, opts.useDocker, phpConstraint, "create a Shopware project", dockerHint); err != nil {
+		return "", nil, err
 	}
 
 	if err := checkSecurityAdvisories(ctx, opts, chosenVersion); err != nil {

--- a/cmd/project/project_dev.go
+++ b/cmd/project/project_dev.go
@@ -17,6 +17,7 @@ import (
 	dockerpkg "github.com/shopware/shopware-cli/internal/docker"
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/tui"
 )
 
@@ -55,27 +56,9 @@ var projectDevCmd = &cobra.Command{
 			return runMigrationWizardTUI(projectRoot, cfg)
 		}
 
-		envCfg, err := cfg.ResolveEnvironment(environmentName)
+		env, err := newDevEnvironment(cmd, projectRoot, cfg)
 		if err != nil {
 			return err
-		}
-
-		exec, err := executor.New(projectRoot, envCfg, cfg)
-		if err != nil {
-			return err
-		}
-
-		if exec.Type() == executor.TypeDocker {
-			if err := dockerpkg.WriteComposeFile(projectRoot, dockerpkg.ComposeOptionsFromConfig(cfg)); err != nil {
-				return err
-			}
-		}
-
-		env := &devEnvironment{
-			projectRoot: projectRoot,
-			cfg:         cfg,
-			envCfg:      envCfg,
-			executor:    exec,
 		}
 
 		if !isatty.IsTerminal(os.Stdin.Fd()) {
@@ -161,6 +144,14 @@ func setupDevEnvironment(cmd *cobra.Command) (*devEnvironment, error) {
 		return nil, shop.ErrDevModeNotSupported
 	}
 
+	return newDevEnvironment(cmd, projectRoot, cfg)
+}
+
+// newDevEnvironment resolves the configured environment, verifies that the
+// system requirements for it are met (Docker running for Docker environments,
+// PHP and Composer for local ones) and prepares the executor. Shared by
+// `project dev` and its start/stop/status subcommands.
+func newDevEnvironment(cmd *cobra.Command, projectRoot string, cfg *shop.Config) (*devEnvironment, error) {
 	envCfg, err := cfg.ResolveEnvironment(environmentName)
 	if err != nil {
 		return nil, err
@@ -171,7 +162,13 @@ func setupDevEnvironment(cmd *cobra.Command) (*devEnvironment, error) {
 		return nil, err
 	}
 
-	if exec.Type() == executor.TypeDocker {
+	useDocker := exec.Type() == executor.TypeDocker
+	dockerHint := "Then set the environment " + tui.BoldText.Render("type") + " to " + tui.BoldText.Render("docker") + " in " + tui.BoldText.Render(".shopware-project.yml")
+	if err := system.ValidateProjectDependencies(cmd.Context(), useDocker, nil, "start the development environment", dockerHint); err != nil {
+		return nil, err
+	}
+
+	if useDocker {
 		if err := dockerpkg.WriteComposeFile(projectRoot, dockerpkg.ComposeOptionsFromConfig(cfg)); err != nil {
 			return nil, err
 		}

--- a/internal/system/setup.go
+++ b/internal/system/setup.go
@@ -3,6 +3,7 @@ package system
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -100,10 +101,27 @@ func CheckProjectDependencies(ctx context.Context, useDocker bool, phpConstraint
 	return missing
 }
 
+// ValidateProjectDependencies runs CheckProjectDependencies and, when
+// something is missing, prints the rendered explanation to stderr and returns
+// an error. action and dockerHint are passed through to
+// RenderMissingDependencies to phrase the help text for the calling command.
+func ValidateProjectDependencies(ctx context.Context, useDocker bool, phpConstraint PHPVersionChecker, action, dockerHint string) error {
+	missing := CheckProjectDependencies(ctx, useDocker, phpConstraint)
+	if len(missing) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(os.Stderr, RenderMissingDependencies(useDocker, missing, action, dockerHint))
+	return fmt.Errorf("missing required dependencies")
+}
+
 // RenderMissingDependencies returns a styled, bordered block describing the
 // missing dependencies and the two supported setup paths (Docker preferred,
-// PHP+Composer alternative).
-func RenderMissingDependencies(useDocker bool, missing []MissingDependency) string {
+// PHP+Composer alternative). action names what the user was trying to do
+// (e.g. "create a Shopware project"); dockerHint is an optional, already
+// styled line explaining how to switch to Docker (shown when Docker is
+// suggested but was not the chosen setup).
+func RenderMissingDependencies(useDocker bool, missing []MissingDependency, action, dockerHint string) string {
 	var b strings.Builder
 
 	b.WriteString(tui.RedText.Bold(true).Render("Missing Dependencies"))
@@ -132,18 +150,18 @@ func RenderMissingDependencies(useDocker bool, missing []MissingDependency) stri
 	case dockerOnlyMissing && missing[0].Reason == "not installed":
 		b.WriteString(tui.BoldText.Render("Install Docker and try again."))
 	case insideContainer:
-		b.WriteString(tui.BoldText.Render("To create a Shopware project from inside this container, install:"))
+		b.WriteString(tui.BoldText.Render(fmt.Sprintf("To %s from inside this container, install:", action)))
 		b.WriteString("\n\n")
 		b.WriteString("  " + arrow + " " + tui.BoldText.Render("PHP 8.2+ and Composer") + "\n")
 		b.WriteString("    PHP:      " + tui.BlueText.Render("https://www.php.net/downloads.php") + "\n")
 		b.WriteString("    Composer: " + tui.BlueText.Render("https://getcomposer.org/") + "\n")
 	default:
-		b.WriteString(tui.BoldText.Render("To create a Shopware project, install one of:"))
+		b.WriteString(tui.BoldText.Render(fmt.Sprintf("To %s, install one of:", action)))
 		b.WriteString("\n\n")
 		b.WriteString("  " + arrow + " " + tui.RecommendedText.Render("Docker") + " " + tui.DimText.Render("(recommended)") + "\n")
 		b.WriteString("    " + tui.BlueText.Render("https://docs.docker.com/get-docker/") + "\n")
-		if !useDocker {
-			b.WriteString("    Then re-run with " + tui.BoldText.Render("--docker") + "\n")
+		if !useDocker && dockerHint != "" {
+			b.WriteString("    " + dockerHint + "\n")
 		}
 		b.WriteString("\n")
 		b.WriteString("  " + arrow + " " + tui.BoldText.Render("PHP 8.2+ and Composer") + "\n")

--- a/internal/system/setup_test.go
+++ b/internal/system/setup_test.go
@@ -18,7 +18,7 @@ func TestRenderMissingDependencies(t *testing.T) {
 	t.Run("docker not running shows start message", func(t *testing.T) {
 		out := RenderMissingDependencies(true, []MissingDependency{
 			{Name: "Docker", Reason: "not running"},
-		})
+		}, "create a Shopware project", "Then re-run with --docker")
 		assert.Contains(t, out, "Start Docker and try again.")
 		assert.NotContains(t, out, "install one of")
 	})
@@ -26,7 +26,7 @@ func TestRenderMissingDependencies(t *testing.T) {
 	t.Run("docker not installed shows install message", func(t *testing.T) {
 		out := RenderMissingDependencies(true, []MissingDependency{
 			{Name: "Docker", Reason: "not installed"},
-		})
+		}, "create a Shopware project", "Then re-run with --docker")
 		assert.Contains(t, out, "Install Docker and try again.")
 		assert.NotContains(t, out, "install one of")
 	})
@@ -35,9 +35,18 @@ func TestRenderMissingDependencies(t *testing.T) {
 		out := RenderMissingDependencies(false, []MissingDependency{
 			{Name: "PHP 8.2+", Reason: "not installed"},
 			{Name: "Composer", Reason: "not installed"},
-		})
-		assert.Contains(t, out, "install one of")
+		}, "create a Shopware project", "Then re-run with --docker")
+		assert.Contains(t, out, "To create a Shopware project, install one of")
+		assert.Contains(t, out, "Then re-run with --docker")
 		assert.Contains(t, out, "https://www.php.net/downloads.php")
 		assert.Contains(t, out, "https://getcomposer.org/")
+	})
+
+	t.Run("action phrases the help text", func(t *testing.T) {
+		out := RenderMissingDependencies(false, []MissingDependency{
+			{Name: "PHP 8.2+", Reason: "not installed"},
+		}, "start the development environment", "")
+		assert.Contains(t, out, "To start the development environment, install one of")
+		assert.NotContains(t, out, "--docker")
 	})
 }


### PR DESCRIPTION
## Summary
Extract the dependency validation logic into a reusable `ValidateProjectDependencies` helper function in the `system` package, making it available to multiple commands. This reduces code duplication and improves consistency in how dependency checks are performed and reported across the CLI.

## Key Changes
- **New `ValidateProjectDependencies` function**: Wraps `CheckProjectDependencies` and handles error reporting to stderr, centralizing the validation pattern used by multiple commands
- **Updated `RenderMissingDependencies` signature**: Added `action` and `dockerHint` parameters to make error messages context-aware and customizable for different commands (e.g., "create a Shopware project" vs "start the development environment")
- **Refactored `project dev` command**: Extracted environment setup into a new `newDevEnvironment` helper function shared by the main command and its subcommands, reducing duplication
- **Updated `project create` command**: Now uses the new `ValidateProjectDependencies` helper instead of inline validation logic
- **Enhanced test coverage**: Added tests for the new `action` parameter and `dockerHint` customization in `RenderMissingDependencies`

## Implementation Details
- The `ValidateProjectDependencies` function prints formatted error output to stderr and returns an error, following the established pattern in the codebase
- The `dockerHint` parameter allows commands to provide context-specific guidance (e.g., suggesting `--docker` flag or `.shopware-project.yml` configuration)
- The refactored `newDevEnvironment` function now validates system dependencies before attempting to set up the executor, ensuring consistent error handling across all dev environment operations

https://claude.ai/code/session_01PkMbTc3KbdJ9bPN8W52ix7