### PR TITLE
fix(extension): stop deleting unrelated zip files from the working directory

### DIFF
--- a/cmd/extension/extension_zip.go
+++ b/cmd/extension/extension_zip.go
@@ -51,19 +51,6 @@ var extensionZipCmd = &cobra.Command{
 			return fmt.Errorf("get name: %w", err)
 		}
 
-		// Clear previous zips
-		existingFiles, err := filepath.Glob(fmt.Sprintf("%s-*.zip", name))
-		if err != nil {
-			return err
-		}
-
-		for _, file := range existingFiles {
-			err = os.Remove(file)
-			if err != nil {
-				return fmt.Errorf("remove existing file: %w", err)
-			}
-		}
-
 		// Create temp dir
 		tempDir, err := os.MkdirTemp("", "extension")
 		if err != nil {

--- a/cmd/extension/extension_zip_test.go
+++ b/cmd/extension/extension_zip_test.go
@@ -1,0 +1,55 @@
+package extension
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZipDoesNotDeleteUnrelatedZipsInWorkingDirectory(t *testing.T) {
+	extDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(extDir, "composer.json"), []byte(`{
+		"name": "frosh/frosh-test",
+		"type": "shopware-platform-plugin",
+		"license": "MIT",
+		"version": "1.0.0",
+		"require": { "shopware/core": "~6.6.0" },
+		"autoload": { "psr-4": { "FroshTest\\": "src/" } },
+		"extra": {
+			"shopware-plugin-class": "FroshTest\\FroshTest",
+			"label": { "de-DE": "Test", "en-GB": "Test" }
+		}
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(extDir, ".shopware-extension.yml"), []byte(
+		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n",
+	), 0o644))
+
+	workDir := t.TempDir()
+	decoyBackup := filepath.Join(workDir, "FroshTest-backup-2024.zip")
+	decoyRelease := filepath.Join(workDir, "FroshTest-1.0.0.zip")
+	require.NoError(t, os.WriteFile(decoyBackup, []byte("precious"), 0o644))
+	require.NoError(t, os.WriteFile(decoyRelease, []byte("artifact"), 0o644))
+
+	t.Chdir(workDir)
+
+	disableGit = true
+	t.Cleanup(func() { disableGit = false })
+
+	outputDir := filepath.Join(workDir, "dist")
+	extensionZipCmd.SetContext(t.Context())
+	require.NoError(t, extensionZipCmd.Flags().Set("output-directory", outputDir))
+	require.NoError(t, extensionZipCmd.Flags().Set("filename", "custom-name.zip"))
+	t.Cleanup(func() {
+		_ = extensionZipCmd.Flags().Set("output-directory", "")
+		_ = extensionZipCmd.Flags().Set("filename", "")
+	})
+
+	require.NoError(t, extensionZipCmd.RunE(extensionZipCmd, []string{extDir}))
+
+	assert.FileExists(t, decoyBackup)
+	assert.FileExists(t, decoyRelease)
+	assert.FileExists(t, filepath.Join(outputDir, "custom-name.zip"))
+}


### PR DESCRIPTION
## What changed?

Removed the "Clear previous zips" block from `extension zip`. It globbed `<Name>-*.zip` in the process working directory and deleted every match before packing, ignoring `--filename` and `--output-directory`. No replacement is needed: the resolved output file is still overwritten on rebuild because the zip writer truncates it on create.

Before: running `extension zip --output-directory dist --filename custom-name.zip <path>` from a directory containing `FroshTest-backup-2024.zip` silently deleted that file.
After: user files in the working directory are never removed; only the resolved output file is written.

## Why?

Any user file matching the pattern (backups, old release artifacts) was destroyed without a prompt or log line, even when the new zip was written to a completely different location. See #1225 for the full analysis.

## How was this tested?

- New regression test `TestZipDoesNotDeleteUnrelatedZipsInWorkingDirectory` runs the command end-to-end with decoy files in the working directory. It fails on the previous code (both decoys deleted) and passes with the fix.
- Full `go test ./...` passes.
- Manual check that repeated builds still replace their own artifact in place.

## Related issue or discussion

Fixes #1225