### PR TITLE
fix(extension): count english description length in characters instead of bytes

### DIFF
--- a/internal/extension/validator.go
+++ b/internal/extension/validator.go
@@ -320,11 +320,11 @@ func runDefaultValidate(ext Extension, check validation.Check) {
 			})
 		}
 
-		if len(metaData.Description.English) < 150 || len(metaData.Description.English) > 185 {
+		if len([]rune(metaData.Description.English)) < 150 || len([]rune(metaData.Description.English)) > 185 {
 			check.AddResult(validation.CheckResult{
 				Path:       rootFile,
 				Identifier: "metadata.description",
-				Message:    fmt.Sprintf("in composer.json, the english description with length of %d should have a length from 150 up to 185 characters.", len(metaData.Description.English)),
+				Message:    fmt.Sprintf("in composer.json, the english description with length of %d should have a length from 150 up to 185 characters.", len([]rune(metaData.Description.English))),
 				Severity:   validation.SeverityError,
 			})
 		}

--- a/internal/extension/validator.go
+++ b/internal/extension/validator.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/shyim/go-spdx"
 
@@ -273,7 +274,7 @@ func runDefaultValidate(ext Extension, check validation.Check) {
 	})
 
 	metaData := ext.GetMetaData()
-	if len([]rune(metaData.Label.German)) == 0 {
+	if len(metaData.Label.German) == 0 {
 		check.AddResult(validation.CheckResult{
 			Path:       rootFile,
 			Identifier: "metadata.label",
@@ -293,7 +294,10 @@ func runDefaultValidate(ext Extension, check validation.Check) {
 
 	// Skip description validation for ShopwareBundle
 	if ext.GetType() != TypeShopwareBundle {
-		if len([]rune(metaData.Description.German)) == 0 {
+		germanDescriptionLength := utf8.RuneCountInString(metaData.Description.German)
+		englishDescriptionLength := utf8.RuneCountInString(metaData.Description.English)
+
+		if germanDescriptionLength == 0 {
 			check.AddResult(validation.CheckResult{
 				Path:       rootFile,
 				Identifier: "metadata.description",
@@ -302,7 +306,7 @@ func runDefaultValidate(ext Extension, check validation.Check) {
 			})
 		}
 
-		if len(metaData.Description.English) == 0 {
+		if englishDescriptionLength == 0 {
 			check.AddResult(validation.CheckResult{
 				Path:       rootFile,
 				Identifier: "metadata.description",
@@ -311,20 +315,20 @@ func runDefaultValidate(ext Extension, check validation.Check) {
 			})
 		}
 
-		if len([]rune(metaData.Description.German)) < 150 || len([]rune(metaData.Description.German)) > 185 {
+		if germanDescriptionLength < 150 || germanDescriptionLength > 185 {
 			check.AddResult(validation.CheckResult{
 				Path:       rootFile,
 				Identifier: "metadata.description",
-				Message:    fmt.Sprintf("in composer.json, the german description with length of %d should have a length from 150 up to 185 characters.", len([]rune(metaData.Description.German))),
+				Message:    fmt.Sprintf("in composer.json, the german description with length of %d should have a length from 150 up to 185 characters.", germanDescriptionLength),
 				Severity:   validation.SeverityError,
 			})
 		}
 
-		if len([]rune(metaData.Description.English)) < 150 || len([]rune(metaData.Description.English)) > 185 {
+		if englishDescriptionLength < 150 || englishDescriptionLength > 185 {
 			check.AddResult(validation.CheckResult{
 				Path:       rootFile,
 				Identifier: "metadata.description",
-				Message:    fmt.Sprintf("in composer.json, the english description with length of %d should have a length from 150 up to 185 characters.", len([]rune(metaData.Description.English))),
+				Message:    fmt.Sprintf("in composer.json, the english description with length of %d should have a length from 150 up to 185 characters.", englishDescriptionLength),
 				Severity:   validation.SeverityError,
 			})
 		}

--- a/internal/extension/validator_test.go
+++ b/internal/extension/validator_test.go
@@ -3,6 +3,7 @@ package extension
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,6 +77,27 @@ func TestLicenseValidate(t *testing.T) {
 	runDefaultValidate(app, check)
 
 	assert.False(t, len(check.Results) > 0)
+}
+
+func TestDescriptionLengthCountedInCharacters(t *testing.T) {
+	app := getAppForValidation()
+	multibyte := strings.Repeat("ä", 160)
+	app.manifest.Meta.Description = TranslatableString{
+		struct {
+			Value string "xml:\",chardata\""
+			Lang  string "xml:\"lang,attr,omitempty\""
+		}{multibyte, "de-DE"},
+		struct {
+			Value string "xml:\",chardata\""
+			Lang  string "xml:\"lang,attr,omitempty\""
+		}{multibyte, "en-GB"},
+	}
+
+	check := &testCheck{}
+
+	runDefaultValidate(app, check)
+
+	assert.Empty(t, check.Results)
 }
 
 func TestIgnores(t *testing.T) {

--- a/internal/extension/validator_test.go
+++ b/internal/extension/validator_test.go
@@ -100,6 +100,31 @@ func TestDescriptionLengthCountedInCharacters(t *testing.T) {
 	assert.Empty(t, check.Results)
 }
 
+func TestDescriptionTooLongReportsCharacterCount(t *testing.T) {
+	app := getAppForValidation()
+	multibyte := strings.Repeat("ä", 200)
+	app.manifest.Meta.Description = TranslatableString{
+		struct {
+			Value string "xml:\",chardata\""
+			Lang  string "xml:\"lang,attr,omitempty\""
+		}{multibyte, "de-DE"},
+		struct {
+			Value string "xml:\",chardata\""
+			Lang  string "xml:\"lang,attr,omitempty\""
+		}{multibyte, "en-GB"},
+	}
+
+	check := &testCheck{}
+
+	runDefaultValidate(app, check)
+
+	assert.Len(t, check.Results, 2)
+	for _, result := range check.Results {
+		assert.Equal(t, "metadata.description", result.Identifier)
+		assert.Contains(t, result.Message, "length of 200")
+	}
+}
+
 func TestIgnores(t *testing.T) {
 	check := &testCheck{}
 


### PR DESCRIPTION
## What changed?

`extension validate` measured the English description's 150-185 length limit in UTF-8 **bytes**, while the German description was correctly measured in **characters** (`len([]rune(...))`). The English check and its error message now use rune-based counting, identical to the German check.

Before (a 160-character description containing multibyte characters):

```
  0  error    [metadata.description]  in composer.json, the english description with length of 320 should have a length from 150 up to 185 characters.
```

After: the same description validates cleanly.

## Why?

English descriptions containing any multibyte character (typographic quotes, currency signs like `€`, symbols like `™`, accented or German names) were falsely rejected even when within 150-185 characters, with an error reporting a length that matches no character counter the user can check. The same description passed as German. Near the lower bound, too-short multibyte descriptions could wrongly pass. The Shopware Account UI accepts these descriptions, so the CLI was stricter than the store itself.

## How was this tested?

- Added regression test `TestDescriptionLengthCountedInCharacters`: a 160-character/320-byte description in both languages must validate cleanly. It fails on the previous code (reporting "length of 320") and passes with the fix.
- Full `go test ./...` passes.
- End-to-end A/B check: `extension validate` on a fixture plugin with the multibyte description, run against a binary built before and after the fix (output above).