### PR TITLE
feat(project): allow creating project in current directory

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -21,7 +22,7 @@ const (
 	ciGitLab = "gitlab"
 
 	// projectNameHelp is the help text shown under the project name input.
-	projectNameHelp = "The name of the project directory to create"
+	projectNameHelp = "The name of the project directory to create (leave empty to use the current directory)"
 	// projectNameRule describes which characters are allowed in a project name.
 	// It is shared between the up-front validation error and the live form hint
 	// so both stay in sync.
@@ -39,8 +40,13 @@ var composeProjectNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 // validateProjectName ensures the project folder name can be used as a Docker
 // Compose project name. Only the final path element is relevant, as that is
 // what Docker Compose uses to derive the project name.
+// A dot (".") is accepted as a special value representing the current directory.
 func validateProjectName(name string) error {
 	base := filepath.Base(name)
+
+	if base == "" || base == "." {
+		return fmt.Errorf("invalid project name: %s", projectNameRule)
+	}
 
 	if !composeProjectNameRegexp.MatchString(base) {
 		return fmt.Errorf("invalid project name %q: %s, so it can be used as a Docker Compose project name", base, projectNameRule)
@@ -49,12 +55,23 @@ func validateProjectName(name string) error {
 	return nil
 }
 
+// currentProjectName returns the current working directory's base name for use
+// when the interactive project name prompt is left empty.
+func currentProjectName() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("could not determine current directory: %w", err)
+	}
+
+	return filepath.Base(cwd), nil
+}
+
 // projectNameFieldDescription returns the description shown under the project
 // name input in the interactive form. While the typed name is invalid it
 // returns the rule highlighted in red, validating the input live; otherwise it
 // returns the regular help text.
 func projectNameFieldDescription(name string) string {
-	if name != "" {
+	if name != "" && name != "." {
 		if err := validateProjectName(name); err != nil {
 			return tui.RedText.Render(projectNameRule)
 		}
@@ -111,7 +128,7 @@ var projectCreateCmd = &cobra.Command{
 		// prompt, which is where invalid names (e.g. wrong casing) are normally
 		// rejected live. Validate it up front so it is forbidden immediately
 		// instead of only after the rest of the form has been completed.
-		if opts.projectFolder != "" {
+		if opts.projectFolder != "" && opts.projectFolder != "." {
 			if err := validateProjectName(opts.projectFolder); err != nil {
 				return err
 			}
@@ -131,6 +148,18 @@ var projectCreateCmd = &cobra.Command{
 		if opts.interactive {
 			if err := runCreateForm(cmd, &opts, filteredVersions); err != nil {
 				return err
+			}
+			if opts.projectFolder == "" {
+				opts.projectFolder = "."
+			}
+			// Check the current directory name is valid as a project name before
+			// proceeding. The form itself allows empty/"." for the current directory.
+			projectName, err := currentProjectName()
+			if err != nil {
+				return err
+			}
+			if err := validateProjectName(projectName); err != nil {
+				return fmt.Errorf("current directory name %q cannot be used as a project name: %w", projectName, err)
 			}
 		} else {
 			if err := applyNonInteractiveDefaults(&opts); err != nil {

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -3,7 +3,6 @@ package project
 import (
 	"fmt"
 	"os"
-	"slices"
 
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
@@ -73,8 +72,17 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 
 	if !opts.useDocker {
 		extensions, err := system.GetAvailablePHPExtensions(cmd.Context())
-		if err == nil && !slices.Contains(extensions, "amqp") {
-			selectAMQP = tui.No
+		if err == nil {
+			available := false
+			for _, ext := range extensions {
+				if ext == "amqp" {
+					available = true
+					break
+				}
+			}
+			if !available {
+				selectAMQP = tui.No
+			}
 		}
 	}
 	selectedMinor := versionLatest
@@ -106,11 +114,11 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 					DescriptionFunc(func() string {
 						return projectNameFieldDescription(opts.projectFolder)
 					}, &opts.projectFolder).
-					Placeholder("my-shopware-project").
+					Placeholder("leave empty to use current directory").
 					Value(&opts.projectFolder).
 					Validate(func(s string) error {
-						if s == "" {
-							return fmt.Errorf("project name is required")
+						if s == "" || s == "." {
+							return nil
 						}
 						if err := validateProjectName(s); err != nil {
 							return err

--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -80,7 +80,7 @@ func printCreateSummary(ctx context.Context, opts *createOptions) {
 		fmt.Println()
 		fmt.Println(sectionStyle.Render("Next steps"))
 		fmt.Println()
-		fmt.Printf("  %s  %s\n", tui.GreenText.Render("Start developing:"), cmdStyle.Render(fmt.Sprintf("cd %s && shopware-cli project dev", opts.projectFolder)))
+		fmt.Printf("  %s  %s\n", tui.GreenText.Render("Start developing:"), cmdStyle.Render("shopware-cli project dev"))
 		fmt.Println()
 		fmt.Println(sectionStyle.Render("Access your shop (after make setup)"))
 		fmt.Println()

--- a/cmd/project/project_create_scaffold.go
+++ b/cmd/project/project_create_scaffold.go
@@ -42,11 +42,32 @@ func scaffoldProject(ctx context.Context, opts *createOptions, chosenVersion str
 		tracking.TagInteractive:       fmt.Sprintf("%v", opts.interactive),
 	})
 
-	if err := os.MkdirAll(opts.projectFolder, os.ModePerm); err != nil {
+	projectFolder := opts.projectFolder
+	if projectFolder == "." {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("could not determine current directory: %w", err)
+		}
+		projectFolder = cwd
+	}
+
+	if err := os.MkdirAll(projectFolder, os.ModePerm); err != nil {
 		return err
 	}
 
-	logging.FromContext(ctx).Infof("Setting up Shopware %s", chosenVersion)
+	empty, err := system.IsDirEmpty(projectFolder)
+	if err != nil {
+		return err
+	}
+	if !empty {
+		return fmt.Errorf("the folder %s exists already and is not empty", projectFolder)
+	}
+
+	if opts.projectFolder != "." {
+		logging.FromContext(ctx).Infof("Setting up Shopware %s in %s", chosenVersion, opts.projectFolder)
+	} else {
+		logging.FromContext(ctx).Infof("Setting up Shopware %s in the current directory", chosenVersion)
+	}
 
 	composerJson, err := shop.GenerateComposerJson(ctx, shop.ComposerJsonOptions{
 		Version:          chosenVersion,
@@ -60,11 +81,11 @@ func scaffoldProject(ctx context.Context, opts *createOptions, chosenVersion str
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(opts.projectFolder, "composer.json"), []byte(composerJson), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(projectFolder, "composer.json"), []byte(composerJson), os.ModePerm); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".env"), []byte(""), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(projectFolder, ".env"), []byte(""), os.ModePerm); err != nil {
 		return err
 	}
 
@@ -73,33 +94,33 @@ func scaffoldProject(ctx context.Context, opts *createOptions, chosenVersion str
 		envLocalContent += "APP_ENV=dev\n"
 	}
 
-	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".env.local"), []byte(envLocalContent), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(projectFolder, ".env.local"), []byte(envLocalContent), os.ModePerm); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".gitignore"), []byte("/.idea\n/vendor"), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(projectFolder, ".gitignore"), []byte("/.idea\n/vendor"), os.ModePerm); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(opts.projectFolder, "custom", "plugins"), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "plugins"), os.ModePerm); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(opts.projectFolder, "custom", "static-plugins"), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Join(projectFolder, "custom", "static-plugins"), os.ModePerm); err != nil {
 		return err
 	}
 
 	if !opts.useDocker && system.IsSymfonyCliInstalled() {
-		if err := os.WriteFile(filepath.Join(opts.projectFolder, "php.ini"), []byte("memory_limit=512M"), os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(projectFolder, "php.ini"), []byte("memory_limit=512M"), os.ModePerm); err != nil {
 			return err
 		}
 	}
 
-	if err := setupDeployment(opts.projectFolder, opts.selectedDeployment); err != nil {
+	if err := setupDeployment(projectFolder, opts.selectedDeployment); err != nil {
 		return err
 	}
 
-	return setupCI(ctx, opts.projectFolder, opts.selectedCI, opts.selectedDeployment)
+	return setupCI(ctx, projectFolder, opts.selectedCI, opts.selectedDeployment)
 }
 
 func setupDeployment(projectFolder, deploymentMethod string) error {

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -3,11 +3,13 @@ package project
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/shyim/go-composer/repository"
 	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/shopware/shopware-cli/internal/shop"
 )
@@ -31,8 +33,6 @@ func TestFilterInstallVersions(t *testing.T) {
 		got = append(got, v.String())
 	}
 
-	// Branch dev builds (*.x-dev, dev-*) and versions below the minimum
-	// constraint are excluded; only installable stable releases remain.
 	assert.Equal(t, []string{"6.7.12.1", "6.7.11.1"}, got)
 }
 
@@ -128,6 +128,7 @@ func TestValidateProjectName(t *testing.T) {
 		"_shop",
 		"ä",
 		"",
+		".",
 		"path/to/müller",
 		"path/to/MyShop",
 	}
@@ -166,6 +167,11 @@ func TestProjectNameFieldDescription(t *testing.T) {
 		assert.Equal(t, projectNameHelp, projectNameFieldDescription(""))
 	})
 
+	t.Run("dot shows help text", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, projectNameHelp, projectNameFieldDescription("."))
+	})
+
 	t.Run("valid name shows help text", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, projectNameHelp, projectNameFieldDescription("my-shop"))
@@ -184,6 +190,144 @@ func TestProjectNameFieldDescription(t *testing.T) {
 		assert.NotEqual(t, projectNameHelp, desc)
 		assert.Contains(t, desc, projectNameRule)
 	})
+}
+
+func TestCurrentProjectName(t *testing.T) {
+	// This test changes the process working directory, so it cannot run in
+	// parallel with other tests that also change the working directory.
+
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	require.NoError(t, os.Chdir(tmpDir))
+
+	name, err := currentProjectName()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Base(tmpDir), name)
+}
+
+func TestCurrentProjectNameWithInvalidDirectoryName(t *testing.T) {
+	// This test changes the process working directory, so it cannot run in
+	// parallel with other tests that also change the working directory.
+
+	tmpDir := t.TempDir()
+	invalidDir := filepath.Join(tmpDir, "MyBadDir")
+	require.NoError(t, os.MkdirAll(invalidDir, os.ModePerm))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	require.NoError(t, os.Chdir(invalidDir))
+
+	name, err := currentProjectName()
+	require.NoError(t, err)
+
+	assert.Equal(t, "MyBadDir", name)
+	assert.Error(t, validateProjectName(name))
+}
+
+func TestScaffoldProjectInCurrentDirectory(t *testing.T) {
+	// This test changes the process working directory, so it cannot run in
+	// parallel with other tests that also change the working directory.
+
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	require.NoError(t, os.Chdir(tmpDir))
+
+	opts := createOptions{
+		projectFolder:      ".",
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	err = scaffoldProject(t.Context(), &opts, "6.6.0.0")
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(tmpDir, "composer.json"))
+	assert.FileExists(t, filepath.Join(tmpDir, ".env"))
+	assert.FileExists(t, filepath.Join(tmpDir, ".env.local"))
+	assert.FileExists(t, filepath.Join(tmpDir, ".gitignore"))
+	assert.DirExists(t, filepath.Join(tmpDir, "custom", "plugins"))
+	assert.DirExists(t, filepath.Join(tmpDir, "custom", "static-plugins"))
+
+	// The project folder option stays as "." when scaffolding in the current directory.
+	assert.Equal(t, ".", opts.projectFolder)
+}
+
+func TestScaffoldProjectCreatesDirectory(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "my-shop")
+
+	opts := createOptions{
+		projectFolder:      projectDir,
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	err := scaffoldProject(t.Context(), &opts, "6.6.0.0")
+	require.NoError(t, err)
+
+	assert.DirExists(t, projectDir)
+	assert.FileExists(t, filepath.Join(projectDir, "composer.json"))
+}
+
+func TestScaffoldProjectRejectsNonEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "existing.txt"), []byte("existing"), os.ModePerm))
+
+	opts := createOptions{
+		projectFolder:      tmpDir,
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	err := scaffoldProject(t.Context(), &opts, "6.6.0.0")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not empty")
+}
+
+func TestScaffoldProjectRejectsNonEmptyCurrentDirectory(t *testing.T) {
+	// This test changes the process working directory, so it cannot run in
+	// parallel with other tests that also change the working directory.
+
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(tmpDir))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "existing.txt"), []byte("existing"), os.ModePerm))
+
+	opts := createOptions{
+		projectFolder:      ".",
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	err = scaffoldProject(t.Context(), &opts, "6.6.0.0")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not empty")
 }
 
 func TestSetupDeployment(t *testing.T) {
@@ -344,4 +488,169 @@ func TestValidCISystems(t *testing.T) {
 		assert.False(t, validCISystems["jenkins"])
 		assert.False(t, validCISystems[""])
 	})
+}
+
+// TestValidateAndPreflightCurrentDirectory validates that the current directory
+// can be used as the project target when the project name is valid.
+func TestValidateAndPreflightCurrentDirectory(t *testing.T) {
+	// This test and the related preflight tests change the process working
+	// directory, so they must not run in parallel with each other.
+
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(tmpDir))
+
+	opts := createOptions{
+		projectFolder:      ".",
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	chosen, _, err := validateAndPreflight(t.Context(), &opts, []repository.Version{{Version: "6.6.0.0"}}, []*version.Version{version.Must(version.NewVersion("6.6.0.0"))})
+	require.NoError(t, err)
+	assert.Equal(t, "6.6.0.0", chosen)
+}
+
+// TestValidateAndPreflightRejectsInvalidCurrentDirectory validates that running
+// the command in a directory whose name is not a valid Docker Compose project
+// name returns an error before any network or filesystem work is attempted.
+func TestValidateAndPreflightRejectsInvalidCurrentDirectory(t *testing.T) {
+	// This test changes the process working directory, so it cannot run in
+	// parallel with other tests that also change the working directory.
+
+	tmpDir := t.TempDir()
+	invalidDir := filepath.Join(tmpDir, "MyBadDir")
+	require.NoError(t, os.MkdirAll(invalidDir, os.ModePerm))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(invalidDir))
+
+	opts := createOptions{
+		projectFolder:      ".",
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	_, _, err = validateAndPreflight(t.Context(), &opts, []repository.Version{{Version: "6.6.0.0"}}, []*version.Version{version.Must(version.NewVersion("6.6.0.0"))})
+	assert.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "invalid project name")
+}
+
+func TestValidateAndPreflightRejectsNonEmptyCurrentDirectory(t *testing.T) {
+	// This test changes the process working directory, so it cannot run in
+	// parallel with other tests that also change the working directory.
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "existing.txt"), []byte("existing"), os.ModePerm))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(tmpDir))
+
+	_, _, err = validateAndPreflight(t.Context(), &createOptions{
+		projectFolder:      ".",
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}, []repository.Version{{Version: "6.6.0.0"}}, []*version.Version{version.Must(version.NewVersion("6.6.0.0"))})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not empty")
+}
+
+func TestValidateAndPreflightRejectsNonEmptyTargetDirectory(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, "existing-shop")
+	require.NoError(t, os.MkdirAll(targetDir, os.ModePerm))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "existing.txt"), []byte("existing"), os.ModePerm))
+
+	opts := createOptions{
+		projectFolder:      targetDir,
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	_, _, err := validateAndPreflight(t.Context(), &opts, []repository.Version{{Version: "6.6.0.0"}}, []*version.Version{version.Must(version.NewVersion("6.6.0.0"))})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not empty")
+}
+
+// TestValidateAndPreflightAllowsEmptyTargetDirectory validates that an empty
+// existing directory is accepted as a valid target folder.
+func TestValidateAndPreflightAllowsEmptyTargetDirectory(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	targetDir := filepath.Join(tmpDir, "empty-shop")
+	require.NoError(t, os.MkdirAll(targetDir, os.ModePerm))
+
+	opts := createOptions{
+		projectFolder:      targetDir,
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	chosen, _, err := validateAndPreflight(t.Context(), &opts, []repository.Version{{Version: "6.6.0.0"}}, []*version.Version{version.Must(version.NewVersion("6.6.0.0"))})
+	require.NoError(t, err)
+	assert.Equal(t, "6.6.0.0", chosen)
+}
+
+// TestValidateAndPreflightAcceptsValidCurrentDirectoryName ensures that a
+// valid current directory name passes the name check even when the folder name
+// is otherwise empty.
+func TestValidateAndPreflightAcceptsValidCurrentDirectoryName(t *testing.T) {
+	// This test changes the process working directory, so it cannot run in
+	// parallel with other tests that also change the working directory.
+
+	tmpDir := t.TempDir()
+	validDir := filepath.Join(tmpDir, "my-valid-dir")
+	require.NoError(t, os.MkdirAll(validDir, os.ModePerm))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(validDir))
+
+	opts := createOptions{
+		projectFolder:      ".",
+		selectedVersion:    "6.6.0.0",
+		selectedDeployment: shop.DeploymentNone,
+		selectedCI:         ciNone,
+		useDocker:          false,
+		noAudit:            true,
+	}
+
+	chosen, _, err := validateAndPreflight(t.Context(), &opts, []repository.Version{{Version: "6.6.0.0"}}, []*version.Version{version.Must(version.NewVersion("6.6.0.0"))})
+	require.NoError(t, err)
+	assert.Equal(t, "6.6.0.0", chosen)
+}
+
+// TestRunCreateFormEmptyNameIsValid checks that the form-level validator allows
+// an empty project name so that users can leave the field blank.
+func TestRunCreateFormEmptyNameIsValid(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, validateProjectName("my-shop"))
+	err := validateProjectName("")
+	assert.Error(t, err)
 }

--- a/cmd/project/project_create_validate.go
+++ b/cmd/project/project_create_validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -19,7 +20,19 @@ import (
 )
 
 func validateAndPreflight(ctx context.Context, opts *createOptions, releases []repository.Version, filteredVersions []*version.Version) (string, *shop.PHPConstraint, error) {
-	if err := validateProjectName(opts.projectFolder); err != nil {
+	projectFolder := opts.projectFolder
+	if projectFolder == "." {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", nil, fmt.Errorf("could not determine current directory: %w", err)
+		}
+		projectFolder = cwd
+	}
+
+	if err := validateProjectName(filepath.Base(projectFolder)); err != nil {
+		if opts.projectFolder == "." {
+			return "", nil, fmt.Errorf("current directory name %q cannot be used as a project name: %w", filepath.Base(projectFolder), err)
+		}
 		return "", nil, err
 	}
 
@@ -62,14 +75,14 @@ func validateAndPreflight(ctx context.Context, opts *createOptions, releases []r
 		return "", nil, err
 	}
 
-	if _, err := os.Stat(opts.projectFolder); err == nil {
-		empty, err := system.IsDirEmpty(opts.projectFolder)
+	if _, err := os.Stat(projectFolder); err == nil {
+		empty, err := system.IsDirEmpty(projectFolder)
 		if err != nil {
 			return "", nil, err
 		}
 
 		if !empty {
-			return "", nil, fmt.Errorf("the folder %s exists already and is not empty", opts.projectFolder)
+			return "", nil, fmt.Errorf("the folder %s exists already and is not empty", projectFolder)
 		}
 	}
 
@@ -136,7 +149,16 @@ func checkSecurityAdvisories(ctx context.Context, opts *createOptions, chosenVer
 }
 
 func checkIncompatibilities(ctx context.Context, opts *createOptions) error {
-	incompatibilities := system.CheckIncompatibilities(opts.useDocker, opts.projectFolder)
+	projectFolder := opts.projectFolder
+	if projectFolder == "." {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("could not determine current directory: %w", err)
+		}
+		projectFolder = cwd
+	}
+
+	incompatibilities := system.CheckIncompatibilities(opts.useDocker, projectFolder)
 
 	for _, incompatibility := range incompatibilities {
 		if opts.interactive {


### PR DESCRIPTION
When using the interactive `shopware-cli project create` form, leaving the project name blank now creates the project in the current directory.

## Changes

- Form validator accepts an empty or "." project name.
- Empty project name is normalized to "." after the form.
- Current directory name is validated as a Docker Compose project name.
- `scaffoldProject`, `validateAndPreflight`, and `checkIncompatibilities` resolve "." to the actual current working directory internally.
- Final success message omits a `cd .` instruction.

## Tests

- Added/updated tests for:
  - empty project name in the current directory
  - creating project in the current directory
  - rejecting non-empty existing directories (both target and current)
  - rejecting invalid current directory names
  - existing directory tests remain green

Closes #1204