### PR TITLE
feat(account): add type and JSON filters to store extension list

### DIFF
--- a/cmd/account/account_producer_extension_list.go
+++ b/cmd/account/account_producer_extension_list.go
@@ -72,7 +72,8 @@ func init() {
 }
 
 // filterProducerExtensions removes deleted/classic/empty entries and optionally
-// keeps only plugins or apps (matched on Generation.Name).
+// keeps only plugins or apps. Account API generation names are "platform" (plugins)
+// and "apps" (apps).
 func filterProducerExtensions(extensions []account_api.Extension, pluginOnly, appOnly bool) []account_api.Extension {
 	filtered := make([]account_api.Extension, 0, len(extensions))
 	for _, extension := range extensions {
@@ -88,13 +89,21 @@ func includeProducerExtension(extension account_api.Extension, pluginOnly, appOn
 	if extension.Status.Name == "deleted" || extension.Name == "" || extension.Generation.Name == "classic" {
 		return false
 	}
-	if pluginOnly && extension.Generation.Name != "plugin" {
+	if pluginOnly && !isProducerPlugin(extension.Generation.Name) {
 		return false
 	}
-	if appOnly && extension.Generation.Name != "app" {
+	if appOnly && !isProducerApp(extension.Generation.Name) {
 		return false
 	}
 	return true
+}
+
+func isProducerPlugin(generation string) bool {
+	return generation == "platform"
+}
+
+func isProducerApp(generation string) bool {
+	return generation == "apps"
 }
 
 type producerExtensionListItem struct {

--- a/cmd/account/account_producer_extension_list.go
+++ b/cmd/account/account_producer_extension_list.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"cmp"
+	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -26,7 +27,7 @@ var accountCompanyProducerExtensionListCmd = &cobra.Command{
 			Limit: 100,
 		}
 
-		if len(listExtensionSearch) > 0 {
+		if listExtensionSearch != "" {
 			criteria.Search = listExtensionSearch
 			criteria.OrderBy = "name"
 			criteria.OrderSequence = "asc"
@@ -37,6 +38,8 @@ var accountCompanyProducerExtensionListCmd = &cobra.Command{
 			return err
 		}
 
+		extensions = filterProducerExtensions(extensions, listExtensionPlugin, listExtensionApp)
+
 		slices.SortFunc(extensions, func(a, b account_api.Extension) int {
 			if c := cmp.Compare(a.Producer.Name, b.Producer.Name); c != 0 {
 				return c
@@ -44,58 +47,125 @@ var accountCompanyProducerExtensionListCmd = &cobra.Command{
 			return cmp.Compare(a.Name, b.Name)
 		})
 
-		cellStyle := lipgloss.NewStyle().Padding(0, 1)
-
-		t := liplogtable.New().
-			Border(lipgloss.NormalBorder()).
-			StyleFunc(func(row, col int) lipgloss.Style {
-				return cellStyle
-			}).
-			Headers("Name", "Type", "Compatible with latest version", "Status")
-
-		lastProducerId := 0
-		for _, extension := range extensions {
-			if extension.Status.Name == "deleted" || extension.Name == "" || extension.Generation.Name == "classic" {
-				continue
-			}
-
-			if extension.Producer.Id != lastProducerId {
-				lastProducerId = extension.Producer.Id
-				t.Row(tui.BoldText.Render(extension.Producer.Name), "", "", "")
-			}
-
-			compatible := tui.RedText.Render("No")
-			if extension.IsCompatibleWithLatestShopwareVersion {
-				compatible = tui.GreenText.Render("Yes")
-			}
-
-			var status string
-			switch extension.Status.Name {
-			case "instore", "approved":
-				status = tui.GreenText.Render(extension.Status.Name)
-			case "incomplete", "waitingforapproval":
-				status = tui.YellowText.Render(extension.Status.Name)
-			default:
-				status = tui.DimText.Render(extension.Status.Name)
-			}
-
-			t.Row(
-				"  "+extension.Name,
-				tui.DimText.Render(extension.Generation.Description),
-				compatible,
-				status,
-			)
+		if listExtensionJSON {
+			return printProducerExtensionsJSON(extensions)
 		}
 
-		fmt.Println(t.Render())
-
-		return nil
+		return printProducerExtensionsTable(extensions)
 	},
 }
 
-var listExtensionSearch string
+var (
+	listExtensionSearch string
+	listExtensionPlugin bool
+	listExtensionApp    bool
+	listExtensionJSON   bool
+)
 
 func init() {
 	accountCompanyProducerExtensionCmd.AddCommand(accountCompanyProducerExtensionListCmd)
 	accountCompanyProducerExtensionListCmd.Flags().StringVar(&listExtensionSearch, "search", "", "Filter for name")
+	accountCompanyProducerExtensionListCmd.Flags().BoolVar(&listExtensionPlugin, "plugin", false, "Show only plugins")
+	accountCompanyProducerExtensionListCmd.Flags().BoolVar(&listExtensionApp, "app", false, "Show only apps")
+	accountCompanyProducerExtensionListCmd.Flags().BoolVar(&listExtensionJSON, "json", false, "Output as json")
+	accountCompanyProducerExtensionListCmd.MarkFlagsMutuallyExclusive("plugin", "app")
+}
+
+// filterProducerExtensions removes deleted/classic/empty entries and optionally
+// keeps only plugins or apps (matched on Generation.Name).
+func filterProducerExtensions(extensions []account_api.Extension, pluginOnly, appOnly bool) []account_api.Extension {
+	filtered := make([]account_api.Extension, 0, len(extensions))
+	for _, extension := range extensions {
+		if !includeProducerExtension(extension, pluginOnly, appOnly) {
+			continue
+		}
+		filtered = append(filtered, extension)
+	}
+	return filtered
+}
+
+func includeProducerExtension(extension account_api.Extension, pluginOnly, appOnly bool) bool {
+	if extension.Status.Name == "deleted" || extension.Name == "" || extension.Generation.Name == "classic" {
+		return false
+	}
+	if pluginOnly && extension.Generation.Name != "plugin" {
+		return false
+	}
+	if appOnly && extension.Generation.Name != "app" {
+		return false
+	}
+	return true
+}
+
+type producerExtensionListItem struct {
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Compatible bool   `json:"compatibleWithLatestVersion"`
+	Status     string `json:"status"`
+	Producer   string `json:"producer"`
+}
+
+func printProducerExtensionsJSON(extensions []account_api.Extension) error {
+	items := make([]producerExtensionListItem, 0, len(extensions))
+	for _, extension := range extensions {
+		items = append(items, producerExtensionListItem{
+			Name:       extension.Name,
+			Type:       extension.Generation.Name,
+			Compatible: extension.IsCompatibleWithLatestShopwareVersion,
+			Status:     extension.Status.Name,
+			Producer:   extension.Producer.Name,
+		})
+	}
+
+	content, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(content))
+	return nil
+}
+
+func printProducerExtensionsTable(extensions []account_api.Extension) error {
+	cellStyle := lipgloss.NewStyle().Padding(0, 1)
+
+	t := liplogtable.New().
+		Border(lipgloss.NormalBorder()).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			return cellStyle
+		}).
+		Headers("Name", "Type", "Compatible with latest version", "Status")
+
+	lastProducerId := 0
+	for _, extension := range extensions {
+		if extension.Producer.Id != lastProducerId {
+			lastProducerId = extension.Producer.Id
+			t.Row(tui.BoldText.Render(extension.Producer.Name), "", "", "")
+		}
+
+		compatible := tui.RedText.Render("No")
+		if extension.IsCompatibleWithLatestShopwareVersion {
+			compatible = tui.GreenText.Render("Yes")
+		}
+
+		var status string
+		switch extension.Status.Name {
+		case "instore", "approved":
+			status = tui.GreenText.Render(extension.Status.Name)
+		case "incomplete", "waitingforapproval":
+			status = tui.YellowText.Render(extension.Status.Name)
+		default:
+			status = tui.DimText.Render(extension.Status.Name)
+		}
+
+		t.Row(
+			"  "+extension.Name,
+			tui.DimText.Render(extension.Generation.Description),
+			compatible,
+			status,
+		)
+	}
+
+	fmt.Println(t.Render())
+	return nil
 }

--- a/cmd/account/account_producer_extension_list.go
+++ b/cmd/account/account_producer_extension_list.go
@@ -72,8 +72,7 @@ func init() {
 }
 
 // filterProducerExtensions removes deleted/classic/empty entries and optionally
-// keeps only plugins or apps. Account API generation names are "platform" (plugins)
-// and "apps" (apps).
+// keeps only plugins or apps.
 func filterProducerExtensions(extensions []account_api.Extension, pluginOnly, appOnly bool) []account_api.Extension {
 	filtered := make([]account_api.Extension, 0, len(extensions))
 	for _, extension := range extensions {
@@ -86,24 +85,16 @@ func filterProducerExtensions(extensions []account_api.Extension, pluginOnly, ap
 }
 
 func includeProducerExtension(extension account_api.Extension, pluginOnly, appOnly bool) bool {
-	if extension.Status.Name == "deleted" || extension.Name == "" || extension.Generation.Name == "classic" {
+	if extension.Status.Name == "deleted" || extension.Name == "" || extension.Generation.Name == account_api.ExtensionGenerationClassic {
 		return false
 	}
-	if pluginOnly && !isProducerPlugin(extension.Generation.Name) {
+	if pluginOnly && extension.Generation.Name != account_api.ExtensionGenerationPlatform {
 		return false
 	}
-	if appOnly && !isProducerApp(extension.Generation.Name) {
+	if appOnly && extension.Generation.Name != account_api.ExtensionGenerationApps {
 		return false
 	}
 	return true
-}
-
-func isProducerPlugin(generation string) bool {
-	return generation == "platform"
-}
-
-func isProducerApp(generation string) bool {
-	return generation == "apps"
 }
 
 type producerExtensionListItem struct {

--- a/cmd/account/account_producer_extension_list_test.go
+++ b/cmd/account/account_producer_extension_list_test.go
@@ -21,12 +21,12 @@ func testExtension(name, generation, status string) account_api.Extension {
 
 func TestFilterProducerExtensions(t *testing.T) {
 	extensions := []account_api.Extension{
-		testExtension("PaymentPlugin", "plugin", "approved"),
-		testExtension("ShippingApp", "app", "instore"),
+		testExtension("PaymentPlugin", "platform", "approved"),
+		testExtension("ShippingApp", "apps", "instore"),
 		testExtension("Legacy", "classic", "approved"),
-		testExtension("Gone", "plugin", "deleted"),
-		testExtension("", "plugin", "approved"),
-		testExtension("ThemePlugin", "plugin", "incomplete"),
+		testExtension("Gone", "platform", "deleted"),
+		testExtension("", "platform", "approved"),
+		testExtension("ThemePlugin", "platform", "incomplete"),
 	}
 
 	t.Run("no type filter keeps plugins and apps", func(t *testing.T) {
@@ -46,12 +46,13 @@ func TestFilterProducerExtensions(t *testing.T) {
 }
 
 func TestIncludeProducerExtension(t *testing.T) {
-	assert.True(t, includeProducerExtension(testExtension("A", "plugin", "approved"), false, false))
+	assert.True(t, includeProducerExtension(testExtension("A", "platform", "approved"), false, false))
 	assert.False(t, includeProducerExtension(testExtension("A", "classic", "approved"), false, false))
-	assert.False(t, includeProducerExtension(testExtension("A", "plugin", "deleted"), false, false))
-	assert.False(t, includeProducerExtension(testExtension("", "plugin", "approved"), false, false))
-	assert.False(t, includeProducerExtension(testExtension("A", "app", "approved"), true, false))
-	assert.True(t, includeProducerExtension(testExtension("A", "app", "approved"), false, true))
+	assert.False(t, includeProducerExtension(testExtension("A", "platform", "deleted"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("", "platform", "approved"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("A", "apps", "approved"), true, false))
+	assert.True(t, includeProducerExtension(testExtension("A", "apps", "approved"), false, true))
+	assert.True(t, includeProducerExtension(testExtension("A", "platform", "approved"), true, false))
 }
 
 func extensionNames(extensions []account_api.Extension) []string {

--- a/cmd/account/account_producer_extension_list_test.go
+++ b/cmd/account/account_producer_extension_list_test.go
@@ -1,0 +1,63 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	account_api "github.com/shopware/shopware-cli/internal/account-api"
+)
+
+func testExtension(name, generation, status string) account_api.Extension {
+	var ext account_api.Extension
+	ext.Name = name
+	ext.Generation.Name = generation
+	ext.Generation.Description = generation
+	ext.Status.Name = status
+	ext.Producer.Name = "Acme"
+	ext.Producer.Id = 1
+	return ext
+}
+
+func TestFilterProducerExtensions(t *testing.T) {
+	extensions := []account_api.Extension{
+		testExtension("PaymentPlugin", "plugin", "approved"),
+		testExtension("ShippingApp", "app", "instore"),
+		testExtension("Legacy", "classic", "approved"),
+		testExtension("Gone", "plugin", "deleted"),
+		testExtension("", "plugin", "approved"),
+		testExtension("ThemePlugin", "plugin", "incomplete"),
+	}
+
+	t.Run("no type filter keeps plugins and apps", func(t *testing.T) {
+		got := filterProducerExtensions(extensions, false, false)
+		assert.ElementsMatch(t, []string{"PaymentPlugin", "ShippingApp", "ThemePlugin"}, extensionNames(got))
+	})
+
+	t.Run("plugin filter", func(t *testing.T) {
+		got := filterProducerExtensions(extensions, true, false)
+		assert.ElementsMatch(t, []string{"PaymentPlugin", "ThemePlugin"}, extensionNames(got))
+	})
+
+	t.Run("app filter", func(t *testing.T) {
+		got := filterProducerExtensions(extensions, false, true)
+		assert.ElementsMatch(t, []string{"ShippingApp"}, extensionNames(got))
+	})
+}
+
+func TestIncludeProducerExtension(t *testing.T) {
+	assert.True(t, includeProducerExtension(testExtension("A", "plugin", "approved"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("A", "classic", "approved"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("A", "plugin", "deleted"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("", "plugin", "approved"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("A", "app", "approved"), true, false))
+	assert.True(t, includeProducerExtension(testExtension("A", "app", "approved"), false, true))
+}
+
+func extensionNames(extensions []account_api.Extension) []string {
+	names := make([]string, 0, len(extensions))
+	for _, ext := range extensions {
+		names = append(names, ext.Name)
+	}
+	return names
+}

--- a/cmd/account/account_producer_extension_list_test.go
+++ b/cmd/account/account_producer_extension_list_test.go
@@ -21,12 +21,12 @@ func testExtension(name, generation, status string) account_api.Extension {
 
 func TestFilterProducerExtensions(t *testing.T) {
 	extensions := []account_api.Extension{
-		testExtension("PaymentPlugin", "platform", "approved"),
-		testExtension("ShippingApp", "apps", "instore"),
-		testExtension("Legacy", "classic", "approved"),
-		testExtension("Gone", "platform", "deleted"),
-		testExtension("", "platform", "approved"),
-		testExtension("ThemePlugin", "platform", "incomplete"),
+		testExtension("PaymentPlugin", account_api.ExtensionGenerationPlatform, "approved"),
+		testExtension("ShippingApp", account_api.ExtensionGenerationApps, "instore"),
+		testExtension("Legacy", account_api.ExtensionGenerationClassic, "approved"),
+		testExtension("Gone", account_api.ExtensionGenerationPlatform, "deleted"),
+		testExtension("", account_api.ExtensionGenerationPlatform, "approved"),
+		testExtension("ThemePlugin", account_api.ExtensionGenerationPlatform, "incomplete"),
 	}
 
 	t.Run("no type filter keeps plugins and apps", func(t *testing.T) {
@@ -46,13 +46,13 @@ func TestFilterProducerExtensions(t *testing.T) {
 }
 
 func TestIncludeProducerExtension(t *testing.T) {
-	assert.True(t, includeProducerExtension(testExtension("A", "platform", "approved"), false, false))
-	assert.False(t, includeProducerExtension(testExtension("A", "classic", "approved"), false, false))
-	assert.False(t, includeProducerExtension(testExtension("A", "platform", "deleted"), false, false))
-	assert.False(t, includeProducerExtension(testExtension("", "platform", "approved"), false, false))
-	assert.False(t, includeProducerExtension(testExtension("A", "apps", "approved"), true, false))
-	assert.True(t, includeProducerExtension(testExtension("A", "apps", "approved"), false, true))
-	assert.True(t, includeProducerExtension(testExtension("A", "platform", "approved"), true, false))
+	assert.True(t, includeProducerExtension(testExtension("A", account_api.ExtensionGenerationPlatform, "approved"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("A", account_api.ExtensionGenerationClassic, "approved"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("A", account_api.ExtensionGenerationPlatform, "deleted"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("", account_api.ExtensionGenerationPlatform, "approved"), false, false))
+	assert.False(t, includeProducerExtension(testExtension("A", account_api.ExtensionGenerationApps, "approved"), true, false))
+	assert.True(t, includeProducerExtension(testExtension("A", account_api.ExtensionGenerationApps, "approved"), false, true))
+	assert.True(t, includeProducerExtension(testExtension("A", account_api.ExtensionGenerationPlatform, "approved"), true, false))
 }
 
 func extensionNames(extensions []account_api.Extension) []string {

--- a/internal/account-api/producer.go
+++ b/internal/account-api/producer.go
@@ -80,6 +80,13 @@ type Producer struct {
 	IsPremiumExtensionPartner bool        `json:"isPremiumExtensionPartner"`
 }
 
+const (
+	// Extension generation names returned by the Account API.
+	ExtensionGenerationClassic  = "classic"
+	ExtensionGenerationPlatform = "platform" // Shopware 6 plugins
+	ExtensionGenerationApps     = "apps"     // Shopware apps
+)
+
 type ListExtensionCriteria struct {
 	Limit         int    `schema:"limit,omitempty"`
 	Offset        int    `schema:"offset,omitempty"`


### PR DESCRIPTION
## Summary

- Add `--plugin` and `--app` flags to `account producer extension list` (mutually exclusive)
- Add `--json` output with name, type, status, compatibility, and producer
- Keep existing `--search` and allow combining it with type filters
- Filter deleted/classic/empty extensions before table or JSON output
- Unit tests for type filtering

Closes #1258

## Test plan

- [x] `go test ./cmd/account/`
- [x] `go vet ./cmd/account/`
- [x] `shopware-cli account producer extension list --help` shows `--app`, `--plugin`, `--search`, `--json`
- [ ] Manual: `account producer extension list --plugin`
- [ ] Manual: `account producer extension list --app`
- [ ] Manual: `account producer extension list --search <name>`
- [ ] Manual: `account producer extension list --plugin --search <name> --json`