### PR TITLE
fix: unset empty PHP_SESSION_SAVE_PATH in entrypoint script

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
 set -euo pipefail
 
+if [ "${PHP_SESSION_SAVE_PATH:-}" = "" ]; then
+    unset PHP_SESSION_SAVE_PATH
+fi
+
 exec "$@"


### PR DESCRIPTION
## Summary

When `PHP_SESSION_SAVE_PATH` is set to an empty string, PHP session handling
can break or behave unexpectedly. Unsetting the variable in the entrypoint
script allows PHP to fall back to its default session save path.

## Changes

- `scripts/entrypoint.sh`: Check if `PHP_SESSION_SAVE_PATH` is empty and unset
  it before executing the main command, ensuring PHP uses its default session
  storage location.