### PR TITLE
fix: keep PROJECT_ROOT in admin/storefront watch and build

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -475,9 +475,20 @@ func runTransparentCommand(p *executor.Process) error {
 	p.Cmd.Stdin = os.Stdin
 	p.Cmd.Stdout = os.Stdout
 	p.Cmd.Stderr = os.Stderr
-	p.Cmd.Env = append(os.Environ(), "APP_SECRET=b59a3a283700fde2162c0d4f2bcf2588c3e841ef1976cf042d8500c3f3152ec513f77453797387dc004ff399cce0d3663e4fec770e6f11aa4ccd2846854c3a9f", "LOCK_DSN=flock")
+	applyTransparentEnv(p)
 
 	return p.Run()
+}
+
+// applyTransparentEnv appends the fixed development defaults without discarding
+// the environment the executor already set (e.g. PROJECT_ROOT for the watchers).
+// A command without its own env falls back to os.Environ().
+func applyTransparentEnv(p *executor.Process) {
+	if p.Cmd.Env == nil {
+		p.Cmd.Env = os.Environ()
+	}
+
+	p.Cmd.Env = append(p.Cmd.Env, "APP_SECRET=b59a3a283700fde2162c0d4f2bcf2588c3e841ef1976cf042d8500c3f3152ec513f77453797387dc004ff399cce0d3663e4fec770e6f11aa4ccd2846854c3a9f", "LOCK_DSN=flock")
 }
 
 func binCICommand(ctx context.Context, cmdExecutor executor.Executor, args ...string) *executor.Process {

--- a/cmd/project/ci_test.go
+++ b/cmd/project/ci_test.go
@@ -23,6 +23,37 @@ func TestBinCICommand(t *testing.T) {
 	assert.Equal(t, []string{"php", "bin/ci", "asset:install"}, assetInstall.Cmd.Args)
 }
 
+func TestRunTransparentCommandPreservesExecutorEnv(t *testing.T) {
+	cmdExecutor := executor.NewLocal("/project").WithEnv(map[string]string{
+		"PROJECT_ROOT": "/project",
+		"ADMIN_ROOT":   "/project/vendor/shopware/administration",
+	})
+
+	proc := cmdExecutor.NPMCommand(t.Context(), "run", "dev")
+
+	applyTransparentEnv(proc)
+
+	assert.Contains(t, proc.Cmd.Env, "PROJECT_ROOT=/project",
+		"executor-provided PROJECT_ROOT must survive a transparent command")
+	assert.Contains(t, proc.Cmd.Env, "ADMIN_ROOT=/project/vendor/shopware/administration",
+		"executor-provided ADMIN_ROOT must survive a transparent command")
+	assert.Contains(t, proc.Cmd.Env, "LOCK_DSN=flock",
+		"transparent command defaults must still be applied")
+}
+
+func TestRunTransparentCommandFallsBackToProcessEnv(t *testing.T) {
+	t.Setenv("SHOPWARE_CLI_TRANSPARENT_ENV_MARKER", "present")
+
+	proc := &executor.Process{Cmd: exec.CommandContext(t.Context(), "true")}
+	require.Nil(t, proc.Cmd.Env)
+
+	applyTransparentEnv(proc)
+
+	assert.Contains(t, proc.Cmd.Env, "SHOPWARE_CLI_TRANSPARENT_ENV_MARKER=present",
+		"a command without an explicit env must inherit the current process environment")
+	assert.Contains(t, proc.Cmd.Env, "LOCK_DSN=flock")
+}
+
 func TestGenerateProjectSBOM(t *testing.T) {
 	root := t.TempDir()
 


### PR DESCRIPTION
`runTransparentCommand` did `cmd.Env = append(os.Environ(), APP_SECRET, LOCK_DSN)`,
which throws away whatever the executor already set via `WithEnv` — including
`PROJECT_ROOT`/`ADMIN_ROOT`.

On SW 6.7 `project admin-watch` runs the admin Vite build (`npm run dev` →
`build.ts`), which reads `var/plugins.json` from `process.env.PROJECT_ROOT`. Every
step before it gets the env; `npm run dev` is the only one routed through
`runTransparentCommand`, so it starts with `PROJECT_ROOT` undefined and dies:

    TypeError: The "paths[0]" argument must be of type string. Received undefined
        at loadExtensions (.../build/vite-plugins/utils/index.ts:112)

Append the defaults instead of replacing the env, and fall back to `os.Environ()`
when the command has none (Docker passes env via `docker compose exec -e`, so no
change there).