### PR TITLE
feat: add config for checksum during project build

### DIFF
--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -314,19 +314,21 @@ var projectCI = &cobra.Command{
 			deleteAssetsSection.End(cmd.Context())
 		}
 
-		checksumSection := ci.Default.Section(cmd.Context(), "Generating extension checksums")
+		if !shopCfg.Build.DisableChecksum {
+			checksumSection := ci.Default.Section(cmd.Context(), "Generating extension checksums")
 
-		extensions := extension.FindExtensionsFromProject(cmd.Context(), args[0], false)
+			extensions := extension.FindExtensionsFromProject(cmd.Context(), args[0], false)
 
-		for _, ext := range extensions {
-			extPath := ext.GetPath()
+			for _, ext := range extensions {
+				extPath := ext.GetPath()
 
-			if err := extension.GenerateChecksumJSON(cmd.Context(), extPath, ext); err != nil {
-				logging.FromContext(cmd.Context()).Warnf("Failed to generate checksum for %s: %v", extPath, err)
+				if err := extension.GenerateChecksumJSON(cmd.Context(), extPath, ext); err != nil {
+					logging.FromContext(cmd.Context()).Warnf("Failed to generate checksum for %s: %v", extPath, err)
+				}
 			}
-		}
 
-		checksumSection.End(cmd.Context())
+			checksumSection.End(cmd.Context())
+		}
 
 		if shopCfg.Build.Hooks != nil && len(shopCfg.Build.Hooks.Post) > 0 {
 			if err := executeCIHooks(cmd.Context(), "Running post hooks", shopCfg.Build.Hooks.Post, args[0]); err != nil {

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -322,6 +322,13 @@ var projectCI = &cobra.Command{
 			for _, ext := range extensions {
 				extPath := ext.GetPath()
 
+				if shopCfg.Build.KeepExistingChecksum {
+					if _, err := os.Stat(path.Join(extPath, "checksum.json")); err == nil {
+						logging.FromContext(cmd.Context()).Infof("Keeping existing checksum.json for %s", extPath)
+						continue
+					}
+				}
+
 				if err := extension.GenerateChecksumJSON(cmd.Context(), extPath, ext); err != nil {
 					logging.FromContext(cmd.Context()).Warnf("Failed to generate checksum for %s: %v", extPath, err)
 				}

--- a/cmd/project/ci.go
+++ b/cmd/project/ci.go
@@ -314,7 +314,7 @@ var projectCI = &cobra.Command{
 			deleteAssetsSection.End(cmd.Context())
 		}
 
-		if !shopCfg.Build.DisableChecksum {
+		if !shopCfg.Build.DisableChecksums {
 			checksumSection := ci.Default.Section(cmd.Context(), "Generating extension checksums")
 
 			extensions := extension.FindExtensionsFromProject(cmd.Context(), args[0], false)
@@ -322,7 +322,7 @@ var projectCI = &cobra.Command{
 			for _, ext := range extensions {
 				extPath := ext.GetPath()
 
-				if shopCfg.Build.KeepExistingChecksum {
+				if shopCfg.Build.KeepExistingChecksums {
 					if _, err := os.Stat(path.Join(extPath, "checksum.json")); err == nil {
 						logging.FromContext(cmd.Context()).Infof("Keeping existing checksum.json for %s", extPath)
 						continue

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -107,6 +107,8 @@ type ConfigBuild struct {
 	DisableStorefrontBuild bool `yaml:"disable_storefront_build,omitempty"`
 	// When enabled, the checksum.json generation for extensions will be skipped
 	DisableChecksum bool `yaml:"disable_checksum,omitempty"`
+	// When enabled, an already existing checksum.json in an extension will be kept instead of being overwritten
+	KeepExistingChecksum bool `yaml:"keep_existing_checksum,omitempty"`
 	// Extensions to force build for, even if they have compiled files
 	ForceExtensionBuild []ConfigBuildExtension `yaml:"force_extension_build,omitempty"`
 	// When enabled, the shopware admin will be built

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -105,6 +105,8 @@ type ConfigBuild struct {
 	ExcludeExtensions []string `yaml:"exclude_extensions,omitempty"`
 	// When enabled, the storefront build will be skipped
 	DisableStorefrontBuild bool `yaml:"disable_storefront_build,omitempty"`
+	// When enabled, the checksum.json generation for extensions will be skipped
+	DisableChecksum bool `yaml:"disable_checksum,omitempty"`
 	// Extensions to force build for, even if they have compiled files
 	ForceExtensionBuild []ConfigBuildExtension `yaml:"force_extension_build,omitempty"`
 	// When enabled, the shopware admin will be built

--- a/internal/shop/config.go
+++ b/internal/shop/config.go
@@ -106,9 +106,9 @@ type ConfigBuild struct {
 	// When enabled, the storefront build will be skipped
 	DisableStorefrontBuild bool `yaml:"disable_storefront_build,omitempty"`
 	// When enabled, the checksum.json generation for extensions will be skipped
-	DisableChecksum bool `yaml:"disable_checksum,omitempty"`
+	DisableChecksums bool `yaml:"disable_checksums,omitempty"`
 	// When enabled, an already existing checksum.json in an extension will be kept instead of being overwritten
-	KeepExistingChecksum bool `yaml:"keep_existing_checksum,omitempty"`
+	KeepExistingChecksums bool `yaml:"keep_existing_checksums,omitempty"`
 	// Extensions to force build for, even if they have compiled files
 	ForceExtensionBuild []ConfigBuildExtension `yaml:"force_extension_build,omitempty"`
 	// When enabled, the shopware admin will be built

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -127,6 +127,10 @@
           "type": "boolean",
           "description": "When enabled, the storefront build will be skipped"
         },
+        "disable_checksum": {
+          "type": "boolean",
+          "description": "When enabled, the checksum.json generation for extensions will be skipped"
+        },
         "force_extension_build": {
           "items": {
             "$ref": "#/$defs/ConfigBuildExtension"

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -131,6 +131,10 @@
           "type": "boolean",
           "description": "When enabled, the checksum.json generation for extensions will be skipped"
         },
+        "keep_existing_checksum": {
+          "type": "boolean",
+          "description": "When enabled, an already existing checksum.json in an extension will be kept instead of being overwritten"
+        },
         "force_extension_build": {
           "items": {
             "$ref": "#/$defs/ConfigBuildExtension"

--- a/internal/shop/config_schema.json
+++ b/internal/shop/config_schema.json
@@ -127,11 +127,11 @@
           "type": "boolean",
           "description": "When enabled, the storefront build will be skipped"
         },
-        "disable_checksum": {
+        "disable_checksums": {
           "type": "boolean",
           "description": "When enabled, the checksum.json generation for extensions will be skipped"
         },
-        "keep_existing_checksum": {
+        "keep_existing_checksums": {
           "type": "boolean",
           "description": "When enabled, an already existing checksum.json in an extension will be kept instead of being overwritten"
         },

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -424,6 +424,21 @@ build: {}
 	assert.False(t, cfg.Build.DisableChecksum)
 }
 
+func TestReadConfigKeepExistingChecksum(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".shopware-project.yml")
+	content := []byte(`
+compatibility_date: "2024-01-01"
+build:
+  keep_existing_checksum: true
+`)
+	assert.NoError(t, os.WriteFile(configPath, content, 0o644))
+
+	cfg, err := ReadConfig(t.Context(), configPath, false)
+	assert.NoError(t, err)
+	assert.True(t, cfg.Build.KeepExistingChecksum)
+}
+
 func TestConfigDump_NormalizeFakerExpressions(t *testing.T) {
 	t.Run("wraps bare faker expressions with delimiters", func(t *testing.T) {
 		config := &ConfigDump{

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -395,6 +395,35 @@ build:
 	assert.Equal(t, "CustomName", cfg.Build.Bundles[1].Name)
 }
 
+func TestReadConfigDisableChecksum(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".shopware-project.yml")
+	content := []byte(`
+compatibility_date: "2024-01-01"
+build:
+  disable_checksum: true
+`)
+	assert.NoError(t, os.WriteFile(configPath, content, 0o644))
+
+	cfg, err := ReadConfig(t.Context(), configPath, false)
+	assert.NoError(t, err)
+	assert.True(t, cfg.Build.DisableChecksum)
+}
+
+func TestReadConfigDisableChecksumDefaultsFalse(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".shopware-project.yml")
+	content := []byte(`
+compatibility_date: "2024-01-01"
+build: {}
+`)
+	assert.NoError(t, os.WriteFile(configPath, content, 0o644))
+
+	cfg, err := ReadConfig(t.Context(), configPath, false)
+	assert.NoError(t, err)
+	assert.False(t, cfg.Build.DisableChecksum)
+}
+
 func TestConfigDump_NormalizeFakerExpressions(t *testing.T) {
 	t.Run("wraps bare faker expressions with delimiters", func(t *testing.T) {
 		config := &ConfigDump{

--- a/internal/shop/config_test.go
+++ b/internal/shop/config_test.go
@@ -395,19 +395,19 @@ build:
 	assert.Equal(t, "CustomName", cfg.Build.Bundles[1].Name)
 }
 
-func TestReadConfigDisableChecksum(t *testing.T) {
+func TestReadConfigDisableChecksums(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, ".shopware-project.yml")
 	content := []byte(`
 compatibility_date: "2024-01-01"
 build:
-  disable_checksum: true
+  disable_checksums: true
 `)
 	assert.NoError(t, os.WriteFile(configPath, content, 0o644))
 
 	cfg, err := ReadConfig(t.Context(), configPath, false)
 	assert.NoError(t, err)
-	assert.True(t, cfg.Build.DisableChecksum)
+	assert.True(t, cfg.Build.DisableChecksums)
 }
 
 func TestReadConfigDisableChecksumDefaultsFalse(t *testing.T) {
@@ -421,22 +421,22 @@ build: {}
 
 	cfg, err := ReadConfig(t.Context(), configPath, false)
 	assert.NoError(t, err)
-	assert.False(t, cfg.Build.DisableChecksum)
+	assert.False(t, cfg.Build.DisableChecksums)
 }
 
-func TestReadConfigKeepExistingChecksum(t *testing.T) {
+func TestReadConfigKeepExistingChecksums(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, ".shopware-project.yml")
 	content := []byte(`
 compatibility_date: "2024-01-01"
 build:
-  keep_existing_checksum: true
+  keep_existing_checksums: true
 `)
 	assert.NoError(t, os.WriteFile(configPath, content, 0o644))
 
 	cfg, err := ReadConfig(t.Context(), configPath, false)
 	assert.NoError(t, err)
-	assert.True(t, cfg.Build.KeepExistingChecksum)
+	assert.True(t, cfg.Build.KeepExistingChecksums)
 }
 
 func TestConfigDump_NormalizeFakerExpressions(t *testing.T) {


### PR DESCRIPTION
## What changed?

Added two new options to the project config (`.shopware-project.yml`) to control extension checksum generation during `shopware-cli project ci`:

- `build.disable_checksums` when `true`, the "Generating extension checksums" step is skipped entirely, so no `checksum.json` files are written into the extensions.
- `build.keep_existing_checksums`  when `true`, extensions that already ship a `checksum.json` keep it untouched; extensions without one still get a generated file.

Both default to `false`, existing behavior is unchanged.

```yaml
build:
  disable_checksums: true
  keep_existing_checksums: true
```

## Why?

Some extensions already deliver a `checksum.json` and I want to keep those intact. `keep_existing_checksums` covers that case, `disable_checksums` is for pipelines that don't want the files generated at all.

## How was this tested?

new tests added (`internal/shop/config_test.go`)

## Related issue or discussion

No.
