### PR TITLE
fix(system): honor PHP_BINARY in project create preflight

### DIFF
--- a/internal/system/php.go
+++ b/internal/system/php.go
@@ -3,16 +3,28 @@ package system
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/shyim/go-version"
 )
 
+// resolvePHPBinary returns the PHP binary to use. It prefers the PHP_BINARY
+// environment variable, matching the convention runComposerInstall already
+// follows, and falls back to the "php" binary found in PATH.
+func resolvePHPBinary() (string, error) {
+	if phpBinary := os.Getenv("PHP_BINARY"); phpBinary != "" {
+		return phpBinary, nil
+	}
+
+	return exec.LookPath("php")
+}
+
 // GetInstalledPHPVersion checks the installed PHP version on the system.
 func GetInstalledPHPVersion(ctx context.Context) (string, error) {
 	// Check if PHP is installed
-	phpPath, err := exec.LookPath("php")
+	phpPath, err := resolvePHPBinary()
 	if err != nil {
 		return "", fmt.Errorf("PHP is not installed: %w", err)
 	}
@@ -37,7 +49,7 @@ func GetInstalledPHPVersion(ctx context.Context) (string, error) {
 
 // GetAvailablePHPExtensions returns the list of loaded PHP extensions by parsing `php -m` output.
 func GetAvailablePHPExtensions(ctx context.Context) ([]string, error) {
-	phpPath, err := exec.LookPath("php")
+	phpPath, err := resolvePHPBinary()
 	if err != nil {
 		return nil, fmt.Errorf("PHP is not installed: %w", err)
 	}

--- a/internal/system/php_test.go
+++ b/internal/system/php_test.go
@@ -10,9 +10,26 @@ import (
 )
 
 func TestGetPHPVersionNotInstalled(t *testing.T) {
+	t.Setenv("PHP_BINARY", "")
 	t.Setenv("PATH", "")
 	_, err := GetInstalledPHPVersion(t.Context())
 	assert.ErrorContains(t, err, "PHP is not installed")
+}
+
+func TestGetPHPVersionPrefersPHPBinaryEnv(t *testing.T) {
+	pathDir := t.TempDir()
+	writeFakePHP(t, pathDir+"/php", "8.0.0")
+
+	binDir := t.TempDir()
+	phpBinary := binDir + "/php"
+	writeFakePHP(t, phpBinary, "8.2.0")
+
+	t.Setenv("PATH", pathDir)
+	t.Setenv("PHP_BINARY", phpBinary)
+
+	phpVersion, err := GetInstalledPHPVersion(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, "8.2.0", phpVersion)
 }
 
 func TestGetPHPVersion(t *testing.T) {
@@ -42,6 +59,7 @@ func TestPHPVersionIsNotAtLeast(t *testing.T) {
 }
 
 func TestGetAvailablePHPExtensionsNotInstalled(t *testing.T) {
+	t.Setenv("PHP_BINARY", "")
 	t.Setenv("PATH", "")
 	_, err := GetAvailablePHPExtensions(t.Context())
 	assert.ErrorContains(t, err, "PHP is not installed")
@@ -59,6 +77,13 @@ func TestGetAvailablePHPExtensions(t *testing.T) {
 
 func setupFakePHP(t *testing.T, tmpDir string, version string) {
 	t.Helper()
+	t.Setenv("PHP_BINARY", "")
+	writeFakePHP(t, tmpDir+"/php", version)
+	t.Setenv("PATH", tmpDir)
+}
+
+func writeFakePHP(t *testing.T, path string, version string) {
+	t.Helper()
 	shPath, err := exec.LookPath("sh")
 	assert.NoError(t, err)
 
@@ -70,6 +95,5 @@ else
 fi
 `, shPath, version)
 
-	assert.NoError(t, os.WriteFile(tmpDir+"/php", []byte(script), 0755))
-	t.Setenv("PATH", tmpDir)
+	assert.NoError(t, os.WriteFile(path, []byte(script), 0755))
 }


### PR DESCRIPTION
## What

Resolve the PHP interpreter through a shared `resolvePHPBinary()` helper that prefers the `PHP_BINARY` environment variable and falls back to `php` from `PATH`. It is used by `GetInstalledPHPVersion` and `GetAvailablePHPExtensions`, and therefore by the whole `project create` dependency preflight.

## Why

The preflight resolved PHP only via `exec.LookPath("php")` and ignored `PHP_BINARY`. On hosts where the default `php` in `PATH` differs from the intended interpreter (for example when multiple PHP versions are installed), it reports the wrong version and aborts with "missing required dependencies", even though the actual Composer install step in `runComposerInstall` already honors `PHP_BINARY`. This makes the preflight consistent with that existing behavior.

## Tests

Added `TestGetPHPVersionPrefersPHPBinaryEnv`; existing tests now clear `PHP_BINARY` for a deterministic PATH fallback. `go test ./...` passes.
