### PR TITLE
Preserve whitespace in <pre> and <textarea> elements

### DIFF
--- a/internal/html/format.go
+++ b/internal/html/format.go
@@ -170,6 +170,90 @@ func isStructuredChild(n Node) bool {
 	return false
 }
 
+// whitespacePreservingTags lists elements whose rendered output depends on
+// the literal whitespace of their content (per HTML's white-space rules).
+// The formatter must emit their children byte-for-byte instead of
+// re-indenting or re-flowing them.
+var whitespacePreservingTags = map[string]bool{
+	"pre":      true,
+	"textarea": true,
+}
+
+// dumpVerbatim renders nodes without inserting or removing any whitespace.
+// Used for the contents of whitespace-preserving elements like <pre>, where
+// re-indenting would change what the browser displays. Nested elements are
+// emitted inline (attributes on one line) and their children recurse in
+// verbatim mode too.
+func dumpVerbatim(builder *strings.Builder, nodes NodeList) {
+	for _, node := range nodes {
+		switch n := node.(type) {
+		case *ElementNode:
+			builder.WriteString("<" + n.Tag)
+			for _, attr := range n.Attributes {
+				builder.WriteString(" ")
+				builder.WriteString(attr.Dump(0))
+			}
+			if n.SelfClosing {
+				builder.WriteString("/>")
+				continue
+			}
+			builder.WriteString(">")
+			dumpVerbatim(builder, n.Children)
+			if !n.Unclosed {
+				builder.WriteString("</" + n.Tag + ">")
+			}
+		case *TwigIfNode:
+			for i, br := range n.Branches {
+				builder.WriteString(openStmt(br.Trim.Left))
+				if i == 0 {
+					builder.WriteString(" if " + br.Condition + " ")
+				} else {
+					builder.WriteString(" elseif " + br.Condition + " ")
+				}
+				builder.WriteString(closeStmt(br.Trim.Right))
+				dumpVerbatim(builder, br.Body)
+			}
+			if len(n.ElseChildren) > 0 {
+				builder.WriteString(openStmt(n.ElseTrim.Left))
+				builder.WriteString(" else ")
+				builder.WriteString(closeStmt(n.ElseTrim.Right))
+				dumpVerbatim(builder, n.ElseChildren)
+			}
+			builder.WriteString(openStmt(n.EndTrim.Left))
+			builder.WriteString(" endif ")
+			builder.WriteString(closeStmt(n.EndTrim.Right))
+		case *TwigBlockNode:
+			builder.WriteString(openStmt(n.OpenTrim.Left))
+			builder.WriteString(" block " + n.Name + " ")
+			builder.WriteString(closeStmt(n.OpenTrim.Right))
+			dumpVerbatim(builder, n.Children)
+			builder.WriteString(openStmt(n.CloseTrim.Left))
+			builder.WriteString(" endblock ")
+			builder.WriteString(closeStmt(n.CloseTrim.Right))
+		case *TwigGenericBlockNode:
+			builder.WriteString(openStmt(n.OpenTrim.Left))
+			builder.WriteString(" " + n.Name)
+			if n.Args != "" {
+				builder.WriteString(" " + n.Args)
+			}
+			builder.WriteString(" ")
+			builder.WriteString(closeStmt(n.OpenTrim.Right))
+			dumpVerbatim(builder, n.Body)
+			if len(n.Else) > 0 {
+				builder.WriteString(openStmt(n.ElseTrim.Left))
+				builder.WriteString(" else ")
+				builder.WriteString(closeStmt(n.ElseTrim.Right))
+				dumpVerbatim(builder, n.Else)
+			}
+			builder.WriteString(openStmt(n.CloseTrim.Left))
+			builder.WriteString(" " + n.EndTag + " ")
+			builder.WriteString(closeStmt(n.CloseTrim.Right))
+		default:
+			builder.WriteString(node.Dump(0))
+		}
+	}
+}
+
 func isTemplateElement(node Node) bool {
 	if elem, ok := node.(*ElementNode); ok {
 		return elem.Tag == "template"
@@ -261,6 +345,16 @@ func (e *ElementNode) Dump(indent int) string {
 
 	// Handle children
 	if len(e.Children) > 0 {
+		// Whitespace-preserving elements (<pre>, <textarea>): emit the
+		// content byte-for-byte — any re-indentation would show up in the
+		// rendered page.
+		if whitespacePreservingTags[strings.ToLower(e.Tag)] {
+			dumpVerbatim(&builder, e.Children)
+			if !e.Unclosed {
+				builder.WriteString("</" + e.Tag + ">")
+			}
+			return builder.String()
+		}
 		// Preserve on p tag the formatting
 		if e.Tag == "p" {
 			hasLongTemplateExpression := false

--- a/internal/html/format_pre_test.go
+++ b/internal/html/format_pre_test.go
@@ -1,0 +1,46 @@
+package html
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreContentIsNotReformatted(t *testing.T) {
+	t.Parallel()
+
+	input := `<pre>
+line1
+    indented line2
+        deeper
+</pre>`
+
+	nodes, err := NewParser(input)
+	assert.NoError(t, err)
+	assert.Equal(t, input, nodes.Dump(0))
+}
+
+func TestPreWithNestedElementsIsPreservedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	input := `<pre><code class="language-twig">{{ product.name }}
+    {% if condition %}indented{% endif %}
+</code></pre>`
+
+	nodes, err := NewParser(input)
+	assert.NoError(t, err)
+	assert.Equal(t, input, nodes.Dump(0))
+}
+
+func TestTextareaContentIsNotReformatted(t *testing.T) {
+	t.Parallel()
+
+	input := `<textarea name="notes">
+  keep
+     this
+spacing</textarea>`
+
+	nodes, err := NewParser(input)
+	assert.NoError(t, err)
+	assert.Equal(t, input, nodes.Dump(0))
+}

--- a/internal/html/testdata/61-pre-tag-content-preserved.txt
+++ b/internal/html/testdata/61-pre-tag-content-preserved.txt
@@ -1,0 +1,26 @@
+{% block foo %}
+    <pre class="code">
+line1
+    indented line2
+
+        deeper
+</pre>
+{% endblock %}
+-----
+{% block foo %}
+<pre class="code">
+line1
+    indented line2
+
+        deeper
+</pre>
+{% endblock %}
+-----
+{% block foo %}
+    <pre class="code">
+line1
+    indented line2
+
+        deeper
+</pre>
+{% endblock %}

--- a/internal/html/testdata/62-textarea-content-preserved.txt
+++ b/internal/html/testdata/62-textarea-content-preserved.txt
@@ -1,0 +1,13 @@
+<div>
+    <textarea name="foo">
+  some
+     spaced
+content</textarea>
+</div>
+-----
+<div>
+    <textarea name="foo">
+  some
+     spaced
+content</textarea>
+</div>


### PR DESCRIPTION
## Summary
Fixes HTML formatting to preserve the exact whitespace and content of whitespace-sensitive elements like `<pre>` and `<textarea>`. Previously, the formatter would re-indent and reflow content inside these tags, which would alter their rendered output in the browser.

## Changes
- Added `whitespacePreservingTags` map to identify elements where whitespace matters (`<pre>`, `<textarea>`)
- Implemented `dumpVerbatim()` function that renders nodes without inserting or removing whitespace, emitting content byte-for-byte
- Updated `ElementNode.Dump()` to detect whitespace-preserving tags and use verbatim rendering for their children
- Added comprehensive test coverage:
  - Unit tests for `<pre>` and `<textarea>` content preservation
  - Integration tests with nested elements and Twig expressions
  - Test data files verifying formatting behavior in block contexts

## Implementation Details
- `dumpVerbatim()` handles all node types (ElementNode, TwigIfNode, TwigBlockNode, TwigGenericBlockNode) while preserving their exact formatting
- Nested elements within whitespace-preserving tags are emitted inline (attributes on one line) to avoid introducing unwanted whitespace
- The solution is recursive, so nested whitespace-preserving elements are also handled correctly

https://claude.ai/code/session_015NdDBo9srRM7QULuNyigtT