### PR TITLE
feat(extension): rename `extension zip` to `extension package`

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -46,10 +46,10 @@ jobs:
         run: shopware-cli project create shopware 6.5.7.3 --no-audit
 
       - name: Build asset of Plugin
-        run: shopware-cli extension zip plugin
+        run: shopware-cli extension package plugin
 
       - name: Build asset of Plugin without Git
-        run: shopware-cli extension zip plugin --disable-git --release
+        run: shopware-cli extension package plugin --disable-git --release
 
       - name: Validate Plugin
         run: shopware-cli extension validate FroshTools.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ shopware-cli extension admin-watch
 shopware-cli extension validate
 
 # Create distribution package
-shopware-cli extension zip
+shopware-cli extension package
 ```
 
 ### Project Management

--- a/cmd/extension/extension_package.go
+++ b/cmd/extension/extension_package.go
@@ -24,11 +24,16 @@ var (
 	extensionReleaseMode = false
 )
 
-var extensionZipCmd = &cobra.Command{
-	Use:   "zip [path] [branch]",
-	Short: "Zip an extension",
-	Args:  cobra.MinimumNArgs(1),
+var extensionPackageCmd = &cobra.Command{
+	Use:     "package [path] [branch]",
+	Short:   "Package an extension",
+	Aliases: []string{"zip"},
+	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if cmd.CalledAs() == "zip" {
+			logging.FromContext(cmd.Context()).Warnf("`extension zip` is deprecated, use `extension package` instead")
+		}
+
 		extPath, err := filepath.Abs(args[0])
 		if err != nil {
 			return err
@@ -222,18 +227,18 @@ var extensionZipCmd = &cobra.Command{
 }
 
 func init() {
-	extensionRootCmd.AddCommand(extensionZipCmd)
-	extensionZipCmd.Flags().BoolVar(&disableGit, "disable-git", false, "Use the source folder as it is")
-	extensionZipCmd.Flags().BoolVar(&extensionReleaseMode, "release", false, "Release mode (remove app secrets)")
-	extensionZipCmd.Flags().String("overwrite-app-backend-url", "", "Change all URLs in manifest.xml to this URL")
-	extensionZipCmd.Flags().String("overwrite-app-backend-secret", "", "Change the secret to this value")
-	extensionZipCmd.Flags().String("overwrite-version", "", "Change the extension version to this value")
-	extensionZipCmd.Flags().Bool("use-git-tag-as-version", false, "Use the detected git tag as the extension version")
-	extensionZipCmd.MarkFlagsMutuallyExclusive("use-git-tag-as-version", "disable-git")
-	extensionZipCmd.MarkFlagsMutuallyExclusive("use-git-tag-as-version", "overwrite-version")
-	extensionZipCmd.Flags().String("output-directory", "", "Output directory for the zip file")
-	extensionZipCmd.Flags().String("git-commit", "", "Commit Hash / Tag to use")
-	extensionZipCmd.Flags().String("filename", "", "Name of the zip file, if not set it will be generated from the extension name and tag")
+	extensionRootCmd.AddCommand(extensionPackageCmd)
+	extensionPackageCmd.Flags().BoolVar(&disableGit, "disable-git", false, "Use the source folder as it is")
+	extensionPackageCmd.Flags().BoolVar(&extensionReleaseMode, "release", false, "Release mode (remove app secrets)")
+	extensionPackageCmd.Flags().String("overwrite-app-backend-url", "", "Change all URLs in manifest.xml to this URL")
+	extensionPackageCmd.Flags().String("overwrite-app-backend-secret", "", "Change the secret to this value")
+	extensionPackageCmd.Flags().String("overwrite-version", "", "Change the extension version to this value")
+	extensionPackageCmd.Flags().Bool("use-git-tag-as-version", false, "Use the detected git tag as the extension version")
+	extensionPackageCmd.MarkFlagsMutuallyExclusive("use-git-tag-as-version", "disable-git")
+	extensionPackageCmd.MarkFlagsMutuallyExclusive("use-git-tag-as-version", "overwrite-version")
+	extensionPackageCmd.Flags().String("output-directory", "", "Output directory for the zip file")
+	extensionPackageCmd.Flags().String("git-commit", "", "Commit Hash / Tag to use")
+	extensionPackageCmd.Flags().String("filename", "", "Name of the zip file, if not set it will be generated from the extension name and tag")
 }
 
 func getStringOnStringError(val string, _ error) string {

--- a/cmd/extension/extension_package_test.go
+++ b/cmd/extension/extension_package_test.go
@@ -9,20 +9,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestZipDoesNotDeleteUnrelatedZipsInWorkingDirectory(t *testing.T) {
+func TestPackageDoesNotDeleteUnrelatedZipsInWorkingDirectory(t *testing.T) {
 	extDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(extDir, "composer.json"), []byte(`{
-		"name": "frosh/frosh-test",
-		"type": "shopware-platform-plugin",
-		"license": "MIT",
-		"version": "1.0.0",
-		"require": { "shopware/core": "~6.6.0" },
-		"autoload": { "psr-4": { "FroshTest\\": "src/" } },
-		"extra": {
-			"shopware-plugin-class": "FroshTest\\FroshTest",
-			"label": { "de-DE": "Test", "en-GB": "Test" }
-		}
-	}`), 0o644))
+			"name": "frosh/frosh-test",
+			"type": "shopware-platform-plugin",
+			"license": "MIT",
+			"version": "1.0.0",
+			"require": { "shopware/core": "~6.6.0" },
+			"autoload": { "psr-4": { "FroshTest\\": "src/" } },
+			"extra": {
+				"shopware-plugin-class": "FroshTest\\FroshTest",
+				"label": { "de-DE": "Test", "en-GB": "Test" }
+			}
+		}`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(extDir, ".shopware-extension.yml"), []byte(
 		"build:\n  zip:\n    composer:\n      enabled: false\n    assets:\n      enabled: false\n",
 	), 0o644))
@@ -39,15 +39,15 @@ func TestZipDoesNotDeleteUnrelatedZipsInWorkingDirectory(t *testing.T) {
 	t.Cleanup(func() { disableGit = false })
 
 	outputDir := filepath.Join(workDir, "dist")
-	extensionZipCmd.SetContext(t.Context())
-	require.NoError(t, extensionZipCmd.Flags().Set("output-directory", outputDir))
-	require.NoError(t, extensionZipCmd.Flags().Set("filename", "custom-name.zip"))
+	extensionPackageCmd.SetContext(t.Context())
+	require.NoError(t, extensionPackageCmd.Flags().Set("output-directory", outputDir))
+	require.NoError(t, extensionPackageCmd.Flags().Set("filename", "custom-name.zip"))
 	t.Cleanup(func() {
-		_ = extensionZipCmd.Flags().Set("output-directory", "")
-		_ = extensionZipCmd.Flags().Set("filename", "")
+		_ = extensionPackageCmd.Flags().Set("output-directory", "")
+		_ = extensionPackageCmd.Flags().Set("filename", "")
 	})
 
-	require.NoError(t, extensionZipCmd.RunE(extensionZipCmd, []string{extDir}))
+	require.NoError(t, extensionPackageCmd.RunE(extensionPackageCmd, []string{extDir}))
 
 	assert.FileExists(t, decoyBackup)
 	assert.FileExists(t, decoyRelease)

--- a/internal/extension/asset_config.go
+++ b/internal/extension/asset_config.go
@@ -294,7 +294,7 @@ func (e *ExtensionAssetConfigEntry) GetContentHash() (string, error) {
 	for _, file := range files {
 		// Write the BasePath-relative file path so the hash stays stable
 		// regardless of where the extension is located on disk (e.g. the
-		// temp directory used by `extension zip`).
+		// temp directory used by `extension package`).
 		if _, err := hasher.Write([]byte(e.relPath(file))); err != nil {
 			return "", err
 		}
@@ -440,7 +440,7 @@ func (e *ExtensionAssetConfigEntry) hashSingleFile(filePath string) (uint64, err
 // relPath returns the given path relative to the extension BasePath. It is used
 // when folding file paths into the content hash so the resulting cache key is
 // independent of the absolute extension location (e.g. the temp directory used
-// by `extension zip`). It falls back to the input path if it cannot be made
+// by `extension package`). It falls back to the input path if it cannot be made
 // relative.
 func (e *ExtensionAssetConfigEntry) relPath(p string) string {
 	rel, err := filepath.Rel(filepath.Clean(e.BasePath), p)

--- a/internal/extension/asset_config_test.go
+++ b/internal/extension/asset_config_test.go
@@ -41,7 +41,7 @@ func TestGetContentHash_AdditionalCaches(t *testing.T) {
 }
 
 func TestGetContentHash_StableAcrossBasePaths(t *testing.T) {
-	// `extension zip` copies the extension into a fresh temp dir on every run,
+	// `extension package` copies the extension into a fresh temp dir on every run,
 	// so the content hash must not depend on the absolute BasePath, otherwise
 	// the cache key changes every run and never hits.
 	build := func(t *testing.T) string {


### PR DESCRIPTION
## Summary
- Rename `extension zip` to `extension package` so the command name reflects packaging intent rather than the artifact format
- Keep `extension zip` as a deprecated alias that routes to the same implementation and logs a deprecation warning
- Update docs, smoke tests, and related comments to the new command name

Closes #1256

## Test plan
- [x] `go test ./cmd/extension/ -run Package`
- [ ] `shopware-cli extension package <path>` produces the same package as before
- [ ] `shopware-cli extension zip <path>` still works and prints the deprecation warning
- [ ] `shopware-cli extension package --help` lists existing flags and shows `zip` as an alias