### PR TITLE
fix: preserve only-extensions values in CI

### DIFF
--- a/cmd/project/platform.go
+++ b/cmd/project/platform.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/extension"
 	"github.com/shopware/shopware-cli/internal/shop"
+	"github.com/shopware/shopware-cli/internal/system"
 	"github.com/shopware/shopware-cli/internal/tui"
 	"github.com/shopware/shopware-cli/logging"
 )
@@ -84,12 +86,15 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 	}
 
 	onlyExtensions, _ := cmd.PersistentFlags().GetString("only-extensions")
+	selectExtensions, _ := cmd.PersistentFlags().GetBool("select-extensions")
 	skipExtensions, _ := cmd.PersistentFlags().GetString("skip-extensions")
 	onlyCustomStatic, _ := cmd.PersistentFlags().GetBool("only-custom-static-extensions")
 
-	// When --only-extensions is passed without a value, present an interactive
-	// multi-select picker instead of requiring the names upfront.
-	if cmd.PersistentFlags().Changed("only-extensions") && strings.TrimSpace(onlyExtensions) == "" {
+	if err := validateExtensionSelection(cmd.Context(), onlyExtensions, selectExtensions); err != nil {
+		return nil, err
+	}
+
+	if selectExtensions {
 		onlyExtensions, err = selectExtensionsInteractively(cmd, sources)
 		if err != nil {
 			return nil, err
@@ -165,6 +170,22 @@ func filterAndGetSources(cmd *cobra.Command, projectRoot string, shopCfg *shop.C
 	}
 
 	return sources, nil
+}
+
+func validateExtensionSelection(ctx context.Context, onlyExtensions string, selectExtensions bool) error {
+	if !selectExtensions {
+		return nil
+	}
+
+	if onlyExtensions != "" {
+		return fmt.Errorf("only one of --only-extensions and --select-extensions can be used")
+	}
+
+	if !system.IsInteractionEnabled(ctx) {
+		return fmt.Errorf("--select-extensions requires an interactive terminal; use --only-extensions with a comma-separated list instead")
+	}
+
+	return nil
 }
 
 // selectExtensionsInteractively presents a filterable multi-select picker of

--- a/cmd/project/platform_test.go
+++ b/cmd/project/platform_test.go
@@ -1,0 +1,44 @@
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/system"
+)
+
+func TestOnlyExtensionsAcceptsSpaceSeparatedValue(t *testing.T) {
+	t.Parallel()
+
+	var onlyExtensions string
+	command := &cobra.Command{
+		Use: "test",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			onlyExtensions, _ = cmd.Flags().GetString("only-extensions")
+			return nil
+		},
+	}
+	command.Flags().String("only-extensions", "", "extensions")
+	command.SetArgs([]string{"--only-extensions", "PluginA,PluginB"})
+
+	require.NoError(t, command.Execute())
+	assert.Equal(t, "PluginA,PluginB", onlyExtensions)
+}
+
+func TestSelectExtensionsRequiresInteractiveTerminal(t *testing.T) {
+	t.Parallel()
+
+	err := validateExtensionSelection(system.WithInteraction(context.Background(), false), "", true)
+	require.EqualError(t, err, "--select-extensions requires an interactive terminal; use --only-extensions with a comma-separated list instead")
+}
+
+func TestSelectExtensionsCannotBeCombinedWithOnlyExtensions(t *testing.T) {
+	t.Parallel()
+
+	err := validateExtensionSelection(context.Background(), "PluginA", true)
+	require.EqualError(t, err, "only one of --only-extensions and --select-extensions can be used")
+}

--- a/cmd/project/project_admin_build.go
+++ b/cmd/project/project_admin_build.go
@@ -83,8 +83,8 @@ func init() {
 	projectRootCmd.AddCommand(projectAdminBuildCmd)
 	projectAdminBuildCmd.PersistentFlags().Bool("skip-assets-install", false, "Skips the assets installation")
 	projectAdminBuildCmd.PersistentFlags().Bool("force-install-dependencies", false, "Force install NPM dependencies")
-	projectAdminBuildCmd.PersistentFlags().String("only-extensions", "", "Only build the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
-	projectAdminBuildCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
+	projectAdminBuildCmd.PersistentFlags().String("only-extensions", "", "Only build the given extensions (comma separated)")
+	projectAdminBuildCmd.PersistentFlags().Bool("select-extensions", false, "Select extensions interactively")
 	projectAdminBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectAdminBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }

--- a/cmd/project/project_admin_watch.go
+++ b/cmd/project/project_admin_watch.go
@@ -61,8 +61,8 @@ var projectAdminWatchCmd = &cobra.Command{
 
 func init() {
 	projectRootCmd.AddCommand(projectAdminWatchCmd)
-	projectAdminWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
-	projectAdminWatchCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
+	projectAdminWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
+	projectAdminWatchCmd.PersistentFlags().Bool("select-extensions", false, "Select extensions interactively")
 	projectAdminWatchCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectAdminWatchCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }

--- a/cmd/project/project_storefront_build.go
+++ b/cmd/project/project_storefront_build.go
@@ -90,8 +90,8 @@ func init() {
 	projectStorefrontBuildCmd.PersistentFlags().Bool("skip-assets-install", false, "Skips the assets installation")
 	projectStorefrontBuildCmd.PersistentFlags().Bool("skip-theme-compile", false, "Skip theme compilation")
 	projectStorefrontBuildCmd.PersistentFlags().Bool("force-install-dependencies", false, "Force install NPM dependencies")
-	projectStorefrontBuildCmd.PersistentFlags().String("only-extensions", "", "Only build the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
-	projectStorefrontBuildCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
+	projectStorefrontBuildCmd.PersistentFlags().String("only-extensions", "", "Only build the given extensions (comma separated)")
+	projectStorefrontBuildCmd.PersistentFlags().Bool("select-extensions", false, "Select extensions interactively")
 	projectStorefrontBuildCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectStorefrontBuildCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 }

--- a/cmd/project/project_storefront_watch.go
+++ b/cmd/project/project_storefront_watch.go
@@ -75,8 +75,8 @@ var projectStorefrontWatchCmd = &cobra.Command{
 
 func init() {
 	projectRootCmd.AddCommand(projectStorefrontWatchCmd)
-	projectStorefrontWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated). Pass without a value (--only-extensions) to pick interactively")
-	projectStorefrontWatchCmd.PersistentFlags().Lookup("only-extensions").NoOptDefVal = " "
+	projectStorefrontWatchCmd.PersistentFlags().String("only-extensions", "", "Only watch the given extensions (comma separated)")
+	projectStorefrontWatchCmd.PersistentFlags().Bool("select-extensions", false, "Select extensions interactively")
 	projectStorefrontWatchCmd.PersistentFlags().String("skip-extensions", "", "Skips the given extensions (comma separated)")
 	projectStorefrontWatchCmd.PersistentFlags().Bool("only-custom-static-extensions", false, "Only build extensions from custom/static-plugins directory")
 	projectStorefrontWatchCmd.PersistentFlags().String("sales-channel", "", "Sales channel ID to target with theme:dump. Pass without a value (--sales-channel) to pick interactively. Omit the flag entirely to keep the legacy theme:dump behavior")


### PR DESCRIPTION
## What changed

- Restored normal `--only-extensions value` parsing for project build and watch commands.
- Moved interactive extension selection to the explicit `--select-extensions` flag.
- Reject interactive selection in non-interactive contexts before Bubble Tea attempts to open a TTY.

## Why

`NoOptDefVal` made `--only-extensions` an optional-value flag. A space-separated extension list was consequently treated as a positional argument and the CLI opened the interactive picker, which fails on GitHub Actions runners without `/dev/tty`.

## Validation

- `go test ./...`

## Impact

Existing CI invocations using `--only-extensions extension-a,extension-b` work again. Interactive selection remains available via `--select-extensions`.
