### PR TITLE
fix: serve content-addressed administration watch bundles

### DIFF
--- a/cmd/extension/extension_admin_watch.go
+++ b/cmd/extension/extension_admin_watch.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -310,7 +309,7 @@ var extensionAdminWatchCmd = &cobra.Command{
 				}
 
 				for _, ext := range esbuildInstances {
-					entrypoints, err := ext.currentEntrypoints()
+					entrypoints, err := esbuild.RebuildEntrypoints(ext.context)
 					if err != nil {
 						logging.FromContext(cmd.Context()).Errorf("cannot rebuild administration bundle for %s: %s", ext.assetName, err)
 						http.Error(w, "cannot rebuild administration bundle", http.StatusServiceUnavailable)
@@ -416,81 +415,6 @@ type adminWatchExtension struct {
 	context     api.BuildContext
 	watchServer api.ServeResult
 	staticDir   string
-}
-
-type adminWatchMetafile struct {
-	Outputs map[string]adminWatchMetafileOutput `json:"outputs"`
-}
-
-type adminWatchMetafileOutput struct {
-	EntryPoint string `json:"entryPoint"`
-	CSSBundle  string `json:"cssBundle"`
-}
-
-type adminWatchEntrypoints struct {
-	JavaScript string
-	CSS        string
-}
-
-func (e adminWatchExtension) currentEntrypoints() (adminWatchEntrypoints, error) {
-	result := e.context.Rebuild()
-
-	if len(result.Errors) > 0 {
-		return adminWatchEntrypoints{}, fmt.Errorf("%s", result.Errors[0].Text)
-	}
-
-	return findAdminWatchEntrypoints(result)
-}
-
-func findAdminWatchEntrypoints(result api.BuildResult) (adminWatchEntrypoints, error) {
-	var metafile adminWatchMetafile
-	if err := json.Unmarshal([]byte(result.Metafile), &metafile); err != nil {
-		return adminWatchEntrypoints{}, fmt.Errorf("cannot decode esbuild metafile: %w", err)
-	}
-
-	for candidatePath, candidate := range metafile.Outputs {
-		if candidate.EntryPoint == "" || path.Ext(candidatePath) != ".js" {
-			continue
-		}
-
-		javaScriptPath, err := adminWatchServePath(candidatePath)
-		if err != nil {
-			return adminWatchEntrypoints{}, err
-		}
-
-		cssPath := ""
-		if candidate.CSSBundle != "" {
-			cssPath, err = adminWatchServePath(candidate.CSSBundle)
-			if err != nil {
-				return adminWatchEntrypoints{}, err
-			}
-		}
-
-		return adminWatchEntrypoints{
-			JavaScript: javaScriptPath,
-			CSS:        cssPath,
-		}, nil
-	}
-
-	return adminWatchEntrypoints{}, fmt.Errorf("esbuild emitted no JavaScript entrypoint")
-}
-
-func adminWatchServePath(outputPath string) (string, error) {
-	cleanOutputPath := filepath.Clean(filepath.FromSlash(outputPath))
-
-	if filepath.IsAbs(cleanOutputPath) {
-		relativePath, err := filepath.Rel(".", cleanOutputPath)
-		if err != nil {
-			return "", fmt.Errorf("cannot resolve esbuild output path %q: %w", outputPath, err)
-		}
-		cleanOutputPath = relativePath
-	}
-
-	if cleanOutputPath == ".." || strings.HasPrefix(cleanOutputPath, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("esbuild output path %q is outside the serve directory", outputPath)
-	}
-
-	return "/" + strings.TrimPrefix(filepath.ToSlash(cleanOutputPath), "/"), nil
 }
 
 func adminWatchOutputURL(browserURL *url.URL, assetName, outputPath string) string {

--- a/cmd/extension/extension_admin_watch.go
+++ b/cmd/extension/extension_admin_watch.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -309,9 +310,21 @@ var extensionAdminWatchCmd = &cobra.Command{
 				}
 
 				for _, ext := range esbuildInstances {
+					entrypoints, err := ext.currentEntrypoints()
+					if err != nil {
+						logging.FromContext(cmd.Context()).Errorf("cannot rebuild administration bundle for %s: %s", ext.assetName, err)
+						http.Error(w, "cannot rebuild administration bundle", http.StatusServiceUnavailable)
+						return
+					}
+
+					css := []string{}
+					if entrypoints.CSS != "" {
+						css = append(css, adminWatchOutputURL(browserUrl, ext.assetName, entrypoints.CSS))
+					}
+
 					bundleInfo.Bundles[ext.name] = adminBundlesInfoAsset{
-						Css:        []string{fmt.Sprintf("%s/.shopware-cli/%s/extension.css", browserUrl.String(), ext.assetName)},
-						Js:         []string{fmt.Sprintf("%s/.shopware-cli/%s/extension.js", browserUrl.String(), ext.assetName)},
+						Css:        css,
+						Js:         []string{adminWatchOutputURL(browserUrl, ext.assetName, entrypoints.JavaScript)},
 						LiveReload: true,
 						Name:       ext.assetName,
 					}
@@ -403,4 +416,88 @@ type adminWatchExtension struct {
 	context     api.BuildContext
 	watchServer api.ServeResult
 	staticDir   string
+}
+
+type adminWatchMetafile struct {
+	Outputs map[string]adminWatchMetafileOutput `json:"outputs"`
+}
+
+type adminWatchMetafileOutput struct {
+	EntryPoint string `json:"entryPoint"`
+	CSSBundle  string `json:"cssBundle"`
+}
+
+type adminWatchEntrypoints struct {
+	JavaScript string
+	CSS        string
+}
+
+func (e adminWatchExtension) currentEntrypoints() (adminWatchEntrypoints, error) {
+	result := e.context.Rebuild()
+
+	if len(result.Errors) > 0 {
+		return adminWatchEntrypoints{}, fmt.Errorf("%s", result.Errors[0].Text)
+	}
+
+	return findAdminWatchEntrypoints(result)
+}
+
+func findAdminWatchEntrypoints(result api.BuildResult) (adminWatchEntrypoints, error) {
+	var metafile adminWatchMetafile
+	if err := json.Unmarshal([]byte(result.Metafile), &metafile); err != nil {
+		return adminWatchEntrypoints{}, fmt.Errorf("cannot decode esbuild metafile: %w", err)
+	}
+
+	for candidatePath, candidate := range metafile.Outputs {
+		if candidate.EntryPoint == "" || path.Ext(candidatePath) != ".js" {
+			continue
+		}
+
+		javaScriptPath, err := adminWatchServePath(candidatePath)
+		if err != nil {
+			return adminWatchEntrypoints{}, err
+		}
+
+		cssPath := ""
+		if candidate.CSSBundle != "" {
+			cssPath, err = adminWatchServePath(candidate.CSSBundle)
+			if err != nil {
+				return adminWatchEntrypoints{}, err
+			}
+		}
+
+		return adminWatchEntrypoints{
+			JavaScript: javaScriptPath,
+			CSS:        cssPath,
+		}, nil
+	}
+
+	return adminWatchEntrypoints{}, fmt.Errorf("esbuild emitted no JavaScript entrypoint")
+}
+
+func adminWatchServePath(outputPath string) (string, error) {
+	cleanOutputPath := filepath.Clean(filepath.FromSlash(outputPath))
+
+	if filepath.IsAbs(cleanOutputPath) {
+		relativePath, err := filepath.Rel(".", cleanOutputPath)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve esbuild output path %q: %w", outputPath, err)
+		}
+		cleanOutputPath = relativePath
+	}
+
+	if cleanOutputPath == ".." || strings.HasPrefix(cleanOutputPath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("esbuild output path %q is outside the serve directory", outputPath)
+	}
+
+	return "/" + strings.TrimPrefix(filepath.ToSlash(cleanOutputPath), "/"), nil
+}
+
+func adminWatchOutputURL(browserURL *url.URL, assetName, outputPath string) string {
+	return fmt.Sprintf(
+		"%s/.shopware-cli/%s/%s",
+		strings.TrimSuffix(browserURL.String(), "/"),
+		assetName,
+		strings.TrimPrefix(outputPath, "/"),
+	)
 }

--- a/cmd/extension/extension_admin_watch_test.go
+++ b/cmd/extension/extension_admin_watch_test.go
@@ -1,0 +1,129 @@
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/evanw/esbuild/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shopware/shopware-cli/internal/esbuild"
+	"github.com/shopware/shopware-cli/logging"
+)
+
+func TestCurrentEntrypointsReturnsContentAddressedPaths(t *testing.T) {
+	dir := t.TempDir()
+	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
+	require.NoError(t, os.MkdirAll(adminDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import './style.css'; console.log('served-marker')"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "style.css"), []byte(".served-marker { color: red; }"), 0o644))
+
+	ctx := logging.WithLogger(t.Context(), logging.NewLogger(false))
+	options := esbuild.NewAssetCompileOptionsAdmin("MyPlugin", dir)
+	options.ProductionMode = false
+	options.DisableSass = true
+
+	esbuildContext, err := esbuild.Context(ctx, options)
+	require.Nil(t, err)
+	t.Cleanup(esbuildContext.Dispose)
+
+	watchServer, serveErr := esbuildContext.Serve(api.ServeOptions{Host: "127.0.0.1"})
+	require.NoError(t, serveErr)
+
+	ext := adminWatchExtension{
+		assetName: "my-plugin",
+		context:   esbuildContext,
+	}
+
+	entrypoints, entrypointErr := ext.currentEntrypoints()
+
+	require.NoError(t, entrypointErr)
+	assert.Regexp(t, `^/my-plugin-[A-Z0-9]+\.js$`, entrypoints.JavaScript)
+	assert.Regexp(t, `^/my-plugin-[A-Z0-9]+\.css$`, entrypoints.CSS)
+	assert.NotEqual(t, "/extension.js", entrypoints.JavaScript)
+	assert.NotEqual(t, "/extension.css", entrypoints.CSS)
+
+	for _, test := range []struct {
+		name   string
+		path   string
+		marker string
+	}{
+		{name: "javascript", path: entrypoints.JavaScript, marker: "served-marker"},
+		{name: "css", path: entrypoints.CSS, marker: ".served-marker"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := http.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				fmt.Sprintf("http://%s:%d%s", watchServer.Hosts[0], watchServer.Port, test.path),
+				nil,
+			)
+			require.NoError(t, err)
+
+			response, err := http.DefaultClient.Do(request)
+			require.NoError(t, err)
+
+			body, readErr := io.ReadAll(response.Body)
+			closeErr := response.Body.Close()
+			require.NoError(t, readErr)
+			require.NoError(t, closeErr)
+			assert.Equal(t, http.StatusOK, response.StatusCode)
+			assert.Contains(t, string(body), test.marker)
+		})
+	}
+}
+
+func TestFindAdminWatchEntrypointsUsesEntrypointInsteadOfChunk(t *testing.T) {
+	metafile, err := json.Marshal(adminWatchMetafile{
+		Outputs: map[string]adminWatchMetafileOutput{
+			"chunk-CHUNK.js": {},
+			"my-plugin-ENTRY.js": {
+				EntryPoint: "Resources/app/administration/src/main.js",
+				CSSBundle:  "my-plugin-STYLES.css",
+			},
+			"my-plugin-STYLES.css": {},
+		},
+	})
+	require.NoError(t, err)
+
+	entrypoints, err := findAdminWatchEntrypoints(api.BuildResult{Metafile: string(metafile)})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/my-plugin-ENTRY.js", entrypoints.JavaScript)
+	assert.Equal(t, "/my-plugin-STYLES.css", entrypoints.CSS)
+}
+
+func TestFindAdminWatchEntrypointsAllowsMissingCSS(t *testing.T) {
+	metafile, err := json.Marshal(adminWatchMetafile{
+		Outputs: map[string]adminWatchMetafileOutput{
+			"my-plugin-ENTRY.js": {
+				EntryPoint: "Resources/app/administration/src/main.js",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	entrypoints, err := findAdminWatchEntrypoints(api.BuildResult{Metafile: string(metafile)})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/my-plugin-ENTRY.js", entrypoints.JavaScript)
+	assert.Empty(t, entrypoints.CSS)
+}
+
+func TestAdminWatchOutputURL(t *testing.T) {
+	browserURL, err := url.Parse("https://watch.example.test/base/")
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"https://watch.example.test/base/.shopware-cli/my-plugin/my-plugin-ENTRY.js",
+		adminWatchOutputURL(browserURL, "my-plugin", "/my-plugin-ENTRY.js"),
+	)
+}

--- a/cmd/extension/extension_admin_watch_test.go
+++ b/cmd/extension/extension_admin_watch_test.go
@@ -1,121 +1,12 @@
 package extension
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/evanw/esbuild/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/shopware/shopware-cli/internal/esbuild"
-	"github.com/shopware/shopware-cli/logging"
 )
-
-func TestCurrentEntrypointsReturnsContentAddressedPaths(t *testing.T) {
-	dir := t.TempDir()
-	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
-	require.NoError(t, os.MkdirAll(adminDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import './style.css'; console.log('served-marker')"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "style.css"), []byte(".served-marker { color: red; }"), 0o644))
-
-	ctx := logging.WithLogger(t.Context(), logging.NewLogger(false))
-	options := esbuild.NewAssetCompileOptionsAdmin("MyPlugin", dir)
-	options.ProductionMode = false
-	options.DisableSass = true
-
-	esbuildContext, err := esbuild.Context(ctx, options)
-	require.Nil(t, err)
-	t.Cleanup(esbuildContext.Dispose)
-
-	watchServer, serveErr := esbuildContext.Serve(api.ServeOptions{Host: "127.0.0.1"})
-	require.NoError(t, serveErr)
-
-	ext := adminWatchExtension{
-		assetName: "my-plugin",
-		context:   esbuildContext,
-	}
-
-	entrypoints, entrypointErr := ext.currentEntrypoints()
-
-	require.NoError(t, entrypointErr)
-	assert.Regexp(t, `^/my-plugin-[A-Z0-9]+\.js$`, entrypoints.JavaScript)
-	assert.Regexp(t, `^/my-plugin-[A-Z0-9]+\.css$`, entrypoints.CSS)
-	assert.NotEqual(t, "/extension.js", entrypoints.JavaScript)
-	assert.NotEqual(t, "/extension.css", entrypoints.CSS)
-
-	for _, test := range []struct {
-		name   string
-		path   string
-		marker string
-	}{
-		{name: "javascript", path: entrypoints.JavaScript, marker: "served-marker"},
-		{name: "css", path: entrypoints.CSS, marker: ".served-marker"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			request, err := http.NewRequestWithContext(
-				t.Context(),
-				http.MethodGet,
-				fmt.Sprintf("http://%s:%d%s", watchServer.Hosts[0], watchServer.Port, test.path),
-				nil,
-			)
-			require.NoError(t, err)
-
-			response, err := http.DefaultClient.Do(request)
-			require.NoError(t, err)
-
-			body, readErr := io.ReadAll(response.Body)
-			closeErr := response.Body.Close()
-			require.NoError(t, readErr)
-			require.NoError(t, closeErr)
-			assert.Equal(t, http.StatusOK, response.StatusCode)
-			assert.Contains(t, string(body), test.marker)
-		})
-	}
-}
-
-func TestFindAdminWatchEntrypointsUsesEntrypointInsteadOfChunk(t *testing.T) {
-	metafile, err := json.Marshal(adminWatchMetafile{
-		Outputs: map[string]adminWatchMetafileOutput{
-			"chunk-CHUNK.js": {},
-			"my-plugin-ENTRY.js": {
-				EntryPoint: "Resources/app/administration/src/main.js",
-				CSSBundle:  "my-plugin-STYLES.css",
-			},
-			"my-plugin-STYLES.css": {},
-		},
-	})
-	require.NoError(t, err)
-
-	entrypoints, err := findAdminWatchEntrypoints(api.BuildResult{Metafile: string(metafile)})
-
-	require.NoError(t, err)
-	assert.Equal(t, "/my-plugin-ENTRY.js", entrypoints.JavaScript)
-	assert.Equal(t, "/my-plugin-STYLES.css", entrypoints.CSS)
-}
-
-func TestFindAdminWatchEntrypointsAllowsMissingCSS(t *testing.T) {
-	metafile, err := json.Marshal(adminWatchMetafile{
-		Outputs: map[string]adminWatchMetafileOutput{
-			"my-plugin-ENTRY.js": {
-				EntryPoint: "Resources/app/administration/src/main.js",
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	entrypoints, err := findAdminWatchEntrypoints(api.BuildResult{Metafile: string(metafile)})
-
-	require.NoError(t, err)
-	assert.Equal(t, "/my-plugin-ENTRY.js", entrypoints.JavaScript)
-	assert.Empty(t, entrypoints.CSS)
-}
 
 func TestAdminWatchOutputURL(t *testing.T) {
 	browserURL, err := url.Parse("https://watch.example.test/base/")

--- a/cmd/extension/static/live-reload.js
+++ b/cmd/extension/static/live-reload.js
@@ -14,20 +14,36 @@ for (const bundleName of Object.keys(bundles)) {
 
     new EventSource(`/.shopware-cli/${bundle.name}/esbuild`).addEventListener('change', e => {
         const { added, removed, updated } = JSON.parse(e.data)
+        const changed = [...added, ...removed, ...updated]
 
-        // patch the path of esbuild
-        updated[0] = `/.shopware-cli/${bundle.name}${updated[0]}`
+        // Content-addressed CSS changes are reported as one removed file and one
+        // added file instead of an update. Swap the old hashed entrypoint for the
+        // new one without reloading the whole administration.
+        if (changed.length && changed.every(file => file.endsWith('.css'))) {
+            const watcherPath = `/.shopware-cli/${bundle.name}`
+            const nextFile = added[0] ?? updated[0]
+            const previousFiles = [...removed, ...updated]
+            const toWatcherPath = file => `${watcherPath}/${file.replace(/^\/+/, '')}`
 
-        if (!added.length && !removed.length && updated.length === 1) {
-            for (const link of document.getElementsByTagName("link")) {
-                const url = new URL(link.href)
+            if (nextFile && added.length <= 1 && updated.length <= 1) {
+                const nextPath = toWatcherPath(nextFile)
+                const previousPaths = previousFiles.map(toWatcherPath)
 
-                if (url.host === location.host && url.pathname === updated[0]) {
-                    const next = link.cloneNode()
-                    next.href = updated[0] + '?' + Math.random().toString(36).slice(2)
-                    next.onload = () => link.remove()
-                    link.parentNode.insertBefore(next, link.nextSibling)
-                    return
+                for (const link of document.getElementsByTagName("link")) {
+                    const url = new URL(link.href)
+                    const previousPath = previousPaths.find(path => url.pathname.endsWith(path))
+
+                    if (url.host === location.host && previousPath) {
+                        const next = link.cloneNode()
+                        const nextUrl = new URL(link.href)
+                        const pathPrefix = url.pathname.slice(0, -previousPath.length)
+                        nextUrl.pathname = pathPrefix + nextPath
+                        nextUrl.search = Math.random().toString(36).slice(2)
+                        next.href = nextUrl.toString()
+                        next.onload = () => link.remove()
+                        link.parentNode.insertBefore(next, link.nextSibling)
+                        return
+                    }
                 }
             }
         }

--- a/internal/esbuild/esbuild.go
+++ b/internal/esbuild/esbuild.go
@@ -118,6 +118,7 @@ func getEsbuildOptions(ctx context.Context, options AssetCompileOptions) (*api.B
 		EntryNames: "[name]-[hash]",
 		AssetNames: "[name]-[hash]",
 		Bundle:     true,
+		Metafile:   true,
 		Write:      false,
 		LogLevel:   api.LogLevelWarning,
 		Plugins:    plugins,
@@ -132,10 +133,6 @@ func Context(ctx context.Context, options AssetCompileOptions) (api.BuildContext
 	if err != nil {
 		panic(err)
 	}
-
-	// The administration watcher uses the metafile to distinguish entrypoints
-	// from generated chunks when serving content-addressed build outputs.
-	bundlerOptions.Metafile = true
 
 	return api.Context(*bundlerOptions)
 }
@@ -201,11 +198,21 @@ func cleanupOutputFolder(options AssetCompileOptions) error {
 
 func writeBundlerResultToDisk(result api.BuildResult, options AssetCompileOptions) (hashedJsRel, hashedCssRel string, err error) {
 	outputDir := filepath.Join(options.Path, options.OutputDir)
+	entrypoints, err := findEntrypoints(result)
+	if err != nil {
+		return "", "", err
+	}
 
 	for _, file := range result.OutputFiles {
+		outputPath, err := servePath(file.Path)
+		if err != nil {
+			return "", "", err
+		}
+
 		filename := filepath.Base(file.Path)
 
-		if strings.HasSuffix(filename, ".css") {
+		switch outputPath {
+		case entrypoints.CSS:
 			unhashedRel := options.OutputCSSFile
 			hashedRel := filepath.Join("css", filename)
 			hashedCssRel = hashedRel
@@ -219,7 +226,7 @@ func writeBundlerResultToDisk(result api.BuildResult, options AssetCompileOption
 			if err := writeOutputFile(filepath.Join(outputDir, hashedRel), file.Contents); err != nil {
 				return "", "", err
 			}
-		} else {
+		case entrypoints.JavaScript:
 			unhashedRel := options.OutputJSFile
 			jsDir := filepath.Dir(options.OutputJSFile)
 			hashedRel := filepath.Join(jsDir, filename)
@@ -233,6 +240,20 @@ func writeBundlerResultToDisk(result api.BuildResult, options AssetCompileOption
 			// Write esbuild content-addressed hashed file for Shopware 6.7+
 			if err := writeOutputFile(filepath.Join(outputDir, hashedRel), file.Contents); err != nil {
 				return "", "", err
+			}
+		default:
+			relativeOutputPath := filepath.FromSlash(strings.TrimPrefix(outputPath, "/"))
+			jsOutputPath := filepath.Join(outputDir, filepath.Dir(options.OutputJSFile), relativeOutputPath)
+
+			if err := writeOutputFile(jsOutputPath, file.Contents); err != nil {
+				return "", "", err
+			}
+
+			if entrypoints.CSS != "" {
+				cssOutputPath := filepath.Join(outputDir, filepath.Dir(options.OutputCSSFile), relativeOutputPath)
+				if err := writeOutputFile(cssOutputPath, file.Contents); err != nil {
+					return "", "", err
+				}
 			}
 		}
 	}

--- a/internal/esbuild/esbuild.go
+++ b/internal/esbuild/esbuild.go
@@ -133,6 +133,10 @@ func Context(ctx context.Context, options AssetCompileOptions) (api.BuildContext
 		panic(err)
 	}
 
+	// The administration watcher uses the metafile to distinguish entrypoints
+	// from generated chunks when serving content-addressed build outputs.
+	bundlerOptions.Metafile = true
+
 	return api.Context(*bundlerOptions)
 }
 

--- a/internal/esbuild/esbuild_test.go
+++ b/internal/esbuild/esbuild_test.go
@@ -2,11 +2,15 @@ package esbuild
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
+	"github.com/evanw/esbuild/pkg/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/shopware/shopware-cli/logging"
 )
@@ -126,6 +130,86 @@ func TestESBuildAdminWithCSS(t *testing.T) {
 	hashedCSSPath := filepath.Join(dir, "Resources", "public", "administration", result.HashedCssFile)
 	_, err = os.Stat(hashedCSSPath)
 	assert.NoError(t, err)
+}
+
+func TestESBuildAdminWithFileAsset(t *testing.T) {
+	dir := t.TempDir()
+
+	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
+	require.NoError(t, os.MkdirAll(adminDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import picture from './picture.png'; import './style.css'; console.log(picture)"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "style.css"), []byte(".picture { background-image: url('./picture.png'); }"), 0o644))
+	pictureContents := []byte("picture-contents")
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "picture.png"), pictureContents, 0o644))
+
+	options := NewAssetCompileOptionsAdmin("Bla", dir)
+	options.DisableSass = true
+	result, err := CompileExtensionAsset(getTestContext(), options)
+	require.NoError(t, err)
+
+	assert.Regexp(t, `^js/bla-[A-Z0-9]+\.js$`, filepath.ToSlash(result.HashedJsFile))
+	assert.Regexp(t, `^css/bla-[A-Z0-9]+\.css$`, filepath.ToSlash(result.HashedCssFile))
+
+	outputDir := filepath.Join(dir, "Resources", "public", "administration")
+	compiledJS, err := os.ReadFile(filepath.Join(outputDir, "js", "bla.js"))
+	require.NoError(t, err)
+	compiledCSS, err := os.ReadFile(filepath.Join(outputDir, "css", "bla.css"))
+	require.NoError(t, err)
+
+	picturePathPattern := regexp.MustCompile(`\./picture-[A-Z0-9]+\.png`)
+	javaScriptPicturePath := picturePathPattern.FindString(string(compiledJS))
+	cssPicturePath := picturePathPattern.FindString(string(compiledCSS))
+	require.NotEmpty(t, javaScriptPicturePath)
+	assert.Equal(t, javaScriptPicturePath, cssPicturePath)
+
+	for _, outputFolder := range []string{"js", "css"} {
+		writtenPicture, err := os.ReadFile(filepath.Join(outputDir, outputFolder, javaScriptPicturePath[2:]))
+		require.NoError(t, err)
+		assert.Equal(t, pictureContents, writtenPicture)
+	}
+}
+
+func TestWriteBundlerResultToDiskDoesNotTreatAssetAsEntrypoint(t *testing.T) {
+	entryPath, err := filepath.Abs("bla-ENTRY.js")
+	require.NoError(t, err)
+	picturePath, err := filepath.Abs("picture-ASSET.png")
+	require.NoError(t, err)
+
+	metafile, err := json.Marshal(watchMetafile{
+		Outputs: map[string]watchMetafileOutput{
+			"bla-ENTRY.js": {
+				EntryPoint: "Resources/app/administration/src/main.js",
+			},
+			"picture-ASSET.png": {},
+		},
+	})
+	require.NoError(t, err)
+
+	options := AssetCompileOptions{
+		Path:          t.TempDir(),
+		OutputDir:     "dist",
+		OutputJSFile:  "js/bla.js",
+		OutputCSSFile: "css/bla.css",
+	}
+	hashedJS, hashedCSS, err := writeBundlerResultToDisk(api.BuildResult{
+		Metafile: string(metafile),
+		OutputFiles: []api.OutputFile{
+			{Path: entryPath, Contents: []byte("entry")},
+			{Path: picturePath, Contents: []byte("picture")},
+		},
+	}, options)
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.FromSlash("js/bla-ENTRY.js"), hashedJS)
+	assert.Empty(t, hashedCSS)
+
+	stableEntry, err := os.ReadFile(filepath.Join(options.Path, options.OutputDir, options.OutputJSFile))
+	require.NoError(t, err)
+	assert.Equal(t, "entry", string(stableEntry))
+
+	writtenPicture, err := os.ReadFile(filepath.Join(options.Path, options.OutputDir, "js", "picture-ASSET.png"))
+	require.NoError(t, err)
+	assert.Equal(t, "picture", string(writtenPicture))
 }
 
 func TestESBuildAdminTypeScript(t *testing.T) {

--- a/internal/esbuild/fs_test.go
+++ b/internal/esbuild/fs_test.go
@@ -1,0 +1,67 @@
+package esbuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyStaticFiles(t *testing.T) {
+	t.Run("copies nested files and permissions", func(t *testing.T) {
+		sourceDir := t.TempDir()
+		targetDir := filepath.Join(t.TempDir(), "target")
+		sourceFile := filepath.Join(sourceDir, "images", "icon.svg")
+		require.NoError(t, os.MkdirAll(filepath.Dir(sourceFile), 0o755))
+		require.NoError(t, os.WriteFile(sourceFile, []byte("<svg>icon</svg>"), 0o640))
+
+		require.NoError(t, copyStaticFiles(sourceDir, targetDir))
+
+		targetFile := filepath.Join(targetDir, "images", "icon.svg")
+		contents, err := os.ReadFile(targetFile)
+		require.NoError(t, err)
+		assert.Equal(t, "<svg>icon</svg>", string(contents))
+
+		info, err := os.Stat(targetFile)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	})
+
+	t.Run("ignores missing source directory", func(t *testing.T) {
+		targetDir := filepath.Join(t.TempDir(), "target")
+
+		require.NoError(t, copyStaticFiles(filepath.Join(t.TempDir(), "missing"), targetDir))
+
+		_, err := os.Stat(targetDir)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("reports target directory creation failure", func(t *testing.T) {
+		sourceDir := t.TempDir()
+		targetParent := filepath.Join(t.TempDir(), "target")
+		require.NoError(t, os.WriteFile(targetParent, []byte("file"), 0o644))
+
+		err := copyStaticFiles(sourceDir, filepath.Join(targetParent, "nested"))
+
+		assert.ErrorContains(t, err, "failed to create target directory")
+	})
+}
+
+func TestCopyFileErrors(t *testing.T) {
+	t.Run("missing source", func(t *testing.T) {
+		err := copyFile(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "target"))
+
+		assert.ErrorContains(t, err, "failed to open source file")
+	})
+
+	t.Run("missing target parent", func(t *testing.T) {
+		sourceFile := filepath.Join(t.TempDir(), "source")
+		require.NoError(t, os.WriteFile(sourceFile, []byte("source"), 0o644))
+
+		err := copyFile(sourceFile, filepath.Join(t.TempDir(), "missing", "target"))
+
+		assert.ErrorContains(t, err, "failed to create target file")
+	})
+}

--- a/internal/esbuild/sass_plugin_test.go
+++ b/internal/esbuild/sass_plugin_test.go
@@ -1,0 +1,54 @@
+package esbuild
+
+import (
+	"testing"
+
+	"github.com/bep/godartsass/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScssImporterCanonicalizeURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{name: "variables", url: "~scss/variables", expected: InternalVariablesScssPath},
+		{name: "variables with extension", url: "~scss/variables.scss", expected: InternalVariablesScssPath},
+		{name: "mixins", url: "~scss/mixins", expected: InternalMixinsScssPath},
+		{name: "mixins with extension", url: "~scss/mixins.scss", expected: InternalMixinsScssPath},
+		{name: "unknown import", url: "./custom.scss", expected: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			canonicalURL, err := (scssImporter{}).CanonicalizeURL(test.url)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, canonicalURL)
+		})
+	}
+}
+
+func TestScssImporterLoad(t *testing.T) {
+	tests := []struct {
+		name             string
+		canonicalURL     string
+		expectedContents string
+	}{
+		{name: "variables", canonicalURL: InternalVariablesScssPath, expectedContents: string(scssVariables)},
+		{name: "mixins", canonicalURL: InternalMixinsScssPath, expectedContents: string(scssMixins)},
+		{name: "unknown import", canonicalURL: "file://custom.scss", expectedContents: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := (scssImporter{}).Load(test.canonicalURL)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedContents, result.Content)
+			assert.Equal(t, godartsass.SourceSyntaxSCSS, result.SourceSyntax)
+		})
+	}
+}

--- a/internal/esbuild/watch.go
+++ b/internal/esbuild/watch.go
@@ -1,0 +1,87 @@
+package esbuild
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/evanw/esbuild/pkg/api"
+)
+
+type Entrypoints struct {
+	JavaScript string
+	CSS        string
+}
+
+type watchMetafile struct {
+	Outputs map[string]watchMetafileOutput `json:"outputs"`
+}
+
+type watchMetafileOutput struct {
+	EntryPoint string `json:"entryPoint"`
+	CSSBundle  string `json:"cssBundle"`
+}
+
+func RebuildEntrypoints(buildContext api.BuildContext) (Entrypoints, error) {
+	result := buildContext.Rebuild()
+
+	if len(result.Errors) > 0 {
+		return Entrypoints{}, errors.New(result.Errors[0].Text)
+	}
+
+	return findEntrypoints(result)
+}
+
+func findEntrypoints(result api.BuildResult) (Entrypoints, error) {
+	var metafile watchMetafile
+	if err := json.Unmarshal([]byte(result.Metafile), &metafile); err != nil {
+		return Entrypoints{}, fmt.Errorf("cannot decode esbuild metafile: %w", err)
+	}
+
+	for candidatePath, candidate := range metafile.Outputs {
+		if candidate.EntryPoint == "" || path.Ext(candidatePath) != ".js" {
+			continue
+		}
+
+		javaScriptPath, err := servePath(candidatePath)
+		if err != nil {
+			return Entrypoints{}, err
+		}
+
+		cssPath := ""
+		if candidate.CSSBundle != "" {
+			cssPath, err = servePath(candidate.CSSBundle)
+			if err != nil {
+				return Entrypoints{}, err
+			}
+		}
+
+		return Entrypoints{
+			JavaScript: javaScriptPath,
+			CSS:        cssPath,
+		}, nil
+	}
+
+	return Entrypoints{}, fmt.Errorf("esbuild emitted no JavaScript entrypoint")
+}
+
+func servePath(outputPath string) (string, error) {
+	cleanOutputPath := filepath.Clean(filepath.FromSlash(outputPath))
+
+	if filepath.IsAbs(cleanOutputPath) {
+		relativePath, err := filepath.Rel(".", cleanOutputPath)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve esbuild output path %q: %w", outputPath, err)
+		}
+		cleanOutputPath = relativePath
+	}
+
+	if cleanOutputPath == ".." || strings.HasPrefix(cleanOutputPath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("esbuild output path %q is outside the serve directory", outputPath)
+	}
+
+	return "/" + strings.TrimPrefix(filepath.ToSlash(cleanOutputPath), "/"), nil
+}

--- a/internal/esbuild/watch.go
+++ b/internal/esbuild/watch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -72,7 +73,12 @@ func servePath(outputPath string) (string, error) {
 	cleanOutputPath := filepath.Clean(filepath.FromSlash(outputPath))
 
 	if filepath.IsAbs(cleanOutputPath) {
-		relativePath, err := filepath.Rel(".", cleanOutputPath)
+		workingDirectory, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("cannot determine esbuild serve directory: %w", err)
+		}
+
+		relativePath, err := filepath.Rel(workingDirectory, cleanOutputPath)
 		if err != nil {
 			return "", fmt.Errorf("cannot resolve esbuild output path %q: %w", outputPath, err)
 		}

--- a/internal/esbuild/watch_test.go
+++ b/internal/esbuild/watch_test.go
@@ -106,3 +106,105 @@ func TestFindEntrypointsAllowsMissingCSS(t *testing.T) {
 	assert.Equal(t, "/my-plugin-ENTRY.js", entrypoints.JavaScript)
 	assert.Empty(t, entrypoints.CSS)
 }
+
+func TestRebuildEntrypointsReturnsBuildError(t *testing.T) {
+	buildContext := staticBuildContext{
+		result: api.BuildResult{
+			Errors: []api.Message{{Text: "build failed"}},
+		},
+	}
+
+	_, err := RebuildEntrypoints(buildContext)
+
+	assert.EqualError(t, err, "build failed")
+}
+
+func TestFindEntrypointsReturnsMetadataErrors(t *testing.T) {
+	t.Run("malformed metafile", func(t *testing.T) {
+		_, err := findEntrypoints(api.BuildResult{Metafile: `{"outputs":`})
+
+		assert.ErrorContains(t, err, "cannot decode esbuild metafile")
+	})
+
+	t.Run("missing JavaScript entrypoint", func(t *testing.T) {
+		metafile, err := json.Marshal(watchMetafile{
+			Outputs: map[string]watchMetafileOutput{
+				"my-plugin.css": {},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = findEntrypoints(api.BuildResult{Metafile: string(metafile)})
+
+		assert.EqualError(t, err, "esbuild emitted no JavaScript entrypoint")
+	})
+
+	t.Run("JavaScript outside serve directory", func(t *testing.T) {
+		metafile, err := json.Marshal(watchMetafile{
+			Outputs: map[string]watchMetafileOutput{
+				"../my-plugin.js": {
+					EntryPoint: "Resources/app/administration/src/main.js",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = findEntrypoints(api.BuildResult{Metafile: string(metafile)})
+
+		assert.ErrorContains(t, err, "outside the serve directory")
+	})
+
+	t.Run("CSS outside serve directory", func(t *testing.T) {
+		metafile, err := json.Marshal(watchMetafile{
+			Outputs: map[string]watchMetafileOutput{
+				"my-plugin.js": {
+					EntryPoint: "Resources/app/administration/src/main.js",
+					CSSBundle:  "../my-plugin.css",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = findEntrypoints(api.BuildResult{Metafile: string(metafile)})
+
+		assert.ErrorContains(t, err, "outside the serve directory")
+	})
+}
+
+func TestServePath(t *testing.T) {
+	t.Run("absolute path in serve directory", func(t *testing.T) {
+		absolutePath, err := filepath.Abs(filepath.Join("chunks", "chunk.js"))
+		require.NoError(t, err)
+
+		resultPath, err := servePath(absolutePath)
+
+		require.NoError(t, err)
+		assert.Equal(t, "/chunks/chunk.js", resultPath)
+	})
+
+	t.Run("parent traversal", func(t *testing.T) {
+		_, err := servePath(filepath.Join("..", "chunk.js"))
+
+		assert.ErrorContains(t, err, "outside the serve directory")
+	})
+}
+
+type staticBuildContext struct {
+	result api.BuildResult
+}
+
+func (c staticBuildContext) Rebuild() api.BuildResult {
+	return c.result
+}
+
+func (staticBuildContext) Watch(api.WatchOptions) error {
+	return nil
+}
+
+func (staticBuildContext) Serve(api.ServeOptions) (api.ServeResult, error) {
+	return api.ServeResult{}, nil
+}
+
+func (staticBuildContext) Cancel() {}
+
+func (staticBuildContext) Dispose() {}

--- a/internal/esbuild/watch_test.go
+++ b/internal/esbuild/watch_test.go
@@ -1,0 +1,108 @@
+package esbuild
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/evanw/esbuild/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRebuildEntrypointsReturnsContentAddressedPaths(t *testing.T) {
+	dir := t.TempDir()
+	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
+	require.NoError(t, os.MkdirAll(adminDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import './style.css'; console.log('served-marker')"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "style.css"), []byte(".served-marker { color: red; }"), 0o644))
+
+	options := NewAssetCompileOptionsAdmin("MyPlugin", dir)
+	options.ProductionMode = false
+	options.DisableSass = true
+
+	esbuildContext, err := Context(getTestContext(), options)
+	require.Nil(t, err)
+	t.Cleanup(esbuildContext.Dispose)
+
+	watchServer, serveErr := esbuildContext.Serve(api.ServeOptions{Host: "127.0.0.1"})
+	require.NoError(t, serveErr)
+
+	entrypoints, entrypointErr := RebuildEntrypoints(esbuildContext)
+
+	require.NoError(t, entrypointErr)
+	assert.Regexp(t, `^/my-plugin-[A-Z0-9]+\.js$`, entrypoints.JavaScript)
+	assert.Regexp(t, `^/my-plugin-[A-Z0-9]+\.css$`, entrypoints.CSS)
+	assert.NotEqual(t, "/extension.js", entrypoints.JavaScript)
+	assert.NotEqual(t, "/extension.css", entrypoints.CSS)
+
+	for _, test := range []struct {
+		name   string
+		path   string
+		marker string
+	}{
+		{name: "javascript", path: entrypoints.JavaScript, marker: "served-marker"},
+		{name: "css", path: entrypoints.CSS, marker: ".served-marker"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := http.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				fmt.Sprintf("http://%s:%d%s", watchServer.Hosts[0], watchServer.Port, test.path),
+				nil,
+			)
+			require.NoError(t, err)
+
+			response, err := http.DefaultClient.Do(request)
+			require.NoError(t, err)
+
+			body, readErr := io.ReadAll(response.Body)
+			closeErr := response.Body.Close()
+			require.NoError(t, readErr)
+			require.NoError(t, closeErr)
+			assert.Equal(t, http.StatusOK, response.StatusCode)
+			assert.Contains(t, string(body), test.marker)
+		})
+	}
+}
+
+func TestFindEntrypointsUsesEntrypointInsteadOfChunk(t *testing.T) {
+	metafile, err := json.Marshal(watchMetafile{
+		Outputs: map[string]watchMetafileOutput{
+			"chunk-CHUNK.js": {},
+			"my-plugin-ENTRY.js": {
+				EntryPoint: "Resources/app/administration/src/main.js",
+				CSSBundle:  "my-plugin-STYLES.css",
+			},
+			"my-plugin-STYLES.css": {},
+		},
+	})
+	require.NoError(t, err)
+
+	entrypoints, err := findEntrypoints(api.BuildResult{Metafile: string(metafile)})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/my-plugin-ENTRY.js", entrypoints.JavaScript)
+	assert.Equal(t, "/my-plugin-STYLES.css", entrypoints.CSS)
+}
+
+func TestFindEntrypointsAllowsMissingCSS(t *testing.T) {
+	metafile, err := json.Marshal(watchMetafile{
+		Outputs: map[string]watchMetafileOutput{
+			"my-plugin-ENTRY.js": {
+				EntryPoint: "Resources/app/administration/src/main.js",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	entrypoints, err := findEntrypoints(api.BuildResult{Metafile: string(metafile)})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/my-plugin-ENTRY.js", entrypoints.JavaScript)
+	assert.Empty(t, entrypoints.CSS)
+}

--- a/internal/esbuild/watch_test.go
+++ b/internal/esbuild/watch_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/evanw/esbuild/pkg/api"
@@ -18,8 +19,10 @@ func TestRebuildEntrypointsReturnsContentAddressedPaths(t *testing.T) {
 	dir := t.TempDir()
 	adminDir := filepath.Join(dir, "Resources", "app", "administration", "src")
 	require.NoError(t, os.MkdirAll(adminDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import './style.css'; console.log('served-marker')"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "style.css"), []byte(".served-marker { color: red; }"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "main.js"), []byte("import picture from './picture.png'; import './style.css'; console.log('served-marker', picture)"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "style.css"), []byte(".served-marker { background-image: url('./picture.png'); }"), 0o644))
+	pictureContents := []byte("picture-contents")
+	require.NoError(t, os.WriteFile(filepath.Join(adminDir, "picture.png"), pictureContents, 0o644))
 
 	options := NewAssetCompileOptionsAdmin("MyPlugin", dir)
 	options.ProductionMode = false
@@ -40,6 +43,8 @@ func TestRebuildEntrypointsReturnsContentAddressedPaths(t *testing.T) {
 	assert.NotEqual(t, "/extension.js", entrypoints.JavaScript)
 	assert.NotEqual(t, "/extension.css", entrypoints.CSS)
 
+	servedBodies := map[string]string{}
+
 	for _, test := range []struct {
 		name   string
 		path   string
@@ -49,25 +54,20 @@ func TestRebuildEntrypointsReturnsContentAddressedPaths(t *testing.T) {
 		{name: "css", path: entrypoints.CSS, marker: ".served-marker"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			request, err := http.NewRequestWithContext(
-				t.Context(),
-				http.MethodGet,
-				fmt.Sprintf("http://%s:%d%s", watchServer.Hosts[0], watchServer.Port, test.path),
-				nil,
-			)
-			require.NoError(t, err)
-
-			response, err := http.DefaultClient.Do(request)
-			require.NoError(t, err)
-
-			body, readErr := io.ReadAll(response.Body)
-			closeErr := response.Body.Close()
-			require.NoError(t, readErr)
-			require.NoError(t, closeErr)
-			assert.Equal(t, http.StatusOK, response.StatusCode)
-			assert.Contains(t, string(body), test.marker)
+			body := readServeOutput(t, watchServer, test.path)
+			servedBodies[test.name] = string(body)
+			assert.Contains(t, servedBodies[test.name], test.marker)
 		})
 	}
+
+	picturePathPattern := regexp.MustCompile(`\./picture-[A-Z0-9]+\.png`)
+	javaScriptPicturePath := picturePathPattern.FindString(servedBodies["javascript"])
+	cssPicturePath := picturePathPattern.FindString(servedBodies["css"])
+	require.NotEmpty(t, javaScriptPicturePath)
+	assert.Equal(t, javaScriptPicturePath, cssPicturePath)
+
+	servedPicture := readServeOutput(t, watchServer, javaScriptPicturePath[1:])
+	assert.Equal(t, pictureContents, servedPicture)
 }
 
 func TestFindEntrypointsUsesEntrypointInsteadOfChunk(t *testing.T) {
@@ -208,3 +208,26 @@ func (staticBuildContext) Serve(api.ServeOptions) (api.ServeResult, error) {
 func (staticBuildContext) Cancel() {}
 
 func (staticBuildContext) Dispose() {}
+
+func readServeOutput(t *testing.T, watchServer api.ServeResult, outputPath string) []byte {
+	t.Helper()
+
+	request, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		fmt.Sprintf("http://%s:%d%s", watchServer.Hosts[0], watchServer.Port, outputPath),
+		nil,
+	)
+	require.NoError(t, err)
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+
+	body, readErr := io.ReadAll(response.Body)
+	closeErr := response.Body.Close()
+	require.NoError(t, readErr)
+	require.NoError(t, closeErr)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	return body
+}


### PR DESCRIPTION
## What changed?

- Resolve esbuild's JavaScript and CSS entrypoints from its metafile inside `internal/esbuild`, keeping the command focused on watcher URL/config wiring.
- Inject the real content-addressed entrypoint URLs into `/api/_info/config`.
- Keep generated chunks and assets on the existing wildcard proxy path so relative imports resolve through esbuild.
- Preserve additional bundler outputs such as imported images beside generated JS and CSS without mistaking them for entrypoints.
- Update CSS live reload to replace removed hashed stylesheets with their newly added versions.
- Add regression coverage for hashed entrypoints, missing CSS, chunk/entrypoint selection, imported images, generated URLs, HTTP serving, build failures, unsafe output paths, static-file copying, and Sass virtual imports.

## Why?

The content-addressable esbuild changes in #1207 replaced the watch server's stable `extension.js` and `extension.css` outputs with hashed filenames. The administration watcher continued injecting the stable paths, which returned 404 and prevented extension administration bundles from loading.

Passing esbuild's native output paths through also preserves the correct base URL for generated chunks and assets. Metafile-based output classification ensures multiple emitted files cannot overwrite or be returned as the JavaScript entrypoint.

## How was this tested?

- `go test ./...`
- `golangci-lint run ./...`
- `go vet ./cmd/extension ./internal/esbuild`
- `node --check cmd/extension/static/live-reload.js`
- `git diff --check`
- `internal/esbuild` coverage profile: 65.7% overall; new watcher functions at 100%, 100%, and 83.3%
- Multi-output integration coverage for JS, CSS, and an imported hashed image through both watch serving and disk compilation

## Related issue or discussion

Fixes #1233
