### PR TITLE
Add container structure tests for base image

### DIFF
--- a/.github/workflows/base-docker.yml
+++ b/.github/workflows/base-docker.yml
@@ -8,11 +8,17 @@ on:
       - main
     paths:
       - 'Dockerfile.base'
+      - 'scripts/entrypoint.sh'
+      - 'tests/container-structure-test.yaml'
+      - '.github/workflows/base-docker.yml'
       - 'internal/verifier/js/**'
       - 'internal/verifier/php/**'
   pull_request:
     paths:
       - 'Dockerfile.base'
+      - 'scripts/entrypoint.sh'
+      - 'tests/container-structure-test.yaml'
+      - '.github/workflows/base-docker.yml'
       - 'internal/verifier/js/**'
       - 'internal/verifier/php/**'
 permissions:
@@ -21,8 +27,48 @@ permissions:
   packages: write
 
 jobs:
+  structure-test:
+    name: Test base image structure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # ratchet:docker/setup-buildx-action@v4.2.0
+
+      - name: Build image under test
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # ratchet:docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: Dockerfile.base
+          load: true
+          tags: shopware-cli-base:structure-test
+          build-args: |
+            PHP_VERSION=8.3
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install container-structure-test
+        env:
+          CONTAINER_STRUCTURE_TEST_VERSION: v1.22.1
+          CONTAINER_STRUCTURE_TEST_SHA256: fa35e89512a8978585f76cf41397956d2e3a30c62c2ad3fb857b1597074d14ca
+        run: |
+          curl --fail --silent --show-error --location \
+            --output container-structure-test \
+            "https://github.com/GoogleContainerTools/container-structure-test/releases/download/${CONTAINER_STRUCTURE_TEST_VERSION}/container-structure-test-linux-amd64"
+          echo "${CONTAINER_STRUCTURE_TEST_SHA256}  container-structure-test" | sha256sum --check
+          chmod +x container-structure-test
+
+      - name: Test image structure
+        run: |
+          ./container-structure-test test \
+            --image shopware-cli-base:structure-test \
+            --config tests/container-structure-test.yaml
+
   build:
     name: Build PHP ${{ matrix.php-version }}
+    needs: structure-test
     strategy:
       matrix:
         php-version: ["8.5", "8.4", "8.3", "8.2"]

--- a/tests/container-structure-test.yaml
+++ b/tests/container-structure-test.yaml
@@ -1,0 +1,49 @@
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: entrypoint is executable
+    path: /usr/local/bin/entrypoint.sh
+    shouldExist: true
+    permissions: -rwxr-xr-x
+
+  - name: JavaScript verifier is installed
+    path: /opt/verifier/js
+    shouldExist: true
+
+  - name: PHP verifier is installed
+    path: /opt/verifier/php
+    shouldExist: true
+
+commandTests:
+  - name: empty PHP session save path is unset
+    command: env
+    args:
+      - PHP_SESSION_SAVE_PATH=
+      - /usr/local/bin/entrypoint.sh
+      - sh
+      - -c
+      - "if env | grep -q '^PHP_SESSION_SAVE_PATH='; then exit 1; fi; echo unset"
+    expectedOutput:
+      - (?m)^unset$
+
+  - name: configured PHP session save path is preserved
+    command: env
+    args:
+      - PHP_SESSION_SAVE_PATH=/tmp/sessions
+      - /usr/local/bin/entrypoint.sh
+      - sh
+      - -c
+      - "env | grep '^PHP_SESSION_SAVE_PATH=/tmp/sessions$'"
+    expectedOutput:
+      - (?m)^PHP_SESSION_SAVE_PATH=/tmp/sessions$
+
+metadataTest:
+  envVars:
+    - key: SHOPWARE_CLI_TOOLS_DIR
+      value: /opt/verifier
+    - key: PHP_MEMORY_LIMIT
+      value: 512M
+  labels:
+    - key: org.opencontainers.image.source
+      value: https://github.com/shopware/shopware-cli
+  cmd: []


### PR DESCRIPTION
## What changed

- add container structure tests for `Dockerfile.base`
- cover the empty `PHP_SESSION_SAVE_PATH` regression and preservation of configured values
- verify the entrypoint, verifier directories, and key image metadata
- run the structure test before publishing the PHP-version image matrix

## Why

Tag `0.16.5` had to restore unsetting an empty `PHP_SESSION_SAVE_PATH`. Testing the built image protects that runtime behavior and other essential base-image structure from future upstream or Dockerfile changes.

## Validation

- built `Dockerfile.base` locally with `PHP_VERSION=8.3`
- ran container-structure-test v1.22.1 locally: 6 tests passed
- `git diff --check`
- YAML syntax validation
