### PR TITLE
Handle PHPStan "No files found" output gracefully

### DIFF
--- a/internal/verifier/phpstan.go
+++ b/internal/verifier/phpstan.go
@@ -87,14 +87,25 @@ func (p PhpStan) Check(ctx context.Context, check *Check, config ToolConfig) err
 
 		log, _ := phpstan.Output()
 
+		// When all files of a source directory are excluded by excludePaths in a
+		// local phpstan.neon, PHPStan prints a plain text message instead of JSON.
+		if isPhpStanNoFilesOutput(string(log)) || isPhpStanNoFilesOutput(stderr.String()) {
+			continue
+		}
+
 		log = []byte(strings.ReplaceAll(string(log), "\"files\":[]", "\"files\":{}"))
 
 		var phpstanResult PhpStanOutput
 
 		if err := json.Unmarshal(log, &phpstanResult); err != nil {
+			errorOutput := stderr.String()
+			if strings.TrimSpace(errorOutput) == "" {
+				errorOutput = string(log)
+			}
+
 			check.AddResult(validation.CheckResult{
 				Path:       "phpstan.neon",
-				Message:    "failed to unmarshal phpstan output: " + stderr.String(),
+				Message:    "failed to unmarshal phpstan output: " + errorOutput,
 				Severity:   validation.SeverityError,
 				Line:       0,
 				Identifier: "phpstan/error",
@@ -132,6 +143,10 @@ func (p PhpStan) Check(ctx context.Context, check *Check, config ToolConfig) err
 	}
 
 	return nil
+}
+
+func isPhpStanNoFilesOutput(output string) bool {
+	return strings.Contains(output, "No files found to analyse")
 }
 
 func (p PhpStan) Fix(ctx context.Context, config ToolConfig) error {

--- a/internal/verifier/phpstan_test.go
+++ b/internal/verifier/phpstan_test.go
@@ -67,3 +67,38 @@ func TestPhpStan_isUselessDeprecation(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPhpStanNoFilesOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "phpstan 2.x error block",
+			output: "\n [ERROR] No files found to analyse.                                            \n\n",
+			want:   true,
+		},
+		{
+			name:   "phpstan 1.x note block",
+			output: "\n ! [NOTE] No files found to analyse.                                            \n\n",
+			want:   true,
+		},
+		{
+			name:   "regular json output",
+			output: `{"totals":{"errors":0,"file_errors":0},"files":{},"errors":[]}`,
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPhpStanNoFilesOutput(tt.output))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Improve PHPStan verifier to gracefully handle cases where no files are found to analyze, which occurs when all files in a source directory are excluded by `excludePaths` in a local `phpstan.neon` configuration.

## Changes
- **Add `isPhpStanNoFilesOutput()` helper function** to detect PHPStan's plain text "No files found to analyse" message (supports both PHPStan 1.x NOTE and 2.x ERROR formats)
- **Skip JSON parsing** when PHPStan outputs the "no files" message instead of JSON, preventing unmarshal errors
- **Improve error reporting** by using stderr output when available, falling back to stdout if stderr is empty
- **Add comprehensive test coverage** with `TestIsPhpStanNoFilesOutput()` covering both PHPStan versions, JSON output, and edge cases

## Implementation Details
- The check now detects the "No files found to analyse" message in both stdout and stderr before attempting JSON unmarshaling
- When detected, the iteration continues to the next source directory without adding an error result
- Error messages now prefer stderr output for better diagnostics, improving debugging when PHPStan encounters issues

https://claude.ai/code/session_01Sh7Kd4repLWbXhDXkn5ZXw