### PR TITLE
Allow creating project in current directory by leaving name empty

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -21,7 +21,7 @@ const (
 	ciGitLab = "gitlab"
 
 	// projectNameHelp is the help text shown under the project name input.
-	projectNameHelp = "The name of the project directory to create"
+	projectNameHelp = "The name of the project directory to create (leave empty to use the current directory)"
 	// projectNameRule describes which characters are allowed in a project name.
 	// It is shared between the up-front validation error and the live form hint
 	// so both stay in sync.
@@ -39,7 +39,12 @@ var composeProjectNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 // validateProjectName ensures the project folder name can be used as a Docker
 // Compose project name. Only the final path element is relevant, as that is
 // what Docker Compose uses to derive the project name.
+// The special value "." (current directory) is always allowed.
 func validateProjectName(name string) error {
+	if name == "." {
+		return nil
+	}
+
 	base := filepath.Base(name)
 
 	if !composeProjectNameRegexp.MatchString(base) {
@@ -195,7 +200,7 @@ func parseCreateFlags(cmd *cobra.Command, args []string) createOptions {
 
 func applyNonInteractiveDefaults(opts *createOptions) error {
 	if opts.projectFolder == "" {
-		return fmt.Errorf("project name is required in non-interactive mode")
+		opts.projectFolder = "."
 	}
 	if opts.selectedVersion == "" {
 		opts.selectedVersion = versionLatest

--- a/cmd/project/project_create_form.go
+++ b/cmd/project/project_create_form.go
@@ -106,11 +106,11 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 					DescriptionFunc(func() string {
 						return projectNameFieldDescription(opts.projectFolder)
 					}, &opts.projectFolder).
-					Placeholder("my-shopware-project").
+					Placeholder("my-shopware-project (leave empty for current directory)").
 					Value(&opts.projectFolder).
 					Validate(func(s string) error {
 						if s == "" {
-							return fmt.Errorf("project name is required")
+							return nil
 						}
 						if err := validateProjectName(s); err != nil {
 							return err
@@ -238,6 +238,10 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 			opts.selectedVersion = versionLatest
 		}
 
+		if opts.projectFolder == "" {
+			opts.projectFolder = "."
+		}
+
 		if !cmd.PersistentFlags().Changed("docker") {
 			opts.useDocker = selectDocker == tui.Yes
 		}
@@ -254,7 +258,13 @@ func runCreateForm(cmd *cobra.Command, opts *createOptions, filteredVersions []*
 		fmt.Println()
 		fmt.Println(sectionStyle.Render("Summary"))
 		fmt.Println()
-		fmt.Printf("  %s %s\n", labelStyle.Render("Project name:"), opts.projectFolder)
+		projectDisplay := opts.projectFolder
+		if projectDisplay == "." {
+			if wd, err := os.Getwd(); err == nil {
+				projectDisplay = wd
+			}
+		}
+		fmt.Printf("  %s %s\n", labelStyle.Render("Project name:"), projectDisplay)
 		fmt.Printf("  %s %s\n", labelStyle.Render("Version:"), opts.selectedVersion)
 		fmt.Printf("  %s %s\n", labelStyle.Render("Deployment:"), opts.selectedDeployment)
 		fmt.Printf("  %s %s\n", labelStyle.Render("CI/CD:"), opts.selectedCI)

--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -65,8 +65,15 @@ func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *
 }
 
 func printCreateSummary(ctx context.Context, opts *createOptions) {
+	projectDisplay := opts.projectFolder
+	if projectDisplay == "." {
+		if wd, err := os.Getwd(); err == nil {
+			projectDisplay = wd
+		}
+	}
+
 	if !opts.interactive {
-		logging.FromContext(ctx).Infof("Project created successfully in %s", opts.projectFolder)
+		logging.FromContext(ctx).Infof("Project created successfully in %s", projectDisplay)
 		return
 	}
 
@@ -74,13 +81,17 @@ func printCreateSummary(ctx context.Context, opts *createOptions) {
 	sectionStyle := lipgloss.NewStyle().Bold(true).Underline(true)
 
 	fmt.Println()
-	fmt.Println(tui.GreenText.Render("✔ Setup complete in " + opts.projectFolder))
+	fmt.Println(tui.GreenText.Render("✔ Setup complete in " + projectDisplay))
 
 	if opts.useDocker {
 		fmt.Println()
 		fmt.Println(sectionStyle.Render("Next steps"))
 		fmt.Println()
-		fmt.Printf("  %s  %s\n", tui.GreenText.Render("Start developing:"), cmdStyle.Render(fmt.Sprintf("cd %s && shopware-cli project dev", opts.projectFolder)))
+		if opts.projectFolder == "." {
+			fmt.Printf("  %s  %s\n", tui.GreenText.Render("Start developing:"), cmdStyle.Render("shopware-cli project dev"))
+		} else {
+			fmt.Printf("  %s  %s\n", tui.GreenText.Render("Start developing:"), cmdStyle.Render(fmt.Sprintf("cd %s && shopware-cli project dev", opts.projectFolder)))
+		}
 		fmt.Println()
 		fmt.Println(sectionStyle.Render("Access your shop (after make setup)"))
 		fmt.Println()

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -103,6 +103,7 @@ func TestValidateProjectName(t *testing.T) {
 		"123shop",
 		"a",
 		"path/to/my-shop",
+		".",
 	}
 
 	for _, name := range validNames {
@@ -343,5 +344,33 @@ func TestValidCISystems(t *testing.T) {
 		t.Parallel()
 		assert.False(t, validCISystems["jenkins"])
 		assert.False(t, validCISystems[""])
+	})
+}
+
+func TestApplyNonInteractiveDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty project folder defaults to current directory", func(t *testing.T) {
+		t.Parallel()
+		opts := createOptions{}
+		err := applyNonInteractiveDefaults(&opts)
+		assert.NoError(t, err)
+		assert.Equal(t, ".", opts.projectFolder)
+	})
+
+	t.Run("dot project folder is kept", func(t *testing.T) {
+		t.Parallel()
+		opts := createOptions{projectFolder: "."}
+		err := applyNonInteractiveDefaults(&opts)
+		assert.NoError(t, err)
+		assert.Equal(t, ".", opts.projectFolder)
+	})
+
+	t.Run("named project folder is kept", func(t *testing.T) {
+		t.Parallel()
+		opts := createOptions{projectFolder: "my-shop"}
+		err := applyNonInteractiveDefaults(&opts)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-shop", opts.projectFolder)
 	})
 }


### PR DESCRIPTION
## What changed?

The `project create` command now accepts an empty project name, which creates the project in the current working directory instead of requiring a new subdirectory.

**Before:** Leaving the "Project Name" prompt empty showed a validation error ("project name is required"). Non-interactive mode also required a name argument.

**After:**
- Interactive: leaving the prompt empty defaults to `.` (current directory). The placeholder and help text hint at this.
- Non-interactive: omitting the name argument (or passing `.`) creates the project in the current directory.
- The summary and completion messages show the resolved absolute path instead of `.`.
- The "next steps" hint skips the `cd` step when the project was created in-place.

## Why?

When installing Shopware on a managed web server, the target directory is often already created by the server management software. Users previously had to provide a directory name even when they were already standing in the correct folder. This change lets them simply press Enter to scaffold the project in-place.

## How was this tested?

- Added `"."` to the valid project names in `TestValidateProjectName`
- Added `TestApplyNonInteractiveDefaults` covering empty, `"."`, and named folder inputs
- Ran `go test ./cmd/project/` and `go vet ./cmd/project/` - all pass

## Related issue or discussion

Fixes: #1204