### PR TITLE
feat(tui): add two columns layout with header

### DIFF
--- a/internal/tui/header.go
+++ b/internal/tui/header.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"strings"
+
 	"charm.land/lipgloss/v2"
 )
 
@@ -28,6 +30,36 @@ func BrandingLine() string {
 	sep := DimStyle.Render(" · ")
 
 	return icon + " " + title + " " + version + sep + docsLink + sep + ghLink
+}
+
+// DocsAndGitHubLinks returns the styled "Documentation · GitHub" link pair.
+func DocsAndGitHubLinks() string {
+	lnkStyle := lipgloss.NewStyle().Foreground(LinkColor).Underline(true)
+	docsLink := StyledLink(docsURL, "Documentation", lnkStyle)
+	ghLink := StyledLink(githubURL, "GitHub", lnkStyle)
+	return docsLink + DimStyle.Render(" · ") + ghLink
+}
+
+// RenderSplitLine places left flush to the left edge and right flush to the
+// right edge of the given width, padding the gap with spaces. If the two
+// don't fit, they're joined with a single space instead of overlapping.
+func RenderSplitLine(width int, left, right string) string {
+	fill := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if fill < 1 {
+		fill = 1
+	}
+	return left + strings.Repeat(" ", fill) + right
+}
+
+// RenderProjectHeader renders a two-line header: "Shopware CLI" and doc/GitHub
+// links on the first line, project name + environment and the installed
+// Shopware version on the second.
+func RenderProjectHeader(width int, projectName, environment, version string) string {
+	line1 := RenderSplitLine(width, BoldText.Render(appTitle), DocsAndGitHubLinks())
+	line2 := RenderSplitLine(width,
+		BoldText.Render(projectName)+"  "+DimStyle.Render(environment),
+		BoldText.Render("Shopware "+version))
+	return line1 + "\n" + line2
 }
 
 // BrandingLineWidth returns the visual width of the branding line in terminal columns.

--- a/internal/tui/header_test.go
+++ b/internal/tui/header_test.go
@@ -1,0 +1,23 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderProjectHeader_ContainsProjectAndVersion(t *testing.T) {
+	header := RenderProjectHeader(100, "acme-shop", "local", "6.6.10.3")
+
+	assert.Contains(t, header, "Shopware CLI")
+	assert.Contains(t, header, "acme-shop")
+	assert.Contains(t, header, "local")
+	assert.Contains(t, header, "Shopware 6.6.10.3")
+}
+
+func TestRenderProjectHeader_IsTwoLines(t *testing.T) {
+	header := RenderProjectHeader(100, "acme-shop", "local", "6.6.10.3")
+
+	assert.Len(t, strings.Split(header, "\n"), 2)
+}

--- a/internal/tui/twocolumns.go
+++ b/internal/tui/twocolumns.go
@@ -1,0 +1,31 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// RenderTwoColumns lays out left and right content side by side within the
+// given total width, separated by a vertical rule, at least minHeight rows
+// tall (pass 0 to just grow to the taller column). rightFraction is the
+// share of width given to the right column (e.g. 0.38); the left column
+// gets the rest, minus the 3-column gutter (" │ "). Renders no border or
+// title of its own.
+func RenderTwoColumns(width, minHeight int, rightFraction float64, left, right string) string {
+	rightW := int(float64(width) * rightFraction)
+	leftW := width - rightW - 3 // 3 = " │ " gutter + divider
+
+	leftCol := lipgloss.NewStyle().Width(leftW).Render(left)
+	rightCol := lipgloss.NewStyle().Width(rightW).Render(right)
+
+	rows := max(minHeight, lipgloss.Height(leftCol), lipgloss.Height(rightCol))
+	leftCol = lipgloss.NewStyle().Width(leftW).Height(rows).Render(left)
+	rightCol = lipgloss.NewStyle().Width(rightW).Height(rows).Render(right)
+
+	divider := lipgloss.NewStyle().Foreground(BorderColor).
+		Render(strings.TrimSuffix(strings.Repeat("│\n", rows), "\n"))
+	gutter := lipgloss.NewStyle().Width(1).Height(rows).Render("")
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, leftCol, gutter, divider, gutter, rightCol)
+}

--- a/internal/tui/twocolumns_test.go
+++ b/internal/tui/twocolumns_test.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderTwoColumns_ContainsBothColumns(t *testing.T) {
+	body := RenderTwoColumns(80, 0, 0.38, "Left column text", "Right column text")
+
+	assert.Contains(t, body, "Left column text")
+	assert.Contains(t, body, "Right column text")
+}
+
+func TestRenderTwoColumns_HasRequestedWidth(t *testing.T) {
+	body := RenderTwoColumns(80, 0, 0.38, "short", "also short")
+
+	for _, line := range strings.Split(body, "\n") {
+		assert.Equal(t, 80, lipgloss.Width(line))
+	}
+}
+
+func TestRenderTwoColumns_GrowsToTallerColumn(t *testing.T) {
+	body := RenderTwoColumns(80, 0, 0.38, "one\ntwo\nthree\nfour", "one line")
+
+	assert.NotPanics(t, func() {
+		RenderTwoColumns(80, 0, 0.38, "one line", "one\ntwo\nthree\nfour")
+	})
+	assert.Contains(t, body, "four")
+	assert.Equal(t, 4, lipgloss.Height(body))
+}
+
+func TestRenderTwoColumns_StretchesToMinHeight(t *testing.T) {
+	body := RenderTwoColumns(80, 10, 0.38, "one line", "one line")
+
+	assert.Equal(t, 10, lipgloss.Height(body))
+}
+
+func TestRenderTwoColumns_MinHeightNeverTruncatesContent(t *testing.T) {
+	body := RenderTwoColumns(80, 1, 0.38, "one\ntwo\nthree", "one line")
+
+	assert.Equal(t, 3, lipgloss.Height(body))
+	assert.Contains(t, body, "three")
+}
+
+func TestRenderTwoColumns_RightFractionControlsSplit(t *testing.T) {
+	narrowRight := RenderTwoColumns(100, 0, 0.1, "left", "right")
+	wideRight := RenderTwoColumns(100, 0, 0.8, "left", "right")
+
+	narrowDivider := strings.IndexRune(strings.Split(narrowRight, "\n")[0], '│')
+	wideDivider := strings.IndexRune(strings.Split(wideRight, "\n")[0], '│')
+
+	assert.Greater(t, narrowDivider, wideDivider, "a smaller rightFraction should push the divider further right")
+}


### PR DESCRIPTION
## What changed?

Adds reusable `internal/tui` building blocks for full-width, titled two-columns screens, needed for the upcoming local Shopware upgrade wizard (#1167):

- `RenderTwoColumns(width, minHeight int, left, right string)` — lays out two columns side by side with a vertical rule, growing to at least `minHeight` (or the taller column) so a stretched layout never truncates content.
- `RenderProjectHeader(width int, projectName, environment, version string)` — a two-line header: "Shopware CLI" + doc/GitHub links on the first line, project name + environment / current Shopware version on the second.
- `RenderSplitLine(width int, left, right string)` — left/right-justifies two strings within a width, used by the header above.
- `DocsAndGitHubLinks()` — the styled "Documentation · GitHub" link pair, factored out of `BrandingLine`.

No existing behavior changes — `BrandingLine` and `RenderPanel` are untouched.

## Why?

Issue #1167 asks for a consistent header (project/environment/version) and two-column layout convention across every panel of the upcoming upgrade wizard. Rather than re-implement that layout math per panel, these are extracted as generic, reusable primitives any panel can compose.

## How it was tested?

Unit tests in `internal/tui/twocolumns_test.go` and `internal/tui/header_test.go` (column growth/min-height behavior, split-line placement, header content).

I also built an example "project upgrade" wizard welcome screen) to validate the components end-to-end in a real layout — see the usage example below. That is **not** part of this PR; it's shown only to demonstrate intended usage.

## Related issue

Part of #1167 (Implement local Shopware upgrade wizard flow) — "Common UX/style elements across all panels" header + two-column layout requirements, and a first pass at Panel 1 (Intro/overview).

## Usage example (not included in this PR)

The snippet below composes `RenderProjectHeader` and `RenderTwoColumns` into the wizard's intro/welcome screen. `RenderSplitLine` and `DocsAndGitHubLinks` are used internally by `RenderProjectHeader`. 

`project_upgrade_wizard_view.go`
```go
package devtui

import (
	"strconv"
	"strings"

	"charm.land/lipgloss/v2"

	"github.com/shopware/shopware-cli/internal/tui"
)

// upgradeWizardEnvironment and upgradeWizardShopwareVersion are placeholders
// for the header's second line until this wizard resolves the real
// environment and installed Shopware version.
const (
	upgradeWizardEnvironment     = "local"
	upgradeWizardShopwareVersion = "6.6.10.3"
)

func (uw upgradeWizard) view(width, height int) string {
	if width == 0 || height == 0 {
		return ""
	}

	innerW := width - 8  // 2 border cols + Padding(1,3) => 6 padding cols
	innerH := height - 4 // 2 border rows + Padding(1,3) => 2 padding rows

	header := tui.RenderProjectHeader(innerW, uw.projectName, upgradeWizardEnvironment, upgradeWizardShopwareVersion)

	rule := lipgloss.NewStyle().Foreground(tui.BorderColor).Render(strings.Repeat("─", innerW))
	title := tui.TitleStyle.Render("Upgrade Shopware to a newer version")
	buttons := renderConfirmButtons("Begin upgrade", "Cancel", uw.confirmYes)

	// content is 7 sections. The title sits flush against the rules directly
	// above/below it (no blank line), while the other 4 gaps keep a blank
	// line. The columns section absorbs whatever height is left after the
	// other 6 fixed-size sections, so the button row always lands flush at
	// the bottom regardless of how much column content there is.
	const gaps = 4
	fixedRows := lipgloss.Height(header) + 3*lipgloss.Height(rule) + lipgloss.Height(title) + lipgloss.Height(buttons)
	columnsMinHeight := max(0, innerH-fixedRows-gaps)
	columns := tui.RenderTwoColumns(innerW, columnsMinHeight, 0.38, uw.leftColumn(), uw.rightColumn())

	content := header + "\n\n" + rule + "\n" + title + "\n" + rule + "\n\n" + columns + "\n\n" + rule + "\n\n" + buttons

	return lipgloss.NewStyle().
		Border(lipgloss.RoundedBorder()).
		BorderForeground(tui.BorderColor).
		Padding(1, 3).
		Width(width).
		Height(height).
		Render(content)
}

func (uw upgradeWizard) leftColumn() string {
	var b strings.Builder
	b.WriteString(tui.DimStyle.Render("This wizard will guide you through a local Shopware upgrade:"))
	b.WriteString("\n\n")
	for i, step := range []string{
		"Check project readiness",
		"Choose the Shopware version to install",
		"Check Composer-managed extensions",
		"Update project files",
		"Run Deployment Helper",
	} {
		b.WriteString(tui.BoldText.Render(strconv.Itoa(i+1) + ". "))
		b.WriteString(step)
		b.WriteString("\n")
	}
	b.WriteString("\n")
	b.WriteString(tui.BoldText.Render("Before files change"))
	b.WriteString("\n")
	b.WriteString(tui.DimStyle.Render("You will review the upgrade plan before the wizard applies it locally.\n\nWe do not check custom project extensions."))
	return b.String()
}

func (uw upgradeWizard) rightColumn() string {
	var b strings.Builder
	b.WriteString(tui.DimStyle.Render("After the wizard finishes:"))
	b.WriteString("\n\n")
	for _, line := range []string{"test the shop locally", "commit the changed files", "deploy through your normal process"} {
		b.WriteString(tui.DimStyle.Render("  • "))
		b.WriteString(line)
		b.WriteString("\n")
	}
	b.WriteString("\n")
	b.WriteString(tui.BoldText.Render("User action"))
	b.WriteString("\n")
	b.WriteString(tui.BoldText.Render("Begin upgrade"))
	b.WriteString(tui.DimStyle.Render(" starts the guided checks and version selection.\n\nNo project files change yet."))
	return b.String()
}
```

### Rendered — without shortcut bar
<img width="1144" height="710" alt="no-shortcuts-visible" src="https://github.com/user-attachments/assets/53deb068-6b34-4d84-b4ba-297ed2a2c963" />


### Rendered — with shortcut bar

Same box (1 row shorter to leave room for the footer), plus a `tui.ShortcutBar`/`ShortcutBadge` row below it — the same convention `project dev` already uses for its footer:

<img width="1144" height="710" alt="with-shortcuts-visible" src="https://github.com/user-attachments/assets/1417ecc9-cbe4-4373-8285-b7699519f0a6" />
