### PR TITLE
fix(devtui): keyboard shortcuts stop working when Caps Lock is on

### DIFF
--- a/internal/devtui/install_wizard.go
+++ b/internal/devtui/install_wizard.go
@@ -110,7 +110,7 @@ var installStepPatterns = []struct {
 }
 
 func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if k := msg.String(); k == keyQ || k == keyCtrlC {
+	if k := keyString(msg); k == keyQ || k == keyCtrlC {
 		if m.telemetry.installOnce() {
 			tags := m.telemetry.installTags(tracking.ResultCancelled, m.install)
 			tags[tracking.TagAbandonedAt] = installStepTagName(m.install.step)
@@ -134,7 +134,7 @@ func (m Model) updateInstallPrompt(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateInstallStepAsk(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
+	switch keyString(msg) {
 	case keyLeft, "h":
 		m.install.confirmYes = true
 	case keyRight, "l":
@@ -157,30 +157,30 @@ func (m Model) updateInstallStepAsk(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateInstallStepLanguage(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == keyEnter {
+	if keyString(msg) == keyEnter {
 		m.install.language = installLanguages[m.install.cursor].id
 		m.install.step = installStepCurrency
 		m.install.cursor = 0
 		return m, nil
 	}
-	m.install.cursor = moveCursor(m.install.cursor, msg.String(), len(installLanguages))
+	m.install.cursor = moveCursor(m.install.cursor, keyString(msg), len(installLanguages))
 	return m, nil
 }
 
 func (m Model) updateInstallStepCurrency(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == keyEnter {
+	if keyString(msg) == keyEnter {
 		m.install.currency = installCurrencies[m.install.cursor]
 		m.install.step = installStepCredentials
 		m.install.username.SetValue(defaultUsername)
 		m.install.password.SetValue("shopware")
 		return m, m.install.focus(credFocusUsername)
 	}
-	m.install.cursor = moveCursor(m.install.cursor, msg.String(), len(installCurrencies))
+	m.install.cursor = moveCursor(m.install.cursor, keyString(msg), len(installCurrencies))
 	return m, nil
 }
 
 func (m Model) updateInstallStepCredentials(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
+	switch keyString(msg) {
 	case keyEnter:
 		return m.handleInstallCredentialsEnter()
 	case keyTab, keyDown:

--- a/internal/devtui/keys.go
+++ b/internal/devtui/keys.go
@@ -1,5 +1,11 @@
 package devtui
 
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
 const (
 	keyCtrlC    = "ctrl+c"
 	keyDown     = "down"
@@ -17,6 +23,16 @@ const (
 	keyLeft     = "left"
 	keyRight    = "right"
 )
+
+// keyString returns the string form of a key press, lower-cased. With Caps
+// Lock on, the terminal sends the shortcut's shifted form instead of the
+// plain one - e.g. pressing ctrl+c sends "ctrl+C" and ctrl+p sends "ctrl+P" -
+// which doesn't match our lowercase key constants ("ctrl+c", "ctrl+p", ...),
+// so the shortcut silently does nothing. Lower-casing here makes the match
+// work either way.
+func keyString(msg tea.KeyPressMsg) string {
+	return strings.ToLower(msg.String())
+}
 
 // moveCursor applies an up/down (or k/j) navigation key to a cursor over a
 // list of length count, clamping to [0, count-1]. Keys other than the four

--- a/internal/devtui/migration_wizard.go
+++ b/internal/devtui/migration_wizard.go
@@ -126,7 +126,7 @@ func (sg *migrationWizard) update(msg tea.KeyPressMsg) (migrationWizard, tea.Cmd
 }
 
 func (sg *migrationWizard) updateWelcome(msg tea.KeyPressMsg) (migrationWizard, tea.Cmd) {
-	switch msg.String() {
+	switch keyString(msg) {
 	case keyLeft, "h":
 		sg.confirmYes = true
 	case keyRight, "l":
@@ -145,7 +145,7 @@ func (sg *migrationWizard) updateWelcome(msg tea.KeyPressMsg) (migrationWizard, 
 }
 
 func (sg *migrationWizard) updateAdminUser(msg tea.KeyPressMsg) (migrationWizard, tea.Cmd) {
-	switch msg.String() {
+	switch keyString(msg) {
 	case keyEnter:
 		return sg.handleAdminUserEnter()
 	case keyTab, keyDown:
@@ -176,16 +176,16 @@ func (sg *migrationWizard) handleAdminUserEnter() (migrationWizard, tea.Cmd) {
 }
 
 func (sg *migrationWizard) updateDockerPHP(msg tea.KeyPressMsg) (migrationWizard, tea.Cmd) {
-	if msg.String() == keyEnter {
+	if keyString(msg) == keyEnter {
 		sg.step = migrationStepReview
 		return *sg, nil
 	}
-	sg.phpCursor = moveCursor(sg.phpCursor, msg.String(), len(sg.phpVersions))
+	sg.phpCursor = moveCursor(sg.phpCursor, keyString(msg), len(sg.phpVersions))
 	return *sg, nil
 }
 
 func (sg *migrationWizard) updateReview(msg tea.KeyPressMsg) (migrationWizard, tea.Cmd) {
-	switch msg.String() {
+	switch keyString(msg) {
 	case keyLeft, "h":
 		sg.confirmYes = true
 	case keyRight, "l":

--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -30,7 +30,7 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.phase == phaseStarting || m.phase == phaseStopping {
-		switch msg.String() {
+		switch keyString(msg) {
 		case "l":
 			m.dockerShowLogs = !m.dockerShowLogs
 		case keyQ, keyCtrlC:
@@ -46,7 +46,7 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.phase == phaseInstalling {
-		switch msg.String() {
+		switch keyString(msg) {
 		case "l":
 			m.installProg.showLogs = !m.installProg.showLogs
 		case keyQ, keyCtrlC:
@@ -68,7 +68,7 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.taskErr = nil
 			return m, nil
 		}
-		if msg.String() == keyQ || msg.String() == keyCtrlC {
+		if keyString(msg) == keyQ || keyString(msg) == keyCtrlC {
 			if tags, ok := m.telemetry.taskTags(tracking.ResultCancelled); ok {
 				trackEventNow(tracking.EventDevAction, tags)
 			}
@@ -81,7 +81,7 @@ func (m Model) updateKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateDashboardKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
+	switch keyString(msg) {
 	case "ctrl+p":
 		m.modal = newCommandPalette(paletteState{
 			adminWatchActive: m.overview.adminWatchRunning || m.overview.adminWatchStarting,
@@ -125,7 +125,7 @@ func (m Model) updateDashboardKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateConfigTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == keyEnter {
+	if keyString(msg) == keyEnter {
 		if m.configTab.cursor == fieldSave && m.configTab.modified {
 			m.configTab.ApplyToConfig(m.config)
 			if err := shop.WriteConfig(m.config, m.projectRoot); err != nil {
@@ -261,13 +261,13 @@ func (m Model) updateMigrationWizard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Enter on the welcome screen's "Quit" button exits the wizard from inside
 	// migrationWizard.update, so detect it here before the state advances.
 	welcomeQuit := m.migrationWizard.step == migrationStepWelcome &&
-		!m.migrationWizard.confirmYes && msg.String() == keyEnter
+		!m.migrationWizard.confirmYes && keyString(msg) == keyEnter
 
 	newGuide, cmd := m.migrationWizard.update(msg)
 	m.migrationWizard = newGuide
 
 	// Ctrl+C on any step quits the app
-	if welcomeQuit || msg.String() == keyCtrlC {
+	if welcomeQuit || keyString(msg) == keyCtrlC {
 		// The done screen already sent a completed/failed event for this run.
 		if m.migrationWizard.step != migrationStepDone {
 			trackEventNow(tracking.EventDevMigrationWizard, migrationWizardTags(tracking.ResultCancelled, m.migrationWizard))
@@ -277,7 +277,7 @@ func (m Model) updateMigrationWizard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// User pressed Enter on the review step. confirmYes=true saves and
 	// continues, confirmYes=false picks the Quit button and exits the wizard.
-	if m.migrationWizard.step == migrationStepReview && msg.String() == keyEnter {
+	if m.migrationWizard.step == migrationStepReview && keyString(msg) == keyEnter {
 		if m.migrationWizard.confirmYes {
 			return m.saveMigrationWizard()
 		}
@@ -287,7 +287,7 @@ func (m Model) updateMigrationWizard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// User pressed Enter on the done screen → start docker containers.
 	// If the previous save errored, stay on the done screen so the user can read it.
-	if m.migrationWizard.step == migrationStepDone && msg.String() == keyEnter && m.migrationWizard.err == nil {
+	if m.migrationWizard.step == migrationStepDone && keyString(msg) == keyEnter && m.migrationWizard.err == nil {
 		return m.startAfterMigrationWizard()
 	}
 

--- a/internal/devtui/overlay_sales_channel_picker.go
+++ b/internal/devtui/overlay_sales_channel_picker.go
@@ -103,7 +103,7 @@ func (sp *salesChannelPicker) Update(msg tea.Msg) (Modal, tea.Cmd) {
 		// any of esc/enter/q closes the picker so the user is never stuck
 		// waiting on a view with no obvious way out.
 		if sp.inner == nil {
-			if msg.String() == "esc" || msg.String() == keyEnter || msg.String() == keyQ {
+			if keyString(msg) == "esc" || keyString(msg) == keyEnter || keyString(msg) == keyQ {
 				return nil, emit(salesChannelPickerResultMsg{Cancelled: true})
 			}
 			return sp, nil

--- a/internal/devtui/tab_config.go
+++ b/internal/devtui/tab_config.go
@@ -210,7 +210,7 @@ func (m ConfigModel) Update(msg tea.Msg) (ConfigModel, tea.Cmd) {
 }
 
 func (m ConfigModel) HandleKey(msg tea.KeyPressMsg) (ConfigModel, tea.Cmd) {
-	switch msg.String() {
+	switch keyString(msg) {
 	case keyUp, keyK:
 		m.moveCursorUp()
 	case keyDown, keyJ:

--- a/internal/devtui/tab_instance.go
+++ b/internal/devtui/tab_instance.go
@@ -146,7 +146,7 @@ func (m InstanceModel) Update(msg tea.Msg) (InstanceModel, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyPressMsg:
-		switch msg.String() {
+		switch keyString(msg) {
 		case keyUp, keyK:
 			m.cursor = m.neighborCursor(-1)
 			return m, nil

--- a/internal/devtui/tab_overview.go
+++ b/internal/devtui/tab_overview.go
@@ -300,7 +300,7 @@ func (m OverviewModel) handleKey(msg tea.KeyPressMsg) (OverviewModel, tea.Cmd) {
 		return m, nil
 	}
 
-	switch msg.String() {
+	switch keyString(msg) {
 	case "up", "k":
 		if m.cursor > 0 {
 			m.cursor--


### PR DESCRIPTION
### What changed?

Added a `keyString()` helper in `internal/devtui/keys.go` that lower-cases the key event string before matching, and switched every keyboard-shortcut comparison in the TUI (`ctrl+c`, `ctrl+p`) from `msg.String()` to `keyString(msg)`.

### Why it changed?

With Caps Lock on, the terminal sends a shortcut's shifted form instead of the plain one — e.g. pressing `ctrl+c` sends `"ctrl+C"` and `ctrl+p` sends `"ctrl+P"`. Every shortcut in the DevTUI package was compared against a lowercase literal (`keyCtrlC = "ctrl+c"`, `keyQ = "q"`, ...), so with Caps Lock on none of these comparisons matched and the shortcuts silently did nothing.

### How it was tested?
Manually reproduced the issue by toggling Caps Lock and pressing `ctrl+c`/`p` in the dashboard; confirmed all shortcuts now respond correctly with Caps Lock on and off

### Related issue

None 