### PR TITLE
feat(project): unique COMPOSE_PROJECT_NAME in .env for Docker volumes

### DIFF
--- a/internal/devtui/model_update.go
+++ b/internal/devtui/model_update.go
@@ -303,6 +303,14 @@ func (m Model) saveMigrationWizard() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Host-side Compose project name so Docker volumes stay unique for this tree.
+	if err := shop.EnsureComposeProjectName(m.projectRoot); err != nil {
+		m.migrationWizard.err = err
+		m.migrationWizard.step = migrationStepDone
+		trackEvent(tracking.EventDevMigrationWizard, migrationWizardTags(tracking.ResultFailed, m.migrationWizard))
+		return m, nil
+	}
+
 	changed, err := ensureDeploymentHelper(m.projectRoot)
 	if err != nil {
 		m.migrationWizard.err = err

--- a/internal/flexmigrator/env.go
+++ b/internal/flexmigrator/env.go
@@ -3,18 +3,36 @@ package flexmigrator
 import (
 	"os"
 	"path"
+
+	"github.com/shopware/shopware-cli/internal/shop"
 )
 
 func MigrateEnv(project string) error {
-	_, envLocalErr := os.Stat(path.Join(project, ".env.local"))
-	_, envErr := os.Stat(path.Join(project, ".env"))
+	envPath := path.Join(project, ".env")
+	envLocalPath := path.Join(project, ".env.local")
+
+	_, envLocalErr := os.Stat(envLocalPath)
+	_, envErr := os.Stat(envPath)
 
 	if os.IsNotExist(envLocalErr) && !os.IsNotExist(envErr) {
-		if err := os.Rename(path.Join(project, ".env"), path.Join(project, ".env.local")); err != nil {
+		// Preserve host-side Compose project name across the flex split:
+		// application secrets move to .env.local; COMPOSE_PROJECT_NAME stays in .env.
+		envBytes, err := os.ReadFile(envPath)
+		if err != nil {
+			return err
+		}
+		composeName := shop.ExtractComposeProjectName(envBytes)
+
+		if err := os.Rename(envPath, envLocalPath); err != nil {
 			return err
 		}
 
-		return os.WriteFile(path.Join(project, ".env"), []byte(""), 0o644)
+		newEnv := ""
+		if composeName != "" {
+			newEnv = shop.ComposeProjectNameEnvKey + "=" + composeName + "\n"
+		}
+
+		return os.WriteFile(envPath, []byte(newEnv), 0o644)
 	}
 
 	return nil

--- a/internal/flexmigrator/env_test.go
+++ b/internal/flexmigrator/env_test.go
@@ -36,6 +36,26 @@ func TestMigrateEnv(t *testing.T) {
 		assert.Empty(t, string(envNewContent))
 	})
 
+	t.Run("preserves COMPOSE_PROJECT_NAME in new .env", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+
+		envContent := []byte("APP_ENV=dev\nCOMPOSE_PROJECT_NAME=sw-shop-abcdef\nAPP_SECRET=test\n")
+		err := os.WriteFile(filepath.Join(tempDir, ".env"), envContent, 0o644)
+		require.NoError(t, err)
+
+		err = MigrateEnv(tempDir)
+		require.NoError(t, err)
+
+		envLocalContent, err := os.ReadFile(filepath.Join(tempDir, ".env.local"))
+		require.NoError(t, err)
+		assert.Equal(t, envContent, envLocalContent)
+
+		envNewContent, err := os.ReadFile(filepath.Join(tempDir, ".env"))
+		require.NoError(t, err)
+		assert.Equal(t, "COMPOSE_PROJECT_NAME=sw-shop-abcdef\n", string(envNewContent))
+	})
+
 	t.Run("no migration needed when .env.local exists", func(t *testing.T) {
 		t.Parallel()
 		// Create a temporary directory for the test

--- a/internal/shop/compose_project_name.go
+++ b/internal/shop/compose_project_name.go
@@ -1,0 +1,115 @@
+package shop
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ComposeProjectNameEnvKey is the host-side Docker Compose project name written
+// to the project .env (not .env.local). Compose loads .env automatically when
+// commands run with Dir = project root.
+const ComposeProjectNameEnvKey = "COMPOSE_PROJECT_NAME"
+
+var nonComposeNameChars = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// GenerateComposeProjectName builds a unique Compose project name that satisfies
+// ProjectNameRule / ValidateProjectName. Format: sw-<basename>-<6 hex>.
+// The random suffix avoids volume reuse when a directory is deleted and
+// recreated with the same basename.
+func GenerateComposeProjectName(projectFolder string) (string, error) {
+	base := strings.ToLower(filepath.Base(projectFolder))
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		base = "shop"
+	}
+
+	base = nonComposeNameChars.ReplaceAllString(base, "-")
+	base = strings.Trim(base, "-_")
+	if base == "" {
+		base = "shop"
+	}
+	// Compose names must start with a letter or digit.
+	if base[0] == '-' || base[0] == '_' {
+		base = "x" + base
+	}
+
+	var suffix [3]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("generate compose project name: %w", err)
+	}
+
+	name := fmt.Sprintf("sw-%s-%s", base, hex.EncodeToString(suffix[:]))
+	if err := ValidateProjectName(name); err != nil {
+		return "", err
+	}
+
+	return name, nil
+}
+
+// EnvFileContent returns the initial host .env contents for a scaffolded project.
+// Docker projects get a unique COMPOSE_PROJECT_NAME so Compose volumes are not
+// reused across same-basename recreations. Non-docker projects get an empty .env.
+func EnvFileContent(useDocker bool, projectFolder string) (string, error) {
+	if !useDocker {
+		return "", nil
+	}
+
+	name, err := GenerateComposeProjectName(projectFolder)
+	if err != nil {
+		return "", err
+	}
+
+	return ComposeProjectNameEnvKey + "=" + name + "\n", nil
+}
+
+// ExtractComposeProjectName returns the COMPOSE_PROJECT_NAME value from raw
+// dotenv content, or "" when unset.
+func ExtractComposeProjectName(envContent []byte) string {
+	for _, line := range strings.Split(string(envContent), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == ComposeProjectNameEnvKey {
+			return strings.TrimSpace(value)
+		}
+	}
+
+	return ""
+}
+
+// EnsureComposeProjectName writes COMPOSE_PROJECT_NAME into the project .env
+// when it is not already set. Existing values are left untouched (no silent
+// volume disconnect for established stacks). The file is created when missing.
+func EnsureComposeProjectName(projectRoot string) error {
+	envPath := filepath.Join(projectRoot, ".env")
+	existing, err := os.ReadFile(envPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if ExtractComposeProjectName(existing) != "" {
+		return nil
+	}
+
+	name, err := GenerateComposeProjectName(projectRoot)
+	if err != nil {
+		return err
+	}
+
+	content := existing
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		content = append(content, '\n')
+	}
+	content = append(content, []byte(ComposeProjectNameEnvKey+"="+name+"\n")...)
+
+	return os.WriteFile(envPath, content, 0o644)
+}

--- a/internal/shop/compose_project_name.go
+++ b/internal/shop/compose_project_name.go
@@ -32,10 +32,7 @@ func GenerateComposeProjectName(projectFolder string) (string, error) {
 	if base == "" {
 		base = "shop"
 	}
-	// Compose names must start with a letter or digit.
-	if base[0] == '-' || base[0] == '_' {
-		base = "x" + base
-	}
+	// Note: the "sw-" prefix already satisfies ValidateProjectName's leading-character rule.
 
 	var suffix [3]byte
 	if _, err := rand.Read(suffix[:]); err != nil {

--- a/internal/shop/compose_project_name_test.go
+++ b/internal/shop/compose_project_name_test.go
@@ -1,0 +1,100 @@
+package shop
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateComposeProjectName(t *testing.T) {
+	t.Parallel()
+
+	name, err := GenerateComposeProjectName("/tmp/my-shop")
+	require.NoError(t, err)
+	assert.Regexp(t, regexp.MustCompile(`^sw-my-shop-[0-9a-f]{6}$`), name)
+	assert.NoError(t, ValidateProjectName(name))
+
+	// Same basename must still differ (random suffix).
+	name2, err := GenerateComposeProjectName("/other/my-shop")
+	require.NoError(t, err)
+	assert.NotEqual(t, name, name2)
+
+	// Sanitize invalid basename characters.
+	weird, err := GenerateComposeProjectName(filepath.Join(t.TempDir(), "My Shop!"))
+	require.NoError(t, err)
+	assert.Regexp(t, regexp.MustCompile(`^sw-my-shop-[0-9a-f]{6}$`), weird)
+	assert.NoError(t, ValidateProjectName(weird))
+}
+
+func TestEnvFileContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-docker is empty", func(t *testing.T) {
+		t.Parallel()
+		content, err := EnvFileContent(false, "/tmp/shop")
+		require.NoError(t, err)
+		assert.Empty(t, content)
+	})
+
+	t.Run("docker writes unique compose project name", func(t *testing.T) {
+		t.Parallel()
+		content, err := EnvFileContent(true, "/tmp/demo-shop")
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(content, ComposeProjectNameEnvKey+"=sw-demo-shop-"))
+		assert.True(t, strings.HasSuffix(content, "\n"))
+		assert.NoError(t, ValidateProjectName(strings.TrimPrefix(strings.TrimSpace(content), ComposeProjectNameEnvKey+"=")))
+	})
+}
+
+func TestExtractComposeProjectName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "sw-shop-abc123", ExtractComposeProjectName([]byte("FOO=bar\nCOMPOSE_PROJECT_NAME=sw-shop-abc123\nAPP=1\n")))
+	assert.Empty(t, ExtractComposeProjectName([]byte("APP_ENV=dev\n")))
+	assert.Empty(t, ExtractComposeProjectName(nil))
+}
+
+func TestEnsureComposeProjectName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes when missing", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, EnsureComposeProjectName(dir))
+
+		content, err := os.ReadFile(filepath.Join(dir, ".env"))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), ComposeProjectNameEnvKey+"=")
+		assert.NotEmpty(t, ExtractComposeProjectName(content))
+	})
+
+	t.Run("preserves existing", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("COMPOSE_PROJECT_NAME=sw-keep-ffffff\n"), 0o644))
+
+		require.NoError(t, EnsureComposeProjectName(dir))
+
+		content, err := os.ReadFile(filepath.Join(dir, ".env"))
+		require.NoError(t, err)
+		assert.Equal(t, "sw-keep-ffffff", ExtractComposeProjectName(content))
+	})
+
+	t.Run("appends without clobbering other keys", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("FOO=bar"), 0o644))
+
+		require.NoError(t, EnsureComposeProjectName(dir))
+
+		content, err := os.ReadFile(filepath.Join(dir, ".env"))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "FOO=bar")
+		assert.Contains(t, string(content), ComposeProjectNameEnvKey+"=")
+	})
+}

--- a/internal/shop/project_scaffold.go
+++ b/internal/shop/project_scaffold.go
@@ -95,11 +95,16 @@ func (s *ShopwareProjectScaffold) Scaffold(ctx context.Context) error {
 		return err
 	}
 
+	envContent, err := EnvFileContent(s.UseDocker, s.ProjectFolder)
+	if err != nil {
+		return err
+	}
+
 	files := []struct {
 		path    string
 		content string
 	}{
-		{path: ".env"},
+		{path: ".env", content: envContent},
 		{path: ".env.local", content: envLocalContent(s.UseDocker)},
 		{path: ".gitignore", content: "/.idea\n/.shopware-cli\n/vendor"},
 	}

--- a/internal/shop/project_scaffold_test.go
+++ b/internal/shop/project_scaffold_test.go
@@ -3,6 +3,7 @@ package shop
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +52,7 @@ func TestShopwareProjectScaffold(t *testing.T) {
 	t.Run("configures Docker without Symfony CLI php.ini", func(t *testing.T) {
 		t.Parallel()
 
-		projectFolder := t.TempDir()
+		projectFolder := filepath.Join(t.TempDir(), "demo-shop")
 		scaffold := ShopwareProjectScaffold{
 			ProjectFolder:       projectFolder,
 			Version:             "6.6.10.0",
@@ -65,6 +66,36 @@ func TestShopwareProjectScaffold(t *testing.T) {
 
 		assert.Equal(t, "APP_ENV=dev\n", readScaffoldFile(t, projectFolder, ".env.local"))
 		assert.NoFileExists(t, filepath.Join(projectFolder, "php.ini"))
+
+		envContent := readScaffoldFile(t, projectFolder, ".env")
+		assert.True(t, strings.HasPrefix(envContent, ComposeProjectNameEnvKey+"=sw-demo-shop-"), "got %q", envContent)
+		assert.True(t, strings.HasSuffix(envContent, "\n"))
+		name := strings.TrimPrefix(strings.TrimSpace(envContent), ComposeProjectNameEnvKey+"=")
+		assert.NoError(t, ValidateProjectName(name))
+
+		// Two docker scaffolds with the same basename get different compose names.
+		projectFolder2 := filepath.Join(t.TempDir(), "demo-shop")
+		scaffold2 := scaffold
+		scaffold2.ProjectFolder = projectFolder2
+		require.NoError(t, scaffold2.Scaffold(t.Context()))
+		env2 := readScaffoldFile(t, projectFolder2, ".env")
+		assert.NotEqual(t, envContent, env2)
+	})
+
+	t.Run("non-docker leaves .env empty without compose project name", func(t *testing.T) {
+		t.Parallel()
+
+		projectFolder := filepath.Join(t.TempDir(), "plain-shop")
+		scaffold := ShopwareProjectScaffold{
+			ProjectFolder:    projectFolder,
+			Version:          "6.6.10.0",
+			DeploymentMethod: DeploymentNone,
+			CISystem:         CINone,
+			UseDocker:        false,
+		}
+		require.NoError(t, scaffold.Scaffold(t.Context()))
+		assert.Empty(t, readScaffoldFile(t, projectFolder, ".env"))
+		assert.NotContains(t, readScaffoldFile(t, projectFolder, ".env"), ComposeProjectNameEnvKey)
 	})
 
 	t.Run("creates the selected deployment and CI files", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements [#1251](https://github.com/shopware/shopware-cli/issues/1251).

Docker Compose was using the directory basename as the project name, so named volumes (`db-data`, …) collided when a project folder was deleted and recreated with the same name (or two trees shared a basename). That made `system:is-installed` succeed against **stale** DB data and skip the install wizard.

### Changes
| Area | Behaviour |
|---|---|
| `project create --docker` | Writes `COMPOSE_PROJECT_NAME=sw-<basename>-<6hex>` to host **`.env`** (not `.env.local`) |
| Non-docker create | `.env` stays empty |
| Existing projects | Unset → basename behaviour (backward compatible); already set → left alone |
| `flexmigrator.MigrateEnv` | Keeps `COMPOSE_PROJECT_NAME` in the new empty `.env` when splitting flex env |
| Migration wizard → Docker | `EnsureComposeProjectName` if missing |

Compose still runs with `Dir = projectRoot` (`devtui/compose.go`) and picks up `.env` automatically — no `-p` / compose `name:` key required.

### Tests
- `go test ./internal/shop/ ./internal/flexmigrator/ ./internal/devtui/ -run Migration…`
- Scaffold docker vs non-docker, uniqueness of same basename, flex preserve, Ensure* preserve/append

## Checklist
- [x] `project create --docker` writes unique name to `.env`
- [x] Two creates with same folder name get different names
- [x] Non-docker does not require a project name
- [x] Tests for scaffold docker vs non-docker
- [x] Migration wizard path sets name if missing