### PR TITLE
fix(tui): show command failures when spinner exits

### DIFF
--- a/internal/tui/progress_spinner.go
+++ b/internal/tui/progress_spinner.go
@@ -2,6 +2,9 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -42,7 +45,21 @@ func RunSpinnerWithLogs(ctx context.Context, title string, cmd *exec.Cmd) error 
 		return context.Canceled
 	}
 
+	if model.err != nil {
+		// A tea.Quit message can stop the program before its final frame has
+		// reached the terminal. Print failures outside the renderer so command
+		// output is always available to the user.
+		writeFailureOutput(os.Stderr, title, model.err, model.logWriter.GetLastLines(12))
+	}
+
 	return model.err
+}
+
+func writeFailureOutput(w io.Writer, title string, err error, lines []string) {
+	_, _ = fmt.Fprintf(w, "\n✗ %s\n\n  Command failed: %v\n", title, err)
+	for _, line := range lines {
+		_, _ = fmt.Fprintf(w, "  %s\n", line)
+	}
 }
 
 type logWriter struct {

--- a/internal/tui/progress_spinner.go
+++ b/internal/tui/progress_spinner.go
@@ -16,6 +16,14 @@ import (
 
 // RunSpinnerWithLogs executes the given command while displaying a spinner and allowing the user to toggle logs with Ctrl+L.
 func RunSpinnerWithLogs(ctx context.Context, title string, cmd *exec.Cmd) error {
+	return runSpinnerWithLogs(ctx, title, cmd, os.Stderr, func(ctx context.Context, model tea.Model) error {
+		p := tea.NewProgram(model, tea.WithContext(ctx))
+		_, err := p.Run()
+		return err
+	})
+}
+
+func runSpinnerWithLogs(ctx context.Context, title string, cmd *exec.Cmd, output io.Writer, runProgram func(context.Context, tea.Model) error) error {
 	cmdCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -36,8 +44,7 @@ func RunSpinnerWithLogs(ctx context.Context, title string, cmd *exec.Cmd) error 
 		cancel:    cancel,
 	}
 
-	p := tea.NewProgram(model, tea.WithContext(cmdCtx))
-	if _, err := p.Run(); err != nil {
+	if err := runProgram(cmdCtx, model); err != nil {
 		return err
 	}
 
@@ -49,7 +56,7 @@ func RunSpinnerWithLogs(ctx context.Context, title string, cmd *exec.Cmd) error 
 		// A tea.Quit message can stop the program before its final frame has
 		// reached the terminal. Print failures outside the renderer so command
 		// output is always available to the user.
-		writeFailureOutput(os.Stderr, title, model.err, model.logWriter.GetLastLines(12))
+		writeFailureOutput(output, title, model.err, model.logWriter.GetLastLines(12))
 	}
 
 	return model.err

--- a/internal/tui/progress_spinner_test.go
+++ b/internal/tui/progress_spinner_test.go
@@ -39,7 +39,7 @@ func TestRunSpinnerWithLogsWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := RunSpinnerWithLogs(ctx, "Installing dependencies", exec.Command("false"))
+	err := RunSpinnerWithLogs(ctx, "Installing dependencies", exec.CommandContext(ctx, "false"))
 
 	assert.ErrorContains(t, err, "error opening TTY")
 }
@@ -47,14 +47,14 @@ func TestRunSpinnerWithLogsWithCancelledContext(t *testing.T) {
 func TestRunSpinnerWithLogs(t *testing.T) {
 	t.Run("returns program errors", func(t *testing.T) {
 		wantErr := errors.New("renderer failed")
-		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &bytes.Buffer{}, func(context.Context, tea.Model) error {
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.CommandContext(t.Context(), "false"), &bytes.Buffer{}, func(context.Context, tea.Model) error {
 			return wantErr
 		})
 		assert.ErrorIs(t, err, wantErr)
 	})
 
 	t.Run("returns cancellation", func(t *testing.T) {
-		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &bytes.Buffer{}, func(_ context.Context, model tea.Model) error {
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.CommandContext(t.Context(), "false"), &bytes.Buffer{}, func(_ context.Context, model tea.Model) error {
 			model.(*installProgressModel).cancelled = true
 			return nil
 		})
@@ -64,7 +64,7 @@ func TestRunSpinnerWithLogs(t *testing.T) {
 	t.Run("prints command failures", func(t *testing.T) {
 		var output bytes.Buffer
 		wantErr := errors.New("exit status 1")
-		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &output, func(_ context.Context, model tea.Model) error {
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.CommandContext(t.Context(), "false"), &output, func(_ context.Context, model tea.Model) error {
 			progress := model.(*installProgressModel)
 			_, err := progress.logWriter.Write([]byte("composer error\n"))
 			require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestRunSpinnerWithLogs(t *testing.T) {
 	})
 
 	t.Run("returns success", func(t *testing.T) {
-		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &bytes.Buffer{}, func(context.Context, tea.Model) error {
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.CommandContext(t.Context(), "false"), &bytes.Buffer{}, func(context.Context, tea.Model) error {
 			return nil
 		})
 		assert.NoError(t, err)
@@ -105,7 +105,7 @@ func TestLogWriterStoresAndTrimsLines(t *testing.T) {
 }
 
 func TestInstallProgressModelInitRunsCommand(t *testing.T) {
-	model := newProgressModel(exec.Command("false"))
+	model := newProgressModel(exec.CommandContext(t.Context(), "false"))
 
 	batch, ok := model.Init()().(tea.BatchMsg)
 	require.True(t, ok)
@@ -119,7 +119,7 @@ func TestInstallProgressModelInitRunsCommand(t *testing.T) {
 }
 
 func TestInstallProgressModelUpdate(t *testing.T) {
-	model := newProgressModel(exec.Command("false"))
+	model := newProgressModel(exec.CommandContext(t.Context(), "false"))
 
 	updated, cmd := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	assert.Same(t, model, updated)
@@ -148,7 +148,7 @@ func TestInstallProgressModelUpdate(t *testing.T) {
 
 func TestInstallProgressModelCancels(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
-	model := newProgressModel(exec.Command("false"))
+	model := newProgressModel(exec.CommandContext(t.Context(), "false"))
 	model.cancel = cancel
 
 	_, cmd := model.Update(tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl}))

--- a/internal/tui/progress_spinner_test.go
+++ b/internal/tui/progress_spinner_test.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteFailureOutput(t *testing.T) {
+	var output bytes.Buffer
+
+	writeFailureOutput(
+		&output,
+		"Installing dependencies",
+		errors.New("exit status 1"),
+		[]string{"Loading composer repositories", "Your requirements could not be resolved."},
+	)
+
+	assert.Equal(t, "\n✗ Installing dependencies\n\n  Command failed: exit status 1\n  Loading composer repositories\n  Your requirements could not be resolved.\n", output.String())
+}
+
+func TestWriteFailureOutputWithoutCommandLogs(t *testing.T) {
+	var output bytes.Buffer
+
+	writeFailureOutput(&output, "Installing dependencies", errors.New("signal: killed"), nil)
+
+	assert.Equal(t, "\n✗ Installing dependencies\n\n  Command failed: signal: killed\n", output.String())
+}

--- a/internal/tui/progress_spinner_test.go
+++ b/internal/tui/progress_spinner_test.go
@@ -2,10 +2,16 @@ package tui
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"os/exec"
+	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteFailureOutput(t *testing.T) {
@@ -27,4 +33,182 @@ func TestWriteFailureOutputWithoutCommandLogs(t *testing.T) {
 	writeFailureOutput(&output, "Installing dependencies", errors.New("signal: killed"), nil)
 
 	assert.Equal(t, "\n✗ Installing dependencies\n\n  Command failed: signal: killed\n", output.String())
+}
+
+func TestRunSpinnerWithLogsWithCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := RunSpinnerWithLogs(ctx, "Installing dependencies", exec.Command("false"))
+
+	assert.ErrorContains(t, err, "error opening TTY")
+}
+
+func TestRunSpinnerWithLogs(t *testing.T) {
+	t.Run("returns program errors", func(t *testing.T) {
+		wantErr := errors.New("renderer failed")
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &bytes.Buffer{}, func(context.Context, tea.Model) error {
+			return wantErr
+		})
+		assert.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("returns cancellation", func(t *testing.T) {
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &bytes.Buffer{}, func(_ context.Context, model tea.Model) error {
+			model.(*installProgressModel).cancelled = true
+			return nil
+		})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("prints command failures", func(t *testing.T) {
+		var output bytes.Buffer
+		wantErr := errors.New("exit status 1")
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &output, func(_ context.Context, model tea.Model) error {
+			progress := model.(*installProgressModel)
+			_, err := progress.logWriter.Write([]byte("composer error\n"))
+			require.NoError(t, err)
+			progress.err = wantErr
+			return nil
+		})
+		assert.ErrorIs(t, err, wantErr)
+		assert.Contains(t, output.String(), "composer error")
+	})
+
+	t.Run("returns success", func(t *testing.T) {
+		err := runSpinnerWithLogs(t.Context(), "Installing dependencies", exec.Command("false"), &bytes.Buffer{}, func(context.Context, tea.Model) error {
+			return nil
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func TestLogWriterStoresAndTrimsLines(t *testing.T) {
+	var writer logWriter
+
+	n, err := writer.Write([]byte("first\r\nsecond"))
+	require.NoError(t, err)
+	assert.Equal(t, len("first\r\nsecond"), n)
+	assert.Equal(t, []string{"first", "second"}, writer.GetLastLines(10))
+
+	for i := range 101 {
+		_, err = writer.Write([]byte(strings.Repeat("x", i%3+1) + "\n"))
+		require.NoError(t, err)
+	}
+
+	lines := writer.GetLastLines(100)
+	assert.Len(t, lines, 100)
+	assert.Equal(t, "xx", lines[0])
+	assert.Equal(t, "xx", lines[len(lines)-1])
+	assert.Len(t, writer.GetLastLines(101), 100)
+	assert.Equal(t, []string{"xx"}, writer.GetLastLines(1))
+}
+
+func TestInstallProgressModelInitRunsCommand(t *testing.T) {
+	model := newProgressModel(exec.Command("false"))
+
+	batch, ok := model.Init()().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 2)
+	_, ok = batch[0]().(spinner.TickMsg)
+	assert.True(t, ok)
+
+	finished, ok := batch[1]().(installFinishedMsg)
+	require.True(t, ok)
+	assert.Error(t, finished.err)
+}
+
+func TestInstallProgressModelUpdate(t *testing.T) {
+	model := newProgressModel(exec.Command("false"))
+
+	updated, cmd := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	assert.Same(t, model, updated)
+	assert.Nil(t, cmd)
+	assert.Equal(t, 80, model.width)
+	assert.Equal(t, 24, model.height)
+
+	_, cmd = model.Update(tea.KeyPressMsg(tea.Key{Code: 'l', Mod: tea.ModCtrl}))
+	assert.Nil(t, cmd)
+	assert.True(t, model.showLogs)
+
+	_, cmd = model.Update(tea.KeyPressMsg(tea.Key{Code: 'x'}))
+	assert.Nil(t, cmd)
+
+	tick := model.spinner.Tick()
+	_, cmd = model.Update(tick)
+	assert.NotNil(t, cmd)
+
+	wantErr := errors.New("install failed")
+	_, cmd = model.Update(installFinishedMsg{err: wantErr})
+	assert.True(t, model.done)
+	assert.ErrorIs(t, model.err, wantErr)
+	_, ok := cmd().(tea.QuitMsg)
+	assert.True(t, ok)
+}
+
+func TestInstallProgressModelCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	model := newProgressModel(exec.Command("false"))
+	model.cancel = cancel
+
+	_, cmd := model.Update(tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl}))
+	assert.True(t, model.cancelled)
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	_, ok := cmd().(tea.QuitMsg)
+	assert.True(t, ok)
+}
+
+func TestInstallProgressModelView(t *testing.T) {
+	t.Run("successful completion", func(t *testing.T) {
+		model := newProgressModel(nil)
+		model.done = true
+		view := model.View().Content
+		assert.Contains(t, view, "✔")
+		assert.Contains(t, view, "Installing dependencies")
+	})
+
+	t.Run("failed completion", func(t *testing.T) {
+		model := newProgressModel(nil)
+		_, err := model.logWriter.Write([]byte("composer error\n"))
+		require.NoError(t, err)
+		model.done = true
+		model.err = errors.New("exit status 1")
+		view := model.View().Content
+		assert.Contains(t, view, "✗")
+		assert.Contains(t, view, "Installing dependencies")
+		assert.Contains(t, view, "composer error")
+	})
+
+	t.Run("running without logs", func(t *testing.T) {
+		model := newProgressModel(nil)
+		assert.Contains(t, model.View().Content, "Ctrl+L to see live log")
+	})
+
+	t.Run("running with empty logs", func(t *testing.T) {
+		model := newProgressModel(nil)
+		model.showLogs = true
+		assert.Contains(t, model.View().Content, "Waiting for output...")
+	})
+
+	t.Run("running with logs in a wide terminal", func(t *testing.T) {
+		model := newProgressModel(nil)
+		_, err := model.logWriter.Write([]byte("first\nsecond\n"))
+		require.NoError(t, err)
+		model.showLogs = true
+		model.width = 200
+		view := model.View().Content
+		assert.Contains(t, view, "Ctrl+L to hide live log")
+		assert.Contains(t, view, "first")
+		assert.Contains(t, view, "second")
+	})
+}
+
+func newProgressModel(cmd *exec.Cmd) *installProgressModel {
+	return &installProgressModel{
+		spinner:   spinner.New(),
+		logWriter: &logWriter{},
+		title:     "Installing dependencies",
+		cmd:       cmd,
+		cancel:    func() {},
+	}
 }


### PR DESCRIPTION
## Summary

- Print command failure details outside the spinner renderer.
- Include the command error and the last 12 log lines on stderr.
- Add unit tests for failures with and without command logs.

## Testing

- Added unit tests covering failure output formatting.