### PR TITLE
docs: add RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,31 @@
+# Releasing
+
+Releases are automated by GoReleaser in GitHub Actions. Pushing a version tag
+starts the release workflow; do not run GoReleaser or create the GitHub release
+manually.
+
+## Create a release
+
+1. Ensure the commit to release is on the intended branch and all required CI
+   checks have passed.
+2. Create an annotated [semantic version](https://semver.org/) tag, for example:
+
+   ```sh
+   git tag -a v1.2.3 -m "v1.2.3"
+   ```
+
+   Use a prerelease suffix such as `v1.2.3-rc.1` for prereleases.
+3. Push only the new tag:
+
+   ```sh
+   git push origin v1.2.3
+   ```
+
+The tag push triggers the `Release` workflow. It runs GoReleaser, which creates
+the GitHub release and publishes the configured artifacts and package updates.
+Watch the workflow to completion and verify the resulting GitHub release.
+
+## If a release fails
+
+Investigate and fix the workflow failure before retrying. Do not move or reuse
+a published version tag; create a new version tag for a corrected release.


### PR DESCRIPTION
### Motivation
- Provide a concise canonical guide that explains releases are automated by GoReleaser via the GitHub Actions `Release` workflow and that maintainers should drive releases by pushing version tags rather than creating releases manually.

### Description
- Add `RELEASING.md` which documents the tag-driven release flow, how to create annotated semantic-version and prerelease tags, that pushing the tag triggers the `Release` workflow (which runs GoReleaser and publishes artifacts), and advice for handling failed releases.

### Testing
- Ran `git diff --cached --check` and verified the working tree/status to ensure `RELEASING.md` was added and there are no staged issues; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e12ed275483289c0db2b815c7a04c)