### PR TITLE
fix(system): do not fail packaging on GHA cache already_exists

### DIFF
--- a/internal/extension/asset_cache.go
+++ b/internal/extension/asset_cache.go
@@ -120,15 +120,17 @@ func storeAssetCache(ctx context.Context, source *ExtensionAssetConfigEntry, ass
 
 	logging.FromContext(ctx).Debugf("Trying to store cache to key %s", cacheKey)
 
+	// Asset cache writes are best-effort. Failures (including GHA already_exists
+	// races) must not fail packaging/zip — the build artifacts are already on disk.
 	if source.Administration.EntryFilePath != nil {
 		if err := system.GetDefaultCache().StoreFolderCache(ctx, cacheKey+"-administration", source.GetOutputAdminPath()); err != nil {
-			return err
+			logging.FromContext(ctx).Warnf("could not store administration asset cache for %s: %v", source.TechnicalName, err)
 		}
 	}
 
 	if source.Storefront.EntryFilePath != nil {
 		if err := system.GetDefaultCache().StoreFolderCache(ctx, cacheKey+"-storefront", source.GetOutputStorefrontPath()); err != nil {
-			return err
+			logging.FromContext(ctx).Warnf("could not store storefront asset cache for %s: %v", source.TechnicalName, err)
 		}
 	}
 
@@ -137,7 +139,7 @@ func storeAssetCache(ctx context.Context, source *ExtensionAssetConfigEntry, ass
 		suffix := hashCacheKeySuffix(cachePath.Path)
 
 		if err := system.GetDefaultCache().StoreFolderCache(ctx, cacheKey+"-"+suffix, outputPath); err != nil {
-			return fmt.Errorf("additional_caches path %q for extension %s: %w", cachePath.Path, source.TechnicalName, err)
+			logging.FromContext(ctx).Warnf("could not store additional asset cache %q for %s: %v", cachePath.Path, source.TechnicalName, err)
 		}
 	}
 

--- a/internal/system/cache_github_actions.go
+++ b/internal/system/cache_github_actions.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -78,6 +79,12 @@ func (c *GitHubActionsCache) Set(ctx context.Context, key string, data io.Reader
 
 	err = c.client.Save(ctx, cacheKey, blob)
 	if err != nil {
+		// GHA cache keys are immutable; a concurrent or prior store of the same
+		// key returns already_exists. The entry is already available — treat as OK.
+		if isCacheAlreadyExists(err) {
+			return nil
+		}
+
 		return fmt.Errorf("failed to save to GitHub Actions cache: %w", err)
 	}
 
@@ -199,6 +206,12 @@ func (c *GitHubActionsCache) StoreFolderCache(ctx context.Context, key string, f
 	// Store the archive in cache
 	blob := actionscache.NewBlob(buf.Bytes())
 	if err := c.client.Save(ctx, cacheKey, blob); err != nil {
+		// Same key may already be present (race between jobs/workers, or a
+		// previous successful save). That is not a packaging failure.
+		if isCacheAlreadyExists(err) {
+			return nil
+		}
+
 		return fmt.Errorf("failed to save folder to GitHub Actions cache: %w", err)
 	}
 
@@ -390,4 +403,23 @@ func (c *GitHubActionsCache) getCacheKey(key string) string {
 	cacheKey = strings.ReplaceAll(cacheKey, "\\", "-")
 
 	return cacheKey
+}
+
+// isCacheAlreadyExists reports whether err means the cache entry is already
+// present. go-actions-cache maps that to os.ErrExist / "already_exists" /
+// "*AlreadyExists*" TypeKeys. Callers should treat this as success: GHA keys
+// are write-once, so the payload is already cached under that key.
+func isCacheAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, os.ErrExist) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "already_exists") ||
+		strings.Contains(msg, "alreadyexists")
 }

--- a/internal/system/cache_test.go
+++ b/internal/system/cache_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -419,4 +421,18 @@ func createTestTarGz(t *testing.T, sourceDir string) []byte {
 	require.NoError(t, gzipWriter.Close())
 
 	return buf.Bytes()
+}
+
+func TestIsCacheAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isCacheAlreadyExists(nil))
+	assert.False(t, isCacheAlreadyExists(errors.New("network timeout")))
+	assert.False(t, isCacheAlreadyExists(ErrCacheNotFound))
+
+	assert.True(t, isCacheAlreadyExists(os.ErrExist))
+	assert.True(t, isCacheAlreadyExists(fmt.Errorf("wrap: %w", os.ErrExist)))
+	assert.True(t, isCacheAlreadyExists(errors.New("failed to save folder to GitHub Actions cache: already_exists")))
+	assert.True(t, isCacheAlreadyExists(errors.New("ArtifactCacheItemAlreadyExistsException")))
+	assert.True(t, isCacheAlreadyExists(errors.New("CacheAlreadyExists")))
 }


### PR DESCRIPTION
## Summary

**Draft.** Fixes packaging failures when writing to the GitHub Actions cache hits an immutable-key race.

### Failure

[FroshAdminDashboard E2E](https://github.com/FriendsOfShopware/FroshAdminDashboard/actions/runs/30348425342/job/90239983961):

```text
shopware-cli extension zip …
… Building administration assets took 58s …
ERROR  building assets: failed to save folder to GitHub Actions cache: already_exists
```

Admin assets built successfully; zip failed only when **storing** the asset folder cache.

### Cause

GHA cache keys are write-once. A second `Save` for the same key (parallel job, retry, or concurrent store) returns `already_exists` / `ArtifactCacheItemAlreadyExistsException` (`go-actions-cache` also maps this to `os.ErrExist`). shopware-cli treated that as a hard error and aborted packaging.

### Fix

1. **`GitHubActionsCache.Set` / `StoreFolderCache`** — treat `already_exists` as success (entry already present).
2. **`storeAssetCache`** — cache writes are best-effort: log a warning and continue so zip/package never fails solely because caching failed.

### Tests

- `TestIsCacheAlreadyExists`
- `go test ./internal/system/ -run IsCacheAlreadyExists`
- `go test ./internal/extension/`

## Related

- FroshAdminDashboard run: https://github.com/FriendsOfShopware/FroshAdminDashboard/actions/runs/30348425342