### PR TITLE
fix(project): exclude .x-dev branch builds from version picker

### DIFF
--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -5,11 +5,36 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/shyim/go-composer/repository"
 	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shopware/shopware-cli/internal/shop"
 )
+
+func TestFilterInstallVersions(t *testing.T) {
+	t.Parallel()
+
+	releases := []repository.Version{
+		{Version: "6.7.12.x-dev"},
+		{Version: "6.7.12.1"},
+		{Version: "6.7.11.x-dev"},
+		{Version: "6.7.11.1"},
+		{Version: "dev-trunk"},
+		{Version: "6.3.0.0"},
+	}
+
+	filtered := filterInstallVersions(releases)
+
+	got := make([]string, 0, len(filtered))
+	for _, v := range filtered {
+		got = append(got, v.String())
+	}
+
+	// Branch dev builds (*.x-dev, dev-*) and versions below the minimum
+	// constraint are excluded; only installable stable releases remain.
+	assert.Equal(t, []string{"6.7.12.1", "6.7.11.1"}, got)
+}
 
 func TestResolveVersion(t *testing.T) {
 	t.Parallel()

--- a/cmd/project/project_create_validate.go
+++ b/cmd/project/project_create_validate.go
@@ -239,6 +239,13 @@ func filterInstallVersions(releases []repository.Version) []*version.Version {
 			continue
 		}
 
+		// Skip branch dev builds like "6.7.12.x-dev". These parse fine and
+		// satisfy the constraint, but they are not installable patch releases
+		// and should not be offered in the version picker.
+		if parsed.Prerelease() == "dev" {
+			continue
+		}
+
 		if constraint.Check(parsed) {
 			filteredVersions = append(filteredVersions, parsed)
 		}


### PR DESCRIPTION
## Problem

The interactive **Patch Version** picker in `project create` started listing branch dev builds like `6.7.12.x-dev` and `6.7.11.x-dev`:

```
Patch Version
Select the specific patch version
> 6.7.12.x-dev
  6.7.12.1
  6.7.11.x-dev
  6.7.11.1
  ...
```

These come from the composer metadata. They parse cleanly and satisfy the `>=6.4.18.0` constraint, so they slipped into the list. The existing dev filter only skipped the `dev-` **prefix** form (`dev-trunk`), which never matches the `.x-dev` **suffix** form.

## Fix

In `filterInstallVersions`, skip any version whose `Prerelease()` is `"dev"`. go-version tags `*.x-dev` builds this way, so this is more robust than string-matching the suffix and correctly keeps stable and `-rc` releases.

Passing a dev version explicitly (`--version dev-trunk`) still resolves through `resolveVersion` — only the picker noise is removed.

## Tests

Added `TestFilterInstallVersions` covering `.x-dev`, `dev-*`, and below-minimum exclusion. `go vet` and the full `cmd/project` package tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)