### PR TITLE
feat(project): recover from composer security-advisory blocking in project create

### DIFF
--- a/cmd/project/project_create.go
+++ b/cmd/project/project_create.go
@@ -112,7 +112,7 @@ var projectCreateCmd = &cobra.Command{
 			return err
 		}
 
-		return installAndFinalize(cmd, &opts, phpConstraint)
+		return installAndFinalize(cmd, &opts, phpConstraint, chosenVersion)
 	},
 }
 

--- a/cmd/project/project_create_install.go
+++ b/cmd/project/project_create_install.go
@@ -1,12 +1,16 @@
 package project
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 
@@ -18,7 +22,7 @@ import (
 	"github.com/shopware/shopware-cli/logging"
 )
 
-func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *shop.PHPConstraint) error {
+func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *shop.PHPConstraint, chosenVersion string) error {
 	ctx := cmd.Context()
 
 	logging.FromContext(ctx).Infof("Installing dependencies")
@@ -31,8 +35,18 @@ func installAndFinalize(cmd *cobra.Command, opts *createOptions, phpConstraint *
 		logging.FromContext(ctx).Infof("Using PHP %s for composer install", composerInstallPHP)
 	}
 
-	if err := runComposerInstall(ctx, opts.projectFolder, opts.useDocker, showSpinner, composerInstallPHP); err != nil {
-		return err
+	if output, err := runComposerInstall(ctx, opts.projectFolder, opts.useDocker, showSpinner, composerInstallPHP); err != nil {
+		if !isComposerSecurityBlocked(output) || opts.noAudit {
+			return err
+		}
+
+		if err := handleSecurityBlockedInstall(ctx, opts, chosenVersion); err != nil {
+			return err
+		}
+
+		if _, err := runComposerInstall(ctx, opts.projectFolder, opts.useDocker, showSpinner, composerInstallPHP); err != nil {
+			return err
+		}
 	}
 
 	if opts.useDocker {
@@ -103,13 +117,53 @@ func printCreateSummary(ctx context.Context, opts *createOptions) {
 	fmt.Println()
 }
 
-func runComposerInstall(ctx context.Context, projectFolder string, useDocker bool, showSpinner bool, phpVersion string) error {
+// isComposerSecurityBlocked reports whether composer output indicates that
+// dependency resolution failed because packages affected by security
+// advisories were blocked (composer >= 2.9 with audit blocking enabled).
+func isComposerSecurityBlocked(output string) bool {
+	return strings.Contains(output, "affected by security advisories")
+}
+
+// handleSecurityBlockedInstall is called when composer refused to install
+// dependencies affected by security advisories. Interactively it asks the user
+// whether to continue without audit blocking and rewrites composer.json with
+// audit blocking disabled; non-interactively it fails with a --no-audit hint.
+func handleSecurityBlockedInstall(ctx context.Context, opts *createOptions, chosenVersion string) error {
+	if !opts.interactive {
+		return fmt.Errorf("dependencies of Shopware %s are affected by known security advisories; re-run with --no-audit to proceed. We strongly recommend installing the Shopware Security plugin (https://store.shopware.com/en/swag136939272659f/shopware-6-security-plugin.html) which backports security fixes to older versions", chosenVersion)
+	}
+
+	var continueAnyway string
+	if err := huh.NewForm(huh.NewGroup(
+		tui.NewYesNo().
+			Title(fmt.Sprintf("Dependencies of Shopware %s are affected by known security advisories", chosenVersion)).
+			Description("Composer refused to install packages affected by security advisories. Continuing will disable composer's audit blocking (--no-audit) so installation can proceed. If you continue, we strongly recommend installing the Shopware Security plugin (https://store.shopware.com/en/swag136939272659f/shopware-6-security-plugin.html) which backports security fixes to older versions. Do you want to continue anyway?").
+			Value(&continueAnyway),
+	)).Run(); err != nil {
+		return err
+	}
+
+	if continueAnyway == tui.No {
+		return fmt.Errorf("project creation cancelled")
+	}
+
+	opts.noAudit = true
+	scaffold := newShopwareProjectScaffold(opts, chosenVersion)
+	if err := scaffold.WriteComposerJson(ctx); err != nil {
+		return err
+	}
+
+	logging.FromContext(ctx).Infof("Retrying installation with audit blocking disabled")
+	return nil
+}
+
+func runComposerInstall(ctx context.Context, projectFolder string, useDocker bool, showSpinner bool, phpVersion string) (string, error) {
 	var cmdInstall *exec.Cmd
 
 	if useDocker && !system.IsInsideContainer() {
 		absProjectFolder, err := filepath.Abs(projectFolder)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		dockerArgs := []string{"run",
@@ -140,7 +194,7 @@ func runComposerInstall(ctx context.Context, projectFolder string, useDocker boo
 	} else {
 		composerBinary, err := exec.LookPath("composer")
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		phpBinary := os.Getenv("PHP_BINARY")
@@ -154,13 +208,20 @@ func runComposerInstall(ctx context.Context, projectFolder string, useDocker boo
 		cmdInstall.Dir = projectFolder
 	}
 
+	var output bytes.Buffer
+
 	if !showSpinner {
 		cmdInstall.Stdin = os.Stdin
-		cmdInstall.Stdout = os.Stdout
-		cmdInstall.Stderr = os.Stderr
+		cmdInstall.Stdout = io.MultiWriter(os.Stdout, &output)
+		cmdInstall.Stderr = io.MultiWriter(os.Stderr, &output)
 
-		return cmdInstall.Run()
+		err := cmdInstall.Run()
+		return output.String(), err
 	}
 
-	return tui.RunSpinnerWithLogs(ctx, "Installing dependencies", cmdInstall)
+	cmdInstall.Stdout = &output
+	cmdInstall.Stderr = &output
+
+	err := tui.RunSpinnerWithLogs(ctx, "Installing dependencies", cmdInstall)
+	return output.String(), err
 }

--- a/cmd/project/project_create_test.go
+++ b/cmd/project/project_create_test.go
@@ -79,3 +79,36 @@ func TestApplyNonInteractiveDefaults(t *testing.T) {
 		assert.Equal(t, "my-shop", opts.projectFolder)
 	})
 }
+
+func TestIsComposerSecurityBlocked(t *testing.T) {
+	t.Parallel()
+
+	t.Run("detects packages blocked by security advisories", func(t *testing.T) {
+		t.Parallel()
+		output := `- shopware/core v6.7.12.1 requires dompdf/dompdf 3.1.4 -> found dompdf/dompdf[v3.1.4] but these were not loaded, because they are affected by security advisories ("PKSA-cv56-2228-pzqx")`
+		assert.True(t, isComposerSecurityBlocked(output))
+	})
+
+	t.Run("ignores regular resolution conflicts", func(t *testing.T) {
+		t.Parallel()
+		output := `- shopware/administration v6.7.6.0 requires shopware/core v6.7.6.0 -> found shopware/core[v6.7.6.0] but it conflicts with your root composer.json require (6.7.12.1).`
+		assert.False(t, isComposerSecurityBlocked(output))
+	})
+
+	t.Run("ignores empty output", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, isComposerSecurityBlocked(""))
+	})
+}
+
+func TestHandleSecurityBlockedInstallNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	opts := createOptions{projectFolder: t.TempDir(), interactive: false}
+
+	err := handleSecurityBlockedInstall(t.Context(), &opts, "6.7.12.1")
+
+	assert.ErrorContains(t, err, "re-run with --no-audit")
+	assert.ErrorContains(t, err, "6.7.12.1")
+	assert.False(t, opts.noAudit)
+}

--- a/internal/shop/project_scaffold.go
+++ b/internal/shop/project_scaffold.go
@@ -91,15 +91,7 @@ func (s *ShopwareProjectScaffold) Scaffold(ctx context.Context) error {
 
 	logging.FromContext(ctx).Infof("Setting up Shopware %s", s.Version)
 
-	composerJSON, err := GenerateComposerJson(ctx, ComposerJsonOptions{
-		Version:          s.Version,
-		RC:               strings.Contains(s.Version, "rc"),
-		UseElasticsearch: s.UseElasticsearch,
-		UseAMQP:          s.UseAMQP,
-		NoAudit:          s.NoAudit,
-		DeploymentMethod: s.DeploymentMethod,
-	})
-	if err != nil {
+	if err := s.WriteComposerJson(ctx); err != nil {
 		return err
 	}
 
@@ -107,7 +99,6 @@ func (s *ShopwareProjectScaffold) Scaffold(ctx context.Context) error {
 		path    string
 		content string
 	}{
-		{path: "composer.json", content: composerJSON},
 		{path: ".env"},
 		{path: ".env.local", content: envLocalContent(s.UseDocker)},
 		{path: ".gitignore", content: "/.idea\n/.shopware-cli\n/vendor"},
@@ -138,6 +129,25 @@ func (s *ShopwareProjectScaffold) Scaffold(ctx context.Context) error {
 	}
 
 	return setupCI(ctx, s.ProjectFolder, s.CISystem, s.DeploymentMethod)
+}
+
+// WriteComposerJson (re)generates the project's composer.json from the
+// scaffold options, e.g. to disable composer's audit blocking after the
+// initial scaffold has been written.
+func (s *ShopwareProjectScaffold) WriteComposerJson(ctx context.Context) error {
+	composerJSON, err := GenerateComposerJson(ctx, ComposerJsonOptions{
+		Version:          s.Version,
+		RC:               strings.Contains(s.Version, "rc"),
+		UseElasticsearch: s.UseElasticsearch,
+		UseAMQP:          s.UseAMQP,
+		NoAudit:          s.NoAudit,
+		DeploymentMethod: s.DeploymentMethod,
+	})
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(s.ProjectFolder, "composer.json"), []byte(composerJSON), os.ModePerm)
 }
 
 func envLocalContent(useDocker bool) string {

--- a/internal/shop/project_scaffold_test.go
+++ b/internal/shop/project_scaffold_test.go
@@ -117,6 +117,26 @@ func TestShopwareProjectScaffold(t *testing.T) {
 	})
 }
 
+func TestWriteComposerJsonDisablesAuditBlocking(t *testing.T) {
+	t.Parallel()
+
+	projectFolder := t.TempDir()
+	scaffold := ShopwareProjectScaffold{
+		ProjectFolder: projectFolder,
+		Version:       "6.6.10.0",
+	}
+
+	require.NoError(t, scaffold.Scaffold(t.Context()))
+	assert.NotContains(t, readScaffoldFile(t, projectFolder, "composer.json"), `"block-insecure"`)
+
+	scaffold.NoAudit = true
+	require.NoError(t, scaffold.WriteComposerJson(t.Context()))
+
+	composerJSON := readScaffoldFile(t, projectFolder, "composer.json")
+	assert.Contains(t, composerJSON, `"block-insecure": false`)
+	assert.Contains(t, composerJSON, `"shopware/core": "6.6.10.0"`)
+}
+
 func TestSetupDeployment(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/progress_spinner.go
+++ b/internal/tui/progress_spinner.go
@@ -28,8 +28,16 @@ func runSpinnerWithLogs(ctx context.Context, title string, cmd *exec.Cmd, output
 	defer cancel()
 
 	var writer logWriter
-	cmd.Stdout = &writer
-	cmd.Stderr = &writer
+	if cmd.Stdout != nil {
+		cmd.Stdout = io.MultiWriter(cmd.Stdout, &writer)
+	} else {
+		cmd.Stdout = &writer
+	}
+	if cmd.Stderr != nil {
+		cmd.Stderr = io.MultiWriter(cmd.Stderr, &writer)
+	} else {
+		cmd.Stderr = &writer
+	}
 
 	s := spinner.New(
 		spinner.WithSpinner(spinner.Dot),

--- a/internal/tui/progress_spinner_test.go
+++ b/internal/tui/progress_spinner_test.go
@@ -83,6 +83,30 @@ func TestRunSpinnerWithLogs(t *testing.T) {
 	})
 }
 
+func TestRunSpinnerWithLogsTeesPresetWriters(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", "echo out; echo err >&2")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	var logLines []string
+	err := runSpinnerWithLogs(t.Context(), "Installing dependencies", cmd, &bytes.Buffer{}, func(_ context.Context, model tea.Model) error {
+		progress := model.(*installProgressModel)
+		progress.err = progress.cmd.Run()
+		logLines = progress.logWriter.GetLastLines(10)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The caller's writers still receive the command output...
+	assert.Equal(t, "out\n", stdout.String())
+	assert.Equal(t, "err\n", stderr.String())
+
+	// ...and the spinner's log writer captures it for the live log view.
+	assert.ElementsMatch(t, []string{"out", "err"}, logLines)
+}
+
 func TestLogWriterStoresAndTrimsLines(t *testing.T) {
 	var writer logWriter
 


### PR DESCRIPTION
## Problem

`project create` pre-checks security advisories, but only for `shopware/core`. When a **transitive dependency** is affected (e.g. `shopware/core 6.7.12.1` requires `dompdf/dompdf 3.1.4`, which has advisories), composer >= 2.9 refuses to load it during `composer install`:

```
- shopware/core v6.7.12.1 requires dompdf/dompdf 3.1.4 -> found dompdf/dompdf[v3.1.4] but these were not loaded, because they are affected by security advisories ("PKSA-...")
```

The install just failed with no guidance.

## Solution

Detect the security-blocking failure from the composer output and:

- **Interactive**: ask whether to continue anyway (same Yes/No form and Shopware Security plugin recommendation as the existing `shopware/core` pre-check). On yes, rewrite `composer.json` with `audit.block-insecure: false` and retry the install once.
- **Non-interactive**: fail with a hint to re-run with `--no-audit`, mirroring the pre-check's message.

Note: composer's `--no-audit` CLI flag does **not** bypass the blocking — it only suppresses the audit report (composer/composer#12607). The actual switch is the `audit.block-insecure: false` config, which our `--no-audit` flag already writes into the generated composer.json. The retry therefore regenerates composer.json via the existing `GenerateComposerJson` path, which also persists the setting for future `composer update` runs in the project.

## Changes

- `internal/tui/progress_spinner.go`: the spinner now tees command output into pre-set `cmd.Stdout`/`cmd.Stderr` instead of overwriting them, so callers can capture output while the live-log view keeps working.
- `cmd/project/project_create_install.go`: `runComposerInstall` returns the captured output; new `isComposerSecurityBlocked` detection and `handleSecurityBlockedInstall` prompt/retry logic.
- `internal/shop/project_scaffold.go`: composer.json writing extracted from `Scaffold` into a reusable `WriteComposerJson` method used by the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)