### PR TITLE
Fix theme dump without selected theme

### DIFF
--- a/internal/extension/storefront_watch.go
+++ b/internal/extension/storefront_watch.go
@@ -35,13 +35,7 @@ func PrepareStorefrontWatcher(ctx context.Context, projectRoot string, cmdExecut
 		return nil, err
 	}
 
-	dumpArgs := []string{"theme:dump"}
-	if opts.ThemeID != "" {
-		dumpArgs = append(dumpArgs, opts.ThemeID)
-		if opts.DomainURL != "" {
-			dumpArgs = append(dumpArgs, opts.DomainURL)
-		}
-	}
+	dumpArgs := storefrontThemeDumpArgs(opts)
 
 	logStep(out, "Dumping theme...")
 	if err := runStep(ctx, cmdExecutor, out, dumpArgs...); err != nil {
@@ -64,6 +58,22 @@ func PrepareStorefrontWatcher(ctx context.Context, projectRoot string, cmdExecut
 	})
 
 	return storefrontExecutor.NPMCommand(ctx, "run-script", "hot-proxy"), nil
+}
+
+func storefrontThemeDumpArgs(opts StorefrontWatcherOptions) []string {
+	args := []string{"theme:dump"}
+	if opts.ThemeID != "" {
+		args = append(args, opts.ThemeID)
+		if opts.DomainURL != "" {
+			args = append(args, opts.DomainURL)
+		}
+	} else {
+		// Preparation commands do not have stdin attached. Keep the legacy
+		// theme:dump behavior without prompting when multiple themes exist.
+		args = append(args, "--no-interaction")
+	}
+
+	return args
 }
 
 func themeCompileSupportsActiveOnly(projectRoot string) bool {

--- a/internal/extension/storefront_watch_test.go
+++ b/internal/extension/storefront_watch_test.go
@@ -1,0 +1,36 @@
+package extension
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStorefrontThemeDumpArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		opts StorefrontWatcherOptions
+		want []string
+	}{
+		{
+			name: "non-interactive without a selected theme",
+			want: []string{"theme:dump", "--no-interaction"},
+		},
+		{
+			name: "selected theme",
+			opts: StorefrontWatcherOptions{ThemeID: "theme-id"},
+			want: []string{"theme:dump", "theme-id"},
+		},
+		{
+			name: "selected theme and domain",
+			opts: StorefrontWatcherOptions{ThemeID: "theme-id", DomainURL: "https://example.com"},
+			want: []string{"theme:dump", "theme-id", "https://example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, storefrontThemeDumpArgs(tt.opts))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- pass Symfony's `--no-interaction` option to `theme:dump` when no theme ID was selected
- preserve the existing explicit theme ID and domain URL arguments
- add regression tests for all three argument combinations

## Why

Since 0.16.0, storefront watcher preparation streams command output without attaching stdin. When multiple themes exist, `theme:dump` tries to prompt for a theme and immediately receives EOF, causing watcher startup to fail.

Running the legacy no-theme path non-interactively avoids the prompt while keeping TUI-owned stdin isolated.

## Validation

- `go test ./internal/extension`
- `go test ./cmd/project ./internal/executor`
- `git diff --check`
