### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What changed?
+_If this PR makes TUI or CLI output changes, please add screenshots or examples that show the before and after behavior._
+
+## Why?
+
+## How was this tested?
+
+## Related issue or discussion
+
+<!--
+Before opening this PR:
+- Small fixes (typos, docs) can go straight to a PR.
+- Larger changes (new features/commands/subcommands, changes to existing
+  command behavior) should be discussed in an issue first.
+- Run `go test ./...` and `golangci-lint run ./...` locally.
+- Add or update tests for bug fixes and new behavior.
+- Keep the PR focused — smaller PRs are easier to review and merge.
+-->


### PR DESCRIPTION
## What changed?

Adds `.github/pull_request_template.md` with the four sections CONTRIBUTING.md asks contributors to fill in.

## Why?

CONTRIBUTING.md already documents these expectations, but nothing prompts contributors to follow them when opening a PR. A template makes that the default.

## How it was tested?

Not required. No code changes.

## Related issue or discussion

None.
