### PR TITLE
Cancel stop confirmation on Esc

### DIFF
--- a/internal/devtui/keys.go
+++ b/internal/devtui/keys.go
@@ -10,6 +10,7 @@ const (
 	keyCtrlC    = "ctrl+c"
 	keyDown     = "down"
 	keyEnter    = "enter"
+	keyEsc      = "esc"
 	keyUp       = "up"
 	keyTab      = "tab"
 	keyShiftTab = "shift+tab"

--- a/internal/devtui/overlay_stop_confirm.go
+++ b/internal/devtui/overlay_stop_confirm.go
@@ -48,6 +48,8 @@ func (sc *stopConfirm) Update(msg tea.Msg) (Modal, tea.Cmd) {
 		}
 	case keyTab:
 		sc.selected = (sc.selected + 1) % count
+	case keyEsc:
+		return nil, emit(stopConfirmResultMsg{Cancel: true})
 	case keyEnter:
 		switch sc.selected {
 		case stopConfirmCancel:
@@ -71,6 +73,7 @@ func (sc *stopConfirm) View(width, height int) string {
 	footerHint := tui.ShortcutBar(
 		tui.Shortcut{Key: "←/→", Label: "Select"},
 		tui.Shortcut{Key: "enter", Label: "Confirm"},
+		tui.Shortcut{Key: "esc", Label: "Cancel"},
 	)
 	return renderPhaseLayout(tui.RenderPhaseCard(card.String()), width, height, footerHint)
 }

--- a/internal/devtui/overlay_stop_confirm_test.go
+++ b/internal/devtui/overlay_stop_confirm_test.go
@@ -121,15 +121,17 @@ func TestStopConfirm_HAndLKeysMoveSelection(t *testing.T) {
 	assert.Equal(t, stopConfirmStop, sc.selected, "'h' should move the selection back")
 }
 
-func TestStopConfirm_EscIsNoop(t *testing.T) {
-	// NOTE: stopConfirm.Update does not handle Esc — pressing it leaves the
-	// modal in place and emits no command. The model-level update layer is
-	// responsible for any global Esc handling.
+func TestStopConfirm_EscEmitsCancel(t *testing.T) {
 	sc := newStopConfirm()
+
 	next, cmd := sc.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
-	assert.Same(t, sc, next)
-	assert.Nil(t, cmd)
-	assert.Equal(t, stopConfirmStop, sc.selected, "esc must not mutate the selection")
+	assert.Nil(t, next, "esc should dismiss the modal")
+	assert.NotNil(t, cmd)
+
+	res, ok := cmd().(stopConfirmResultMsg)
+	assert.True(t, ok, "expected stopConfirmResultMsg, got %T", cmd())
+	assert.True(t, res.Cancel, "esc should emit a cancel result")
+	assert.False(t, res.Stop)
 }
 
 func TestStopConfirm_NonKeyMsgIsIgnored(t *testing.T) {


### PR DESCRIPTION
## What changed?

Pressing `Esc` on the "Leaving the workspace" stop confirmation now cancels it, same as navigating to "Cancel" and pressing Enter. The footer hint was updated to show `esc` as a shortcut.

<img width="1123" height="812" alt="image" src="https://github.com/user-attachments/assets/cef4493d-d92f-46e8-9176-e62e37746c20" />

## Why it changed?

Previously users had to arrow/tab over to the "Cancel" button and press Enter just to back out of the dialog. `Esc` is more natural way to dismiss a confirmation, so this makes canceling faster.

## How it was tested?

Updated the existing unit test to assert `Esc` emits a cancel result.

## Related issue

None.
