### PR TITLE
Fix interactive storefront theme selection

### DIFF
--- a/cmd/project/project_storefront_watch.go
+++ b/cmd/project/project_storefront_watch.go
@@ -58,7 +58,7 @@ var projectStorefrontWatchCmd = &cobra.Command{
 			}
 		}
 
-		watchProcess, err := extension.PrepareStorefrontWatcher(cmd.Context(), projectRoot, cmdExecutor, opts, os.Stdout)
+		watchProcess, err := extension.PrepareStorefrontWatcher(cmd.Context(), projectRoot, cmdExecutor, opts, cmd.InOrStdin(), os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/internal/devtui/tab_overview.go
+++ b/internal/devtui/tab_overview.go
@@ -589,7 +589,7 @@ func (m OverviewModel) startStorefrontWatch(opts extension.StorefrontWatcherOpti
 			return nil, fmt.Errorf("preparing plugins.json: %w", err)
 		}
 
-		watchProcess, err := extension.PrepareStorefrontWatcher(ctx, projectRoot, e, opts, out)
+		watchProcess, err := extension.PrepareStorefrontWatcher(ctx, projectRoot, e, opts, nil, out)
 		if err != nil {
 			return nil, fmt.Errorf("starting storefront watcher: %w", err)
 		}

--- a/internal/extension/storefront_watch.go
+++ b/internal/extension/storefront_watch.go
@@ -2,12 +2,14 @@ package extension
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/shopware/shopware-cli/internal/executor"
 	"github.com/shopware/shopware-cli/internal/npm"
+	"github.com/shopware/shopware-cli/internal/system"
 )
 
 type StorefrontWatcherOptions struct {
@@ -19,7 +21,12 @@ type StorefrontWatcherOptions struct {
 // returns the hot-proxy process. When out is non-nil, the output of every
 // preparation step (feature:dump, theme:compile, theme:dump, npm install) is
 // streamed to it so the steps are not silent while they run.
-func PrepareStorefrontWatcher(ctx context.Context, projectRoot string, cmdExecutor executor.Executor, opts StorefrontWatcherOptions, out io.Writer) (*executor.Process, error) {
+func PrepareStorefrontWatcher(ctx context.Context, projectRoot string, cmdExecutor executor.Executor, opts StorefrontWatcherOptions, in io.Reader, out io.Writer) (*executor.Process, error) {
+	dumpArgs, err := storefrontThemeDumpArgs(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	logStep(out, "Dumping features...")
 	if err := runStep(ctx, cmdExecutor, out, "feature:dump"); err != nil {
 		return nil, err
@@ -35,10 +42,8 @@ func PrepareStorefrontWatcher(ctx context.Context, projectRoot string, cmdExecut
 		return nil, err
 	}
 
-	dumpArgs := storefrontThemeDumpArgs(opts)
-
 	logStep(out, "Dumping theme...")
-	if err := runStep(ctx, cmdExecutor, out, dumpArgs...); err != nil {
+	if err := runStorefrontThemeDump(ctx, cmdExecutor, in, out, dumpArgs...); err != nil {
 		return nil, err
 	}
 
@@ -60,20 +65,28 @@ func PrepareStorefrontWatcher(ctx context.Context, projectRoot string, cmdExecut
 	return storefrontExecutor.NPMCommand(ctx, "run-script", "hot-proxy"), nil
 }
 
-func storefrontThemeDumpArgs(opts StorefrontWatcherOptions) []string {
+func storefrontThemeDumpArgs(ctx context.Context, opts StorefrontWatcherOptions) ([]string, error) {
 	args := []string{"theme:dump"}
 	if opts.ThemeID != "" {
 		args = append(args, opts.ThemeID)
 		if opts.DomainURL != "" {
 			args = append(args, opts.DomainURL)
 		}
-	} else {
-		// Preparation commands do not have stdin attached. Keep the legacy
-		// theme:dump behavior without prompting when multiple themes exist.
-		args = append(args, "--no-interaction")
+	} else if !system.IsInteractionEnabled(ctx) {
+		return nil, fmt.Errorf("theme selection requires interaction; pass --sales-channel <id> when using --no-interaction")
 	}
 
-	return args
+	return args, nil
+}
+
+func runStorefrontThemeDump(ctx context.Context, e executor.Executor, in io.Reader, out io.Writer, args ...string) error {
+	cmd := e.ConsoleCommand(ctx, args...)
+	cmd.Cmd.Stdin = in
+	if out != nil {
+		return cmd.RunWithOutput(out)
+	}
+
+	return cmd.Run()
 }
 
 func themeCompileSupportsActiveOnly(projectRoot string) bool {

--- a/internal/extension/storefront_watch_test.go
+++ b/internal/extension/storefront_watch_test.go
@@ -71,7 +71,7 @@ func TestStorefrontThemeDumpArgs(t *testing.T) {
 }
 
 func TestRunStorefrontThemeDumpAttachesInput(t *testing.T) {
-	process := &executor.Process{Cmd: exec.Command(os.Args[0], "-test.run=^$")}
+	process := &executor.Process{Cmd: exec.CommandContext(t.Context(), os.Args[0], "-test.run=^$")}
 	exec := &storefrontWatchExecutor{process: process}
 	in := strings.NewReader("selected theme\n")
 	var out bytes.Buffer

--- a/internal/extension/storefront_watch_test.go
+++ b/internal/extension/storefront_watch_test.go
@@ -1,28 +1,55 @@
 package extension
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/executor"
+	"github.com/shopware/shopware-cli/internal/system"
 )
+
+type storefrontWatchExecutor struct {
+	executor.Executor
+	process *executor.Process
+	args    []string
+}
+
+func (e *storefrontWatchExecutor) ConsoleCommand(_ context.Context, args ...string) *executor.Process {
+	e.args = args
+	return e.process
+}
 
 func TestStorefrontThemeDumpArgs(t *testing.T) {
 	tests := []struct {
-		name string
-		opts StorefrontWatcherOptions
-		want []string
+		name        string
+		interactive bool
+		opts        StorefrontWatcherOptions
+		want        []string
+		wantErr     string
 	}{
 		{
-			name: "non-interactive without a selected theme",
-			want: []string{"theme:dump", "--no-interaction"},
+			name:        "interactive without a selected theme",
+			interactive: true,
+			want:        []string{"theme:dump"},
 		},
 		{
-			name: "selected theme",
+			name:    "non-interactive without a selected theme",
+			wantErr: "theme selection requires interaction; pass --sales-channel <id> when using --no-interaction",
+		},
+		{
+			name: "non-interactive with a selected theme",
 			opts: StorefrontWatcherOptions{ThemeID: "theme-id"},
 			want: []string{"theme:dump", "theme-id"},
 		},
 		{
-			name: "selected theme and domain",
+			name: "non-interactive with a selected theme and domain",
 			opts: StorefrontWatcherOptions{ThemeID: "theme-id", DomainURL: "https://example.com"},
 			want: []string{"theme:dump", "theme-id", "https://example.com"},
 		},
@@ -30,7 +57,28 @@ func TestStorefrontThemeDumpArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, storefrontThemeDumpArgs(tt.opts))
+			ctx := system.WithInteraction(context.Background(), tt.interactive)
+			args, err := storefrontThemeDumpArgs(ctx, tt.opts)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, args)
 		})
 	}
+}
+
+func TestRunStorefrontThemeDumpAttachesInput(t *testing.T) {
+	process := &executor.Process{Cmd: exec.Command(os.Args[0], "-test.run=^$")}
+	exec := &storefrontWatchExecutor{process: process}
+	in := strings.NewReader("selected theme\n")
+	var out bytes.Buffer
+
+	require.NoError(t, runStorefrontThemeDump(t.Context(), exec, in, &out, "theme:dump"))
+	assert.Equal(t, []string{"theme:dump"}, exec.args)
+	assert.Same(t, in, process.Cmd.Stdin)
+	assert.Same(t, &out, process.Cmd.Stdout)
+	assert.Same(t, &out, process.Cmd.Stderr)
 }


### PR DESCRIPTION
## What changed

- forward the CLI input stream to `theme:dump` during interactive storefront watcher startup
- keep the Dev TUI isolated from stdin by passing no input stream there
- reject non-interactive startup without `--sales-channel <id>` before running preparation commands
- cover interactive selection, non-interactive validation, explicit theme/domain arguments, and stdin wiring with regression tests

## Why

The storefront watcher refactor in 0.16.0 stopped forwarding stdin to `theme:dump`. With multiple themes or domains, Shopware could no longer ask the user which configuration to dump.

The previous `--no-interaction` workaround avoided the prompt but caused Shopware to write an empty `domainUrl` to `theme-files.json`. The hot-reload script then failed with `ERR_INVALID_URL` when constructing `new URL("")`.

Interactive CLI runs now retain Shopware's theme and domain selection. Non-interactive runs must provide a sales channel so the theme ID and domain URL are known.

## Validation

- `go test ./internal/extension ./cmd/project ./internal/devtui ./internal/executor`
- `git diff --check`
