### PR TITLE
Add /.shopware-cli to .gitignore of new projects

### DIFF
--- a/cmd/project/project_create_scaffold.go
+++ b/cmd/project/project_create_scaffold.go
@@ -77,7 +77,7 @@ func scaffoldProject(ctx context.Context, opts *createOptions, chosenVersion str
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".gitignore"), []byte("/.idea\n/vendor"), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(opts.projectFolder, ".gitignore"), []byte("/.idea\n/.shopware-cli\n/vendor"), os.ModePerm); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What changed?
Added `/.shopware-cli` to the `.gitignore` file that is generated for new projects created via `shopware-cli project create`. This prevents the local `.shopware-cli` configuration directory from being committed into version control.

## Why?
The `.shopware-cli` directory contains local CLI configuration that should not be shared across environments. Ignoring it by default in newly scaffolded projects avoids accidental commits of local-only settings.

## How was this tested?
- Existing tests in `cmd/project/` continue to pass (`go test ./cmd/project/`).

## Related issue or discussion
N/A

<!--
Before opening this PR:
- Small fixes (typos, docs) can go straight to a PR.
- Larger changes (new features/commands/subcommands, changes to existing
  command behavior) should be discussed in an issue first.
- Run `go test ./...` and `golangci-lint run ./...` locally.
- Add or update tests for bug fixes and new behavior.
- Keep the PR focused — smaller PRs are easier to review and merge.
-->