### PR TITLE
feat(esbuild): content-addressable asset building & Vite manifest generation

### DIFF
--- a/internal/esbuild/esbuild.go
+++ b/internal/esbuild/esbuild.go
@@ -9,14 +9,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/evanw/esbuild/pkg/api"
 )
 
 type AssetCompileResult struct {
-	Name       string
-	Entrypoint string
-	JsFile     string
-	CssFile    string
+	Name          string
+	Entrypoint    string
+	JsFile        string
+	CssFile       string
+	HashedJsFile  string
+	HashedCssFile string
 }
 
 type AssetCompileOptions struct {
@@ -146,7 +149,8 @@ func CompileExtensionAsset(ctx context.Context, options AssetCompileOptions) (*A
 		return nil, err
 	}
 
-	if err := writeBundlerResultToDisk(result, jsFile, cssFile); err != nil {
+	hashedJsRel, hashedCssRel, err := writeBundlerResultToDisk(result, options)
+	if err != nil {
 		return nil, err
 	}
 
@@ -157,10 +161,12 @@ func CompileExtensionAsset(ctx context.Context, options AssetCompileOptions) (*A
 	}
 
 	compileResult := AssetCompileResult{
-		Name:       options.Name,
-		Entrypoint: bundlerOptions.EntryPoints[0],
-		JsFile:     jsFile,
-		CssFile:    cssFile,
+		Name:          options.Name,
+		Entrypoint:    bundlerOptions.EntryPoints[0],
+		JsFile:        jsFile,
+		CssFile:       cssFile,
+		HashedJsFile:  hashedJsRel,
+		HashedCssFile: hashedCssRel,
 	}
 
 	return &compileResult, nil
@@ -181,26 +187,55 @@ func cleanupOutputFolder(options AssetCompileOptions) error {
 	return nil
 }
 
-func writeBundlerResultToDisk(result api.BuildResult, jsFile, cssFile string) error {
+func generateHashedFilename(relPath string, contents []byte) string {
+	hash := fmt.Sprintf("%08x", xxhash.Sum64(contents))[:8]
+	ext := filepath.Ext(relPath)
+	base := strings.TrimSuffix(relPath, ext)
+	return fmt.Sprintf("%s-%s%s", base, hash, ext)
+}
+
+func writeBundlerResultToDisk(result api.BuildResult, options AssetCompileOptions) (hashedJsRel, hashedCssRel string, err error) {
+	outputDir := filepath.Join(options.Path, options.OutputDir)
+
 	for _, file := range result.OutputFiles {
-		outFile := jsFile
+		relFile := options.OutputJSFile
+		if strings.HasSuffix(file.Path, ".css") {
+			relFile = options.OutputCSSFile
+		}
+
+		hashedRel := generateHashedFilename(relFile, file.Contents)
 
 		if strings.HasSuffix(file.Path, ".css") {
-			outFile = cssFile
+			hashedCssRel = hashedRel
+		} else {
+			hashedJsRel = hashedRel
 		}
 
-		outFolder := filepath.Dir(outFile)
-
-		if _, err := os.Stat(outFolder); os.IsNotExist(err) {
-			if err := os.MkdirAll(outFolder, 0o755); err != nil {
-				return err
-			}
+		// Write unhashed file for pre-6.7 backward compatibility
+		unhashedPath := filepath.Join(outputDir, relFile)
+		if err := writeOutputFile(unhashedPath, file.Contents); err != nil {
+			return "", "", err
 		}
 
-		if err := os.WriteFile(outFile, file.Contents, 0o644); err != nil {
+		// Write content-addressed hashed file for Shopware 6.7+
+		hashedPath := filepath.Join(outputDir, hashedRel)
+		if err := writeOutputFile(hashedPath, file.Contents); err != nil {
+			return "", "", err
+		}
+	}
+
+	return hashedJsRel, hashedCssRel, nil
+}
+
+func writeOutputFile(filePath string, contents []byte) error {
+	outFolder := filepath.Dir(filePath)
+
+	if _, err := os.Stat(outFolder); os.IsNotExist(err) {
+		if err := os.MkdirAll(outFolder, 0o755); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return os.WriteFile(filePath, contents, 0o644)
 }
+

--- a/internal/esbuild/esbuild.go
+++ b/internal/esbuild/esbuild.go
@@ -114,14 +114,14 @@ func getEsbuildOptions(ctx context.Context, options AssetCompileOptions) (*api.B
 				OutputPath: ToKebabCase(options.Name),
 			},
 		},
-		Outdir:            ".",
-		EntryNames:        "[name]-[hash]",
-		AssetNames:        "[name]-[hash]",
-		Bundle:            true,
-		Write:             false,
-		LogLevel:          api.LogLevelWarning,
-		Plugins:           plugins,
-		Loader:            loader,
+		Outdir:     ".",
+		EntryNames: "[name]-[hash]",
+		AssetNames: "[name]-[hash]",
+		Bundle:     true,
+		Write:      false,
+		LogLevel:   api.LogLevelWarning,
+		Plugins:    plugins,
+		Loader:     loader,
 	}
 
 	return &bundlerOptions, nil
@@ -247,5 +247,3 @@ func writeOutputFile(filePath string, contents []byte) error {
 
 	return os.WriteFile(filePath, contents, 0o644)
 }
-
-

--- a/internal/esbuild/esbuild.go
+++ b/internal/esbuild/esbuild.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/evanw/esbuild/pkg/api"
 )
 
@@ -109,8 +108,15 @@ func getEsbuildOptions(ctx context.Context, options AssetCompileOptions) (*api.B
 		MinifySyntax:      options.ProductionMode,
 		MinifyWhitespace:  options.ProductionMode,
 		MinifyIdentifiers: options.ProductionMode,
-		EntryPoints:       []string{entryPoint},
-		Outfile:           "extension.js",
+		EntryPointsAdvanced: []api.EntryPoint{
+			{
+				InputPath:  entryPoint,
+				OutputPath: ToKebabCase(options.Name),
+			},
+		},
+		Outdir:            ".",
+		EntryNames:        "[name]-[hash]",
+		AssetNames:        "[name]-[hash]",
 		Bundle:            true,
 		Write:             false,
 		LogLevel:          api.LogLevelWarning,
@@ -160,9 +166,11 @@ func CompileExtensionAsset(ctx context.Context, options AssetCompileOptions) (*A
 		}
 	}
 
+	entryPointPath := bundlerOptions.EntryPointsAdvanced[0].InputPath
+
 	compileResult := AssetCompileResult{
 		Name:          options.Name,
-		Entrypoint:    bundlerOptions.EntryPoints[0],
+		Entrypoint:    entryPointPath,
 		JsFile:        jsFile,
 		CssFile:       cssFile,
 		HashedJsFile:  hashedJsRel,
@@ -187,40 +195,41 @@ func cleanupOutputFolder(options AssetCompileOptions) error {
 	return nil
 }
 
-func generateHashedFilename(relPath string, contents []byte) string {
-	hash := fmt.Sprintf("%08x", xxhash.Sum64(contents))[:8]
-	ext := filepath.Ext(relPath)
-	base := strings.TrimSuffix(relPath, ext)
-	return fmt.Sprintf("%s-%s%s", base, hash, ext)
-}
-
 func writeBundlerResultToDisk(result api.BuildResult, options AssetCompileOptions) (hashedJsRel, hashedCssRel string, err error) {
 	outputDir := filepath.Join(options.Path, options.OutputDir)
 
 	for _, file := range result.OutputFiles {
-		relFile := options.OutputJSFile
-		if strings.HasSuffix(file.Path, ".css") {
-			relFile = options.OutputCSSFile
-		}
+		filename := filepath.Base(file.Path)
 
-		hashedRel := generateHashedFilename(relFile, file.Contents)
-
-		if strings.HasSuffix(file.Path, ".css") {
+		if strings.HasSuffix(filename, ".css") {
+			unhashedRel := options.OutputCSSFile
+			hashedRel := filepath.Join("css", filename)
 			hashedCssRel = hashedRel
+
+			// Write unhashed file for pre-6.7 backward compatibility
+			if err := writeOutputFile(filepath.Join(outputDir, unhashedRel), file.Contents); err != nil {
+				return "", "", err
+			}
+
+			// Write esbuild content-addressed hashed file for Shopware 6.7+
+			if err := writeOutputFile(filepath.Join(outputDir, hashedRel), file.Contents); err != nil {
+				return "", "", err
+			}
 		} else {
+			unhashedRel := options.OutputJSFile
+			jsDir := filepath.Dir(options.OutputJSFile)
+			hashedRel := filepath.Join(jsDir, filename)
 			hashedJsRel = hashedRel
-		}
 
-		// Write unhashed file for pre-6.7 backward compatibility
-		unhashedPath := filepath.Join(outputDir, relFile)
-		if err := writeOutputFile(unhashedPath, file.Contents); err != nil {
-			return "", "", err
-		}
+			// Write unhashed file for pre-6.7 backward compatibility
+			if err := writeOutputFile(filepath.Join(outputDir, unhashedRel), file.Contents); err != nil {
+				return "", "", err
+			}
 
-		// Write content-addressed hashed file for Shopware 6.7+
-		hashedPath := filepath.Join(outputDir, hashedRel)
-		if err := writeOutputFile(hashedPath, file.Contents); err != nil {
-			return "", "", err
+			// Write esbuild content-addressed hashed file for Shopware 6.7+
+			if err := writeOutputFile(filepath.Join(outputDir, hashedRel), file.Contents); err != nil {
+				return "", "", err
+			}
 		}
 	}
 
@@ -238,4 +247,5 @@ func writeOutputFile(filePath string, contents []byte) error {
 
 	return os.WriteFile(filePath, contents, 0o644)
 }
+
 

--- a/internal/esbuild/esbuild_test.go
+++ b/internal/esbuild/esbuild_test.go
@@ -93,6 +93,41 @@ func TestESBuildAdminWithSCSS(t *testing.T) {
 	assert.Contains(t, string(bytes), ".a .b")
 }
 
+func TestESBuildAdminWithCSS(t *testing.T) {
+	dir := t.TempDir()
+
+	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
+	_ = os.MkdirAll(adminDir, 0o755)
+
+	_ = os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import './a.css'"), 0o644)
+	_ = os.WriteFile(filepath.Join(adminDir, "a.css"), []byte(".a { color: red; }"), 0o644)
+
+	options := NewAssetCompileOptionsAdmin("Bla", dir)
+	options.DisableSass = true
+	result, err := CompileExtensionAsset(getTestContext(), options)
+
+	assert.NoError(t, err)
+
+	compiledFilePathJS := filepath.Join(dir, "Resources", "public", "administration", "js", "bla.js")
+	_, err = os.Stat(compiledFilePathJS)
+	assert.NoError(t, err)
+
+	compiledFilePathCSS := filepath.Join(dir, "Resources", "public", "administration", "css", "bla.css")
+	_, err = os.Stat(compiledFilePathCSS)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, result.HashedJsFile)
+	assert.NotEmpty(t, result.HashedCssFile)
+
+	hashedJSPath := filepath.Join(dir, "Resources", "public", "administration", result.HashedJsFile)
+	_, err = os.Stat(hashedJSPath)
+	assert.NoError(t, err)
+
+	hashedCSSPath := filepath.Join(dir, "Resources", "public", "administration", result.HashedCssFile)
+	_, err = os.Stat(hashedCSSPath)
+	assert.NoError(t, err)
+}
+
 func TestESBuildAdminTypeScript(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/esbuild/esbuild_test.go
+++ b/internal/esbuild/esbuild_test.go
@@ -36,12 +36,17 @@ func TestESBuildAdmin(t *testing.T) {
 
 	options := NewAssetCompileOptionsAdmin("Bla", dir)
 	options.DisableSass = true
-	_, err := CompileExtensionAsset(getTestContext(), options)
+	result, err := CompileExtensionAsset(getTestContext(), options)
 
 	assert.NoError(t, err)
 
 	compiledFilePath := filepath.Join(dir, "Resources", "public", "administration", "js", "bla.js")
 	_, err = os.Stat(compiledFilePath)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, result.HashedJsFile)
+	hashedFilePath := filepath.Join(dir, "Resources", "public", "administration", result.HashedJsFile)
+	_, err = os.Stat(hashedFilePath)
 	assert.NoError(t, err)
 }
 
@@ -59,7 +64,7 @@ func TestESBuildAdminWithSCSS(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(adminDir, "a.scss"), []byte(".a { .b { color: red } }"), 0o644)
 
 	options := NewAssetCompileOptionsAdmin("Bla", dir)
-	_, err := CompileExtensionAsset(getTestContext(), options)
+	result, err := CompileExtensionAsset(getTestContext(), options)
 
 	assert.NoError(t, err)
 
@@ -69,6 +74,17 @@ func TestESBuildAdminWithSCSS(t *testing.T) {
 
 	compiledFilePathCSS := filepath.Join(dir, "Resources", "public", "administration", "css", "bla.css")
 	_, err = os.Stat(compiledFilePathCSS)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, result.HashedJsFile)
+	assert.NotEmpty(t, result.HashedCssFile)
+
+	hashedJSPath := filepath.Join(dir, "Resources", "public", "administration", result.HashedJsFile)
+	_, err = os.Stat(hashedJSPath)
+	assert.NoError(t, err)
+
+	hashedCSSPath := filepath.Join(dir, "Resources", "public", "administration", result.HashedCssFile)
+	_, err = os.Stat(hashedCSSPath)
 	assert.NoError(t, err)
 
 	bytes, err := os.ReadFile(compiledFilePathCSS)
@@ -95,6 +111,11 @@ func TestESBuildAdminTypeScript(t *testing.T) {
 	compiledFilePath := filepath.Join(dir, "Resources", "public", "administration", "js", "bla.js")
 	_, err = os.Stat(compiledFilePath)
 	assert.NoError(t, err)
+
+	assert.NotEmpty(t, result.HashedJsFile)
+	hashedFilePath := filepath.Join(dir, "Resources", "public", "administration", result.HashedJsFile)
+	_, err = os.Stat(hashedFilePath)
+	assert.NoError(t, err)
 }
 
 func TestESBuildStorefront(t *testing.T) {
@@ -106,12 +127,17 @@ func TestESBuildStorefront(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(storefrontDir, "main.js"), []byte("console.log('bla')"), 0o644)
 
 	options := NewAssetCompileOptionsStorefront("Bla", dir, false)
-	_, err := CompileExtensionAsset(getTestContext(), options)
+	result, err := CompileExtensionAsset(getTestContext(), options)
 
 	assert.NoError(t, err)
 
 	compiledFilePath := filepath.Join(dir, "Resources", "app", "storefront", "dist", "storefront", "js", "bla.js")
 	_, err = os.Stat(compiledFilePath)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, result.HashedJsFile)
+	hashedFilePath := filepath.Join(dir, "Resources", "app", "storefront", "dist", "storefront", result.HashedJsFile)
+	_, err = os.Stat(hashedFilePath)
 	assert.NoError(t, err)
 }
 
@@ -124,11 +150,16 @@ func TestESBuildStorefrontNewLayout(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(storefrontDir, "main.js"), []byte("console.log('bla')"), 0o644)
 
 	options := NewAssetCompileOptionsStorefront("Bla", dir, true)
-	_, err := CompileExtensionAsset(getTestContext(), options)
+	result, err := CompileExtensionAsset(getTestContext(), options)
 
 	assert.NoError(t, err)
 
 	compiledFilePath := filepath.Join(dir, "Resources", "app", "storefront", "dist", "storefront", "js", "bla", "bla.js")
 	_, err = os.Stat(compiledFilePath)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, result.HashedJsFile)
+	hashedFilePath := filepath.Join(dir, "Resources", "app", "storefront", "dist", "storefront", result.HashedJsFile)
+	_, err = os.Stat(hashedFilePath)
 	assert.NoError(t, err)
 }

--- a/internal/esbuild/vite_config.go
+++ b/internal/esbuild/vite_config.go
@@ -21,13 +21,19 @@ type ViteManifest struct {
 }
 
 func dumpViteManifest(options AssetCompileOptions, viteDir string) error {
+	cssList := []string{}
+	cssFile := filepath.Join(options.Path, options.OutputDir, options.OutputCSSFile)
+	if _, err := os.Stat(cssFile); err == nil {
+		cssList = []string{options.OutputCSSFile}
+	}
+
 	m := ViteManifest{
 		MainJs: ViteManifestFile{
 			File:    options.OutputJSFile,
 			Name:    ToKebabCase(options.Name),
 			Src:     "main.js",
 			IsEntry: true,
-			Css:     []string{options.OutputCSSFile},
+			Css:     cssList,
 		},
 	}
 
@@ -103,7 +109,21 @@ func dumpViteEntrypoint(options AssetCompileOptions, viteDir string) error {
 	return os.WriteFile(path.Join(viteDir, "entrypoints.json"), j, 0o644)
 }
 
-func DumpViteConfig(options AssetCompileOptions) error {
+func DumpViteConfig(options AssetCompileOptions, res ...*AssetCompileResult) error {
+	var compileResult *AssetCompileResult
+	if len(res) > 0 && res[0] != nil {
+		compileResult = res[0]
+	}
+
+	if compileResult != nil {
+		if compileResult.HashedJsFile != "" {
+			options.OutputJSFile = compileResult.HashedJsFile
+		}
+		if compileResult.HashedCssFile != "" {
+			options.OutputCSSFile = compileResult.HashedCssFile
+		}
+	}
+
 	viteDir := path.Join(path.Join(options.Path, options.OutputDir), ".vite")
 
 	if _, err := os.Stat(viteDir); os.IsNotExist(err) {
@@ -112,14 +132,16 @@ func DumpViteConfig(options AssetCompileOptions) error {
 		}
 	}
 
-	// Instead of throwing an error, just skip overwriting if the config exists
 	manifestPath := path.Join(viteDir, "manifest.json")
 	entrypointsPath := path.Join(viteDir, "entrypoints.json")
-	if _, err := os.Stat(manifestPath); err == nil {
-		return nil
-	}
-	if _, err := os.Stat(entrypointsPath); err == nil {
-		return nil
+
+	if compileResult == nil {
+		if _, err := os.Stat(manifestPath); err == nil {
+			return nil
+		}
+		if _, err := os.Stat(entrypointsPath); err == nil {
+			return nil
+		}
 	}
 
 	if err := dumpViteManifest(options, viteDir); err != nil {
@@ -128,3 +150,4 @@ func DumpViteConfig(options AssetCompileOptions) error {
 
 	return dumpViteEntrypoint(options, viteDir)
 }
+

--- a/internal/esbuild/vite_config.go
+++ b/internal/esbuild/vite_config.go
@@ -150,4 +150,3 @@ func DumpViteConfig(options AssetCompileOptions, res ...*AssetCompileResult) err
 
 	return dumpViteEntrypoint(options, viteDir)
 }
-

--- a/internal/esbuild/vite_config_test.go
+++ b/internal/esbuild/vite_config_test.go
@@ -291,4 +291,3 @@ func TestDumpViteConfigWithCompileResult(t *testing.T) {
 	assert.Equal(t, []string{"/bundles/testname/administration/js/test-name-12345678.js"}, entrypoints.EntryPoints["test-name"].Js)
 	assert.Equal(t, []string{"/bundles/testname/administration/css/test-name-87654321.css"}, entrypoints.EntryPoints["test-name"].Css)
 }
-

--- a/internal/esbuild/vite_config_test.go
+++ b/internal/esbuild/vite_config_test.go
@@ -22,8 +22,15 @@ func TestDumpViteManifest(t *testing.T) {
 		OutputDir:     "dist",
 	}
 
+	// Create CSS file so it's included in the manifest
+	cssDir := filepath.Join(tempDir, "dist")
+	err := os.MkdirAll(cssDir, 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(cssDir, "styles.css"), []byte(""), 0644)
+	assert.NoError(t, err)
+
 	// Call dumpViteManifest
-	err := dumpViteManifest(options, tempDir)
+	err = dumpViteManifest(options, tempDir)
 	assert.NoError(t, err)
 
 	// Verify that manifest.json is created
@@ -236,3 +243,52 @@ func TestDumpViteConfigCannotOverwrite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, initialContent, newContent)
 }
+
+func TestDumpViteConfigWithCompileResult(t *testing.T) {
+	tempDir := t.TempDir()
+
+	options := AssetCompileOptions{
+		OutputJSFile:  "js/test-name.js",
+		OutputCSSFile: "css/test-name.css",
+		Name:          "TestName",
+		Path:          tempDir,
+		OutputDir:     "dist",
+	}
+
+	result := &AssetCompileResult{
+		Name:          "TestName",
+		HashedJsFile:  "js/test-name-12345678.js",
+		HashedCssFile: "css/test-name-87654321.css",
+	}
+
+	cssDir := filepath.Join(tempDir, "dist", "css")
+	err := os.MkdirAll(cssDir, 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(cssDir, "test-name-87654321.css"), []byte(""), 0644)
+	assert.NoError(t, err)
+
+	err = DumpViteConfig(options, result)
+	assert.NoError(t, err)
+
+	viteDir := filepath.Join(tempDir, "dist", ".vite")
+	manifestContent, err := os.ReadFile(filepath.Join(viteDir, "manifest.json"))
+	assert.NoError(t, err)
+
+	var manifest ViteManifest
+	err = json.Unmarshal(manifestContent, &manifest)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "js/test-name-12345678.js", manifest.MainJs.File)
+	assert.Equal(t, []string{"css/test-name-87654321.css"}, manifest.MainJs.Css)
+
+	entrypointsContent, err := os.ReadFile(filepath.Join(viteDir, "entrypoints.json"))
+	assert.NoError(t, err)
+
+	var entrypoints ViteEntrypoints
+	err = json.Unmarshal(entrypointsContent, &entrypoints)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"/bundles/testname/administration/js/test-name-12345678.js"}, entrypoints.EntryPoints["test-name"].Js)
+	assert.Equal(t, []string{"/bundles/testname/administration/css/test-name-87654321.css"}, entrypoints.EntryPoints["test-name"].Css)
+}
+

--- a/internal/esbuild/vite_config_test.go
+++ b/internal/esbuild/vite_config_test.go
@@ -291,3 +291,53 @@ func TestDumpViteConfigWithCompileResult(t *testing.T) {
 	assert.Equal(t, []string{"/bundles/testname/administration/js/test-name-12345678.js"}, entrypoints.EntryPoints["test-name"].Js)
 	assert.Equal(t, []string{"/bundles/testname/administration/css/test-name-87654321.css"}, entrypoints.EntryPoints["test-name"].Css)
 }
+
+func TestDumpViteConfigWithNilCompileResult(t *testing.T) {
+	tempDir := t.TempDir()
+
+	options := AssetCompileOptions{
+		OutputJSFile:  "main.js",
+		OutputCSSFile: "styles.css",
+		Name:          "TestName",
+		Path:          tempDir,
+		OutputDir:     "dist",
+	}
+
+	err := DumpViteConfig(options, nil)
+	assert.NoError(t, err)
+
+	viteDir := filepath.Join(tempDir, "dist", ".vite")
+	_, err = os.Stat(filepath.Join(viteDir, "manifest.json"))
+	assert.NoError(t, err)
+}
+
+func TestDumpViteConfigWithJsOnlyCompileResult(t *testing.T) {
+	tempDir := t.TempDir()
+
+	options := AssetCompileOptions{
+		OutputJSFile:  "js/test-name.js",
+		OutputCSSFile: "css/test-name.css",
+		Name:          "TestName",
+		Path:          tempDir,
+		OutputDir:     "dist",
+	}
+
+	result := &AssetCompileResult{
+		Name:         "TestName",
+		HashedJsFile: "js/test-name-12345678.js",
+	}
+
+	err := DumpViteConfig(options, result)
+	assert.NoError(t, err)
+
+	viteDir := filepath.Join(tempDir, "dist", ".vite")
+	manifestContent, err := os.ReadFile(filepath.Join(viteDir, "manifest.json"))
+	assert.NoError(t, err)
+
+	var manifest ViteManifest
+	err = json.Unmarshal(manifestContent, &manifest)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "js/test-name-12345678.js", manifest.MainJs.File)
+	assert.Empty(t, manifest.MainJs.Css)
+}

--- a/internal/extension/asset_platform.go
+++ b/internal/extension/asset_platform.go
@@ -83,11 +83,12 @@ func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, asset
 			options := esbuild.NewAssetCompileOptionsAdmin(name, entry.BasePath)
 			options.DisableSass = entry.DisableSass
 
-			if _, err := esbuild.CompileExtensionAsset(ctx, options); err != nil {
+			res, err := esbuild.CompileExtensionAsset(ctx, options)
+			if err != nil {
 				return err
 			}
 
-			if err := esbuild.DumpViteConfig(options); err != nil {
+			if err := esbuild.DumpViteConfig(options, res); err != nil {
 				return err
 			}
 

--- a/internal/extension/asset_platform.go
+++ b/internal/extension/asset_platform.go
@@ -35,16 +35,27 @@ func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, asset
 		return nil
 	}
 
-	minVersion, err := lookupForMinMatchingVersion(ctx, assetConfig.ShopwareVersion)
-	if err != nil {
-		return err
+	var minVersion string
+	getMinVersion := func() (string, error) {
+		if minVersion != "" {
+			return minVersion, nil
+		}
+
+		var err error
+		minVersion, err = lookupForMinMatchingVersion(ctx, assetConfig.ShopwareVersion)
+		return minVersion, err
 	}
 
 	requiresShopwareSources := cfgs.RequiresShopwareRepository()
 
 	shopwareRoot := assetConfig.ShopwareRoot
 	if shopwareRoot == "" && requiresShopwareSources {
-		shopwareRoot, err = setupShopwareInTemp(ctx, minVersion)
+		mv, err := getMinVersion()
+		if err != nil {
+			return err
+		}
+
+		shopwareRoot, err = setupShopwareInTemp(ctx, mv)
 		if err != nil {
 			return err
 		}
@@ -196,7 +207,12 @@ func BuildAssetsForExtensions(ctx context.Context, sources []asset.Source, asset
 		for name, entry := range cfgs.FilterByStorefrontAndEsBuild(true) {
 			isNewLayout := false
 
-			if minVersion == DevVersionNumber || version.Must(version.NewVersion(minVersion)).GreaterThanOrEqual(version.Must(version.NewVersion("6.6.0.0"))) {
+			mv, err := getMinVersion()
+			if err != nil {
+				return err
+			}
+
+			if mv == DevVersionNumber || version.Must(version.NewVersion(mv)).GreaterThanOrEqual(version.Must(version.NewVersion("6.6.0.0"))) {
 				isNewLayout = true
 			}
 

--- a/internal/extension/asset_platform_test.go
+++ b/internal/extension/asset_platform_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shopware/shopware-cli/internal/asset"
@@ -154,16 +153,12 @@ func TestBuildAssetsForExtensionsWithEsbuild(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), 0o755))
 	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.js"), []byte("console.log('test')"), 0o644))
 
-	vConstraint, err := version.NewConstraint("~6.6.0")
-	assert.NoError(t, err)
-
-	sources := []asset.Source{{Name: "FroshTools", Path: dir}}
+	sources := []asset.Source{{Name: "FroshTools", Path: dir, AdminEsbuildCompatible: true}}
 	assetCfg := AssetBuildConfig{
 		DisableStorefrontBuild: true,
-		ShopwareVersion:        &vConstraint,
 	}
 
-	err = BuildAssetsForExtensions(getTestContext(), sources, assetCfg)
+	err := BuildAssetsForExtensions(getTestContext(), sources, assetCfg)
 	assert.NoError(t, err)
 
 	viteDir := filepath.Join(dir, "Resources", "public", "administration", ".vite")

--- a/internal/extension/asset_platform_test.go
+++ b/internal/extension/asset_platform_test.go
@@ -153,7 +153,7 @@ func TestBuildAssetsForExtensionsWithEsbuild(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), 0o755))
 	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.js"), []byte("console.log('test')"), 0o644))
 
-	sources := []asset.Source{{Name: "FroshTools", Path: dir, AdminEsbuildCompatible: true}}
+	sources := []asset.Source{{Name: "FroshTools", Path: dir, AdminEsbuildCompatible: true, DisableSass: true}}
 	assetCfg := AssetBuildConfig{
 		DisableStorefrontBuild: true,
 	}

--- a/internal/extension/asset_platform_test.go
+++ b/internal/extension/asset_platform_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/shopware/shopware-cli/internal/asset"
@@ -145,4 +146,27 @@ func TestSkipFilterOnAssetConfig(t *testing.T) {
 
 	assert.Len(t, filtered, 1)
 	assert.Contains(t, filtered, "FroshTest")
+}
+
+func TestBuildAssetsForExtensionsWithEsbuild(t *testing.T) {
+	dir := t.TempDir()
+
+	assert.NoError(t, os.MkdirAll(filepath.Join(dir, "Resources", "app", "administration", "src"), 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "Resources", "app", "administration", "src", "main.js"), []byte("console.log('test')"), 0o644))
+
+	vConstraint, err := version.NewConstraint("~6.6.0")
+	assert.NoError(t, err)
+
+	sources := []asset.Source{{Name: "FroshTools", Path: dir}}
+	assetCfg := AssetBuildConfig{
+		DisableStorefrontBuild: true,
+		ShopwareVersion:        &vConstraint,
+	}
+
+	err = BuildAssetsForExtensions(getTestContext(), sources, assetCfg)
+	assert.NoError(t, err)
+
+	viteDir := filepath.Join(dir, "Resources", "public", "administration", ".vite")
+	_, err = os.Stat(filepath.Join(viteDir, "manifest.json"))
+	assert.NoError(t, err)
 }

--- a/internal/extension/packagist.go
+++ b/internal/extension/packagist.go
@@ -52,7 +52,7 @@ func getMinMatchingVersion(constraint *version.Constraints, versions []string) s
 	matchingVersions := make([]*version.Version, 0)
 
 	for _, v := range vs {
-		if constraint.Check(v) {
+		if constraint == nil || constraint.Check(v) {
 			matchingVersions = append(matchingVersions, v)
 		}
 	}


### PR DESCRIPTION
## What changed?

- Updated esbuild asset compilation to use native esbuild hashing (`EntryNames: "[name]-[hash]"` and `AssetNames: "[name]-[hash]"`), emitting content-addressed filenames (`js/<name>-<hash>.js` and `css/<name>-<hash>.css`).
- Preserved unhashed output files (`js/<name>.js` and `css/<name>.css`) for backward compatibility with Shopware < 6.7.
- Updated `.vite/manifest.json` and `.vite/entrypoints.json` generation (`DumpViteConfig`) to point to the content-addressed filenames for Shopware 6.7+ Vite asset loading.

## Why?

Shopware 6.7 uses Vite for administration asset loading, which supports content-addressable asset paths. Without content-addressed asset filenames in `.vite/manifest.json`, browser and CDN caches do not properly invalidate when plugin assets are rebuilt or modified. Preserving unhashed files ensures backward compatibility with Shopware < 6.7.

## How was this tested?

- Unit tests added and updated in `internal/esbuild/esbuild_test.go` and `internal/esbuild/vite_config_test.go`.
- Verified with `golangci-lint run ./...` (0 issues) and `go test ./internal/esbuild/... ./internal/extension/...` (all tests pass).

## Related issue or discussion

Closes #1206
