### PR TITLE
Separate build-time version constraint from compatibility constraint

### DIFF
--- a/cmd/extension/extension_build.go
+++ b/cmd/extension/extension_build.go
@@ -45,7 +45,7 @@ var extensionAssetBundleCmd = &cobra.Command{
 			}
 			assetCfg.ShopwareVersion = constraint
 		} else {
-			constraint, err := validatedExtensions[0].GetShopwareVersionConstraint()
+			constraint, err := extension.GetShopwareVersionConstraintForBuild(validatedExtensions[0])
 			if err != nil {
 				return fmt.Errorf("cannot get shopware version constraint: %w", err)
 			}

--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -135,7 +135,7 @@ var extensionZipCmd = &cobra.Command{
 				return fmt.Errorf("before hooks assets: %w", err)
 			}
 
-			shopwareConstraint, err := tempExt.GetShopwareVersionConstraint()
+			shopwareConstraint, err := extension.GetShopwareVersionConstraintForBuild(tempExt)
 			if err != nil {
 				return fmt.Errorf("get shopware version constraint: %w", err)
 			}

--- a/internal/extension/app.go
+++ b/internal/extension/app.go
@@ -89,15 +89,6 @@ func (a App) GetExtensionConfig() *Config {
 }
 
 func (a App) GetShopwareVersionConstraint() (*version.Constraints, error) {
-	if a.config != nil && a.config.Build.ShopwareVersionConstraint != "" {
-		v, err := version.NewConstraint(a.config.Build.ShopwareVersionConstraint)
-		if err != nil {
-			return nil, err
-		}
-
-		return &v, err
-	}
-
 	if a.manifest.Meta.Compatibility != "" {
 		v, err := version.NewConstraint(a.manifest.Meta.Compatibility)
 		if err != nil {

--- a/internal/extension/bundle.go
+++ b/internal/extension/bundle.go
@@ -119,7 +119,7 @@ func (p ShopwareBundle) GetExtensionConfig() *Config {
 }
 
 func (p ShopwareBundle) GetShopwareVersionConstraint() (*version.Constraints, error) {
-	return getShopwareVersionConstraintFromComposer(p.config, p.Composer.Require)
+	return getShopwareVersionConstraintFromComposer(p.Composer.Require)
 }
 
 func (ShopwareBundle) GetType() string {

--- a/internal/extension/extension_test.go
+++ b/internal/extension/extension_test.go
@@ -17,6 +17,7 @@ type mockExtension struct {
 	extVersion *version.Version
 	config     *Config
 	rootDir    string
+	constraint *version.Constraints
 }
 
 func (m *mockExtension) GetName() (string, error) {
@@ -65,6 +66,9 @@ func (m *mockExtension) GetLicense() (string, error) {
 }
 
 func (m *mockExtension) GetShopwareVersionConstraint() (*version.Constraints, error) {
+	if m.constraint != nil {
+		return m.constraint, nil
+	}
 	c, err := version.NewConstraint(">= 6.5")
 	if err != nil {
 		return nil, err

--- a/internal/extension/platform.go
+++ b/internal/extension/platform.go
@@ -137,7 +137,7 @@ func (p PlatformPlugin) GetExtensionConfig() *Config {
 }
 
 func (p PlatformPlugin) GetShopwareVersionConstraint() (*version.Constraints, error) {
-	return getShopwareVersionConstraintFromComposer(p.config, p.Composer.Require)
+	return getShopwareVersionConstraintFromComposer(p.Composer.Require)
 }
 
 func (PlatformPlugin) GetType() string {

--- a/internal/extension/root.go
+++ b/internal/extension/root.go
@@ -160,7 +160,7 @@ func GetShopwareBuildVersionConstraint(config *Config) (*version.Constraints, er
 		return &constraint, nil
 	}
 
-	return nil, nil
+	return nil, nil //nolint:nilnil // nil constraint signals "no build override configured", not an error
 }
 
 // GetShopwareVersionConstraintForBuild resolves the constraint that should be used when building

--- a/internal/extension/root.go
+++ b/internal/extension/root.go
@@ -125,17 +125,13 @@ type Extension interface {
 }
 
 // getShopwareVersionConstraintFromComposer is a shared helper for composer-based extensions
-// (PlatformPlugin and ShopwareBundle) to extract the Shopware version constraint.
-func getShopwareVersionConstraintFromComposer(config *Config, composerRequire map[string]string) (*version.Constraints, error) {
-	if config != nil && config.Build.ShopwareVersionConstraint != "" {
-		constraint, err := version.NewConstraint(config.Build.ShopwareVersionConstraint)
-		if err != nil {
-			return nil, err
-		}
-
-		return &constraint, nil
-	}
-
+// (PlatformPlugin and ShopwareBundle) to extract the Shopware compatibility constraint from
+// the composer requirements. It intentionally ignores the build-time override
+// (config.Build.ShopwareVersionConstraint) so that the reported compatibility always reflects
+// what the extension actually supports (e.g. for account store uploads). Use
+// GetShopwareBuildVersionConstraint / GetShopwareVersionConstraintForBuild when the build-time
+// override should be honored.
+func getShopwareVersionConstraintFromComposer(composerRequire map[string]string) (*version.Constraints, error) {
 	shopwareConstraintString, ok := composerRequire["shopware/core"]
 	if !ok {
 		return nil, fmt.Errorf("require.shopware/core is required")
@@ -147,4 +143,39 @@ func getShopwareVersionConstraintFromComposer(config *Config, composerRequire ma
 	}
 
 	return &shopwareConstraint, nil
+}
+
+// GetShopwareBuildVersionConstraint returns the Shopware version constraint configured as a
+// build-time override via config.Build.ShopwareVersionConstraint. It handles a nil config
+// gracefully and returns (nil, nil) when no override is configured. This is the single source
+// of truth for the build-time constraint and is never mixed into an extension's reported
+// compatibility constraint.
+func GetShopwareBuildVersionConstraint(config *Config) (*version.Constraints, error) {
+	if config != nil && config.Build.ShopwareVersionConstraint != "" {
+		constraint, err := version.NewConstraint(config.Build.ShopwareVersionConstraint)
+		if err != nil {
+			return nil, err
+		}
+
+		return &constraint, nil
+	}
+
+	return nil, nil
+}
+
+// GetShopwareVersionConstraintForBuild resolves the constraint that should be used when building
+// assets for the given extension. It honors the build-time override
+// (config.Build.ShopwareVersionConstraint) when set and otherwise falls back to the extension's
+// reported compatibility constraint.
+func GetShopwareVersionConstraintForBuild(ext Extension) (*version.Constraints, error) {
+	buildConstraint, err := GetShopwareBuildVersionConstraint(ext.GetExtensionConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	if buildConstraint != nil {
+		return buildConstraint, nil
+	}
+
+	return ext.GetShopwareVersionConstraint()
 }

--- a/internal/extension/root_test.go
+++ b/internal/extension/root_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/shyim/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -282,65 +283,110 @@ func TestUpdateMetaData_App(t *testing.T) {
 }
 
 func TestGetShopwareVersionConstraintFromComposer(t *testing.T) {
-	t.Run("uses config constraint when set", func(t *testing.T) {
-		config := &Config{
-			Build: ConfigBuild{
-				ShopwareVersionConstraint: "~6.5.0",
-			},
-		}
-
-		constraint, err := getShopwareVersionConstraintFromComposer(config, map[string]string{
-			"shopware/core": "~6.4.0",
-		})
-		require.NoError(t, err)
-		assert.NotNil(t, constraint)
-	})
-
-	t.Run("uses composer require when config not set", func(t *testing.T) {
-		config := &Config{}
-
-		constraint, err := getShopwareVersionConstraintFromComposer(config, map[string]string{
+	t.Run("uses composer require", func(t *testing.T) {
+		constraint, err := getShopwareVersionConstraintFromComposer(map[string]string{
 			"shopware/core": "~6.5.0",
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, constraint)
+		assert.True(t, constraint.Check(version.Must(version.NewVersion("6.5.0.0"))))
+	})
+
+	t.Run("ignores the build override and always uses composer require", func(t *testing.T) {
+		// The build override must never leak into the reported compatibility constraint,
+		// otherwise account uploads would report the wrong compatible Shopware versions.
+		constraint, err := getShopwareVersionConstraintFromComposer(map[string]string{
+			"shopware/core": "~6.4.0",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, constraint)
+		assert.True(t, constraint.Check(version.Must(version.NewVersion("6.4.0.0"))))
 	})
 
 	t.Run("returns error when shopware/core not in require", func(t *testing.T) {
-		config := &Config{}
-
-		_, err := getShopwareVersionConstraintFromComposer(config, map[string]string{
+		_, err := getShopwareVersionConstraintFromComposer(map[string]string{
 			"php": ">=8.1",
 		})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "shopware/core is required")
 	})
 
-	t.Run("handles nil config", func(t *testing.T) {
-		constraint, err := getShopwareVersionConstraintFromComposer(nil, map[string]string{
-			"shopware/core": "~6.5.0",
+	t.Run("returns error for invalid constraint in composer", func(t *testing.T) {
+		_, err := getShopwareVersionConstraintFromComposer(map[string]string{
+			"shopware/core": "invalid[constraint",
 		})
+		assert.Error(t, err)
+	})
+}
+
+func TestGetShopwareBuildVersionConstraint(t *testing.T) {
+	t.Run("returns constraint when build override is set", func(t *testing.T) {
+		config := &Config{
+			Build: ConfigBuild{
+				ShopwareVersionConstraint: "~6.5.0",
+			},
+		}
+
+		constraint, err := GetShopwareBuildVersionConstraint(config)
 		require.NoError(t, err)
-		assert.NotNil(t, constraint)
+		require.NotNil(t, constraint)
+		assert.True(t, constraint.Check(version.Must(version.NewVersion("6.5.0.0"))))
 	})
 
-	t.Run("returns error for invalid constraint in config", func(t *testing.T) {
+	t.Run("returns nil when build override is not set", func(t *testing.T) {
+		constraint, err := GetShopwareBuildVersionConstraint(&Config{})
+		require.NoError(t, err)
+		assert.Nil(t, constraint)
+	})
+
+	t.Run("handles nil config", func(t *testing.T) {
+		constraint, err := GetShopwareBuildVersionConstraint(nil)
+		require.NoError(t, err)
+		assert.Nil(t, constraint)
+	})
+
+	t.Run("returns error for invalid constraint", func(t *testing.T) {
 		config := &Config{
 			Build: ConfigBuild{
 				ShopwareVersionConstraint: "invalid[constraint",
 			},
 		}
 
-		_, err := getShopwareVersionConstraintFromComposer(config, map[string]string{})
+		_, err := GetShopwareBuildVersionConstraint(config)
 		assert.Error(t, err)
 	})
+}
 
-	t.Run("returns error for invalid constraint in composer", func(t *testing.T) {
-		config := &Config{}
+func mustConstraint(t *testing.T, s string) *version.Constraints {
+	t.Helper()
+	c, err := version.NewConstraint(s)
+	require.NoError(t, err)
+	return &c
+}
 
-		_, err := getShopwareVersionConstraintFromComposer(config, map[string]string{
-			"shopware/core": "invalid[constraint",
-		})
-		assert.Error(t, err)
+func TestGetShopwareVersionConstraintForBuild(t *testing.T) {
+	t.Run("uses build override when set", func(t *testing.T) {
+		ext := &mockExtension{
+			config:     &Config{Build: ConfigBuild{ShopwareVersionConstraint: "~6.5.0"}},
+			constraint: mustConstraint(t, "~6.4.0"),
+		}
+
+		constraint, err := GetShopwareVersionConstraintForBuild(ext)
+		require.NoError(t, err)
+		require.NotNil(t, constraint)
+		assert.True(t, constraint.Check(version.Must(version.NewVersion("6.5.0.0"))))
+		assert.False(t, constraint.Check(version.Must(version.NewVersion("6.4.0.0"))))
+	})
+
+	t.Run("falls back to compatibility constraint when no override", func(t *testing.T) {
+		ext := &mockExtension{
+			config:     &Config{},
+			constraint: mustConstraint(t, "~6.4.0"),
+		}
+
+		constraint, err := GetShopwareVersionConstraintForBuild(ext)
+		require.NoError(t, err)
+		require.NotNil(t, constraint)
+		assert.True(t, constraint.Check(version.Must(version.NewVersion("6.4.0.0"))))
 	})
 }

--- a/internal/extension/zip.go
+++ b/internal/extension/zip.go
@@ -38,7 +38,7 @@ func PrepareFolderForZipping(ctx context.Context, path string, ext Extension, ex
 		return fmt.Errorf(errorFormat, err)
 	}
 
-	minShopwareVersionConstraint, err := ext.GetShopwareVersionConstraint()
+	minShopwareVersionConstraint, err := GetShopwareVersionConstraintForBuild(ext)
 	if err != nil {
 		return fmt.Errorf(errorFormat, err)
 	}


### PR DESCRIPTION
## What changed?

Refactored the Shopware version constraint handling to clearly separate two distinct concerns:

1. **Compatibility constraint** (`GetShopwareVersionConstraintFromComposer`): Extracted from composer requirements, represents what the extension actually supports. This is used for account store uploads and should never be overridden.

2. **Build-time constraint** (`GetShopwareBuildVersionConstraint`): New function that returns the build-time override from `config.Build.ShopwareVersionConstraint` when set, or `nil` otherwise.

3. **Build constraint resolution** (`GetShopwareVersionConstraintForBuild`): New function that honors the build-time override when present, otherwise falls back to the extension's compatibility constraint.

Updated all callers to use the appropriate function:
- `App.GetShopwareVersionConstraint()`: Now only returns manifest compatibility, no longer checks build override
- `PlatformPlugin` and `ShopwareBundle`: Now only return composer-based compatibility constraint
- Build commands (`extension_build.go`, `extension_zip.go`, `zip.go`): Use `GetShopwareVersionConstraintForBuild` to respect build overrides during asset building

## Why?

This change prevents the build-time override from leaking into the extension's reported compatibility constraint. Previously, when a build override was set, it would be returned by `GetShopwareVersionConstraint()`, which is used for account store uploads. This would cause the extension to report incorrect compatible Shopware versions to the store.

The new structure ensures:
- The compatibility constraint always reflects what the extension actually supports (from composer/manifest)
- The build-time override is only used when building assets for a specific Shopware version
- Clear separation of concerns with dedicated functions for each use case

## How was this tested?

Added comprehensive test coverage:
- `TestGetShopwareVersionConstraintFromComposer`: Tests that composer constraint is always used, build override is ignored
- `TestGetShopwareBuildVersionConstraint`: Tests build override extraction and nil handling
- `TestGetShopwareVersionConstraintForBuild`: Tests override precedence and fallback behavior
- Updated `mockExtension` to support constraint injection for testing

Existing tests updated to reflect the new function signatures.

## Related issue or discussion

N/A

https://claude.ai/code/session_018rSkJatbBwyr1BUigjNd11