### PR TITLE
fix(docker): chain docker-dev entrypoint so APP_ENV sentinel is cleared

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ ARG TARGETPLATFORM
 
 COPY $TARGETPLATFORM/shopware-cli /usr/local/bin/
 
-ENTRYPOINT ["/usr/local/bin/shopware-cli"]
+ENTRYPOINT ["/entrypoint", "/usr/local/bin/entrypoint.sh", "/usr/local/bin/shopware-cli"]
 CMD ["--help"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -45,4 +45,7 @@ ENV PHP_MEMORY_LIMIT=512M
 
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Chain docker-dev's /entrypoint (clears the APP_ENV sentinel) before ours
+ENTRYPOINT ["/entrypoint", "/usr/local/bin/entrypoint.sh"]
 CMD []

--- a/tests/container-structure-test.yaml
+++ b/tests/container-structure-test.yaml
@@ -37,7 +37,32 @@ commandTests:
     expectedOutput:
       - (?m)^PHP_SESSION_SAVE_PATH=/tmp/sessions$
 
+  - name: APP_ENV sentinel is cleared by the entrypoint chain
+    command: env
+    args:
+      - APP_ENV=xxxxxxx
+      - /entrypoint
+      - /usr/local/bin/entrypoint.sh
+      - sh
+      - -c
+      - "if env | grep -q '^APP_ENV='; then exit 1; fi; echo unset"
+    expectedOutput:
+      - (?m)^unset$
+
+  - name: configured APP_ENV is preserved by the entrypoint chain
+    command: env
+    args:
+      - APP_ENV=test
+      - /entrypoint
+      - /usr/local/bin/entrypoint.sh
+      - sh
+      - -c
+      - "env | grep '^APP_ENV=test$'"
+    expectedOutput:
+      - (?m)^APP_ENV=test$
+
 metadataTest:
+  entrypoint: ["/entrypoint", "/usr/local/bin/entrypoint.sh"]
   envVars:
     - key: SHOPWARE_CLI_TOOLS_DIR
       value: /opt/verifier


### PR DESCRIPTION
## What changed?

Chain docker-dev's `/entrypoint` in front of ours and the binary instead of replacing it:

```diff
-ENTRYPOINT ["/usr/local/bin/shopware-cli"]
+ENTRYPOINT ["/entrypoint", "/usr/local/bin/entrypoint.sh", "/usr/local/bin/shopware-cli"]
```

Plus a `metadataTest.entrypoint` assertion and two commandTests for the sentinel.

## Why?

docker-dev inherits `APP_ENV=prod` from `fpm/Dockerfile` and can't unset it (moby/moby#3465), so it sets a sentinel value and clears it at runtime in `/entrypoint` (shopware/docker#194):

```sh
if [ "$APP_ENV" = "xxxxxxx" ]; then
    unset APP_ENV
fi
```

Which only works if `/entrypoint` actually runs. Since #1174 moved Dockerfile.base onto docker-dev, our Dockerfile overwrites ENTRYPOINT with the binary, so nothing clears it:

```console
$ docker run --rm --entrypoint sh ghcr.io/shopware/shopware-cli:latest-php-8.4 -c 'echo $APP_ENV'
xxxxxxx
```

So `project ci` never gets `prod`, because the `os.Getenv("APP_ENV") == ""` check in cmd/project/ci.go:59 can't fire anymore. And anything Symfony-based booted in the image comes up as `xxxxxxx` and skips `config/packages/{env}/`. I ran into it with a PHPUnit suite that kept using the project's prod S3 storage instead of the test config, took a while to track down.

Side effect of the same thing: scripts/entrypoint.sh has never actually run in the published images, so #1195 isn't doing anything at the moment either.

## How was this tested?

Built the base at 8.3 (what structure-test uses) and 8.4, plus the release image, and ran container-structure-test v1.22.1.

Before, the binary sees `APP_ENV=xxxxxxx`. After, it's unset. 8/8 after, 7/1 before, the failing one being the new metadataTest.entrypoint, which is the bit that would have caught this in the first place:

```
Image entrypoint [/entrypoint] does not match expected entrypoint: [/entrypoint /usr/local/bin/entrypoint.sh]
```

Checked that docker-dev php8.2/8.3/8.4/8.5-node24-caddy all still ship `/entrypoint`, so the whole matrix is fine. `go test ./...` and `golangci-lint run ./...` are clean (no Go changes here). `--version`, `project --help` and php/node/npm/composer/bun/git/jq all still work through the chain.

## Related issue or discussion

None yet.