### PR TITLE
feat(account): support demo shops in extension info push and pull

### DIFF
--- a/cmd/account/account_producer_extension_info_pull.go
+++ b/cmd/account/account_producer_extension_info_pull.go
@@ -88,6 +88,18 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 			availabilities = append(availabilities, a.Name)
 		}
 
+		demoShops := make([]extension.ConfigStoreDemoShop, 0)
+
+		for _, demo := range storeExt.Demos {
+			demoShops = append(demoShops, extension.ConfigStoreDemoShop{
+				Type:          demo.Type.Name,
+				Link:          demo.Link,
+				Localization:  demo.Localization.Name,
+				LoginName:     demo.LoginName,
+				LoginPassword: demo.LoginPassword,
+			})
+		}
+
 		storeImages, err := p.GetExtensionImages(cmd.Context(), storeExt.Id)
 		if err != nil {
 			return fmt.Errorf("cannot get extension images: %w", err)
@@ -232,6 +244,7 @@ var accountCompanyProducerExtensionInfoPullCmd = &cobra.Command{
 		newCfg.Store.Faq = extension.ConfigTranslated[[]extension.ConfigStoreFaq]{German: &faqDE, English: &faqEN}
 		newCfg.Store.MetaTitle = extension.ConfigTranslated[string]{German: &germanMetaTitle, English: &englishMetaTitle}
 		newCfg.Store.MetaDescription = extension.ConfigTranslated[string]{German: &germanMetaDescription, English: &englishMetaDescription}
+		newCfg.Store.DemoShops = &demoShops
 		newCfg.Store.Images = nil
 
 		if len(storeImages) > 0 {

--- a/cmd/account/account_producer_extension_info_push.go
+++ b/cmd/account/account_producer_extension_info_push.go
@@ -194,6 +194,15 @@ func updateStoreInfo(ext *accountApi.Extension, zipExt extension.Extension, cfg 
 		ext.AutomaticBugfixVersionCompatibility = *cfg.Store.AutomaticBugfixVersionCompatibility
 	}
 
+	if cfg.Store.DemoShops != nil {
+		newDemos, err := buildExtensionDemos(*cfg.Store.DemoShops, info)
+		if err != nil {
+			return err
+		}
+
+		ext.Demos = newDemos
+	}
+
 	for _, info := range ext.Infos {
 		language := info.Locale.Name[0:2]
 
@@ -267,6 +276,65 @@ func updateStoreInfo(ext *accountApi.Extension, zipExt extension.Extension, cfg 
 	}
 
 	return nil
+}
+
+// buildExtensionDemos maps the configured demo shops to the API representation. The type and the
+// localization are only known by name in the configuration, so both are resolved against the
+// general information of the account API.
+func buildExtensionDemos(configDemos []extension.ConfigStoreDemoShop, info *accountApi.ExtensionGeneralInformation) ([]accountApi.ExtensionDemo, error) {
+	newDemos := make([]accountApi.ExtensionDemo, 0)
+
+	for _, configDemo := range configDemos {
+		demoType, err := findDemoType(configDemo.Type, info.DemoTypes)
+		if err != nil {
+			return nil, err
+		}
+
+		localization, err := findLocale(configDemo.Localization, info.Locales)
+		if err != nil {
+			return nil, err
+		}
+
+		newDemos = append(newDemos, accountApi.ExtensionDemo{
+			Type:          *demoType,
+			Link:          configDemo.Link,
+			Localization:  *localization,
+			LoginName:     configDemo.LoginName,
+			LoginPassword: configDemo.LoginPassword,
+		})
+	}
+
+	return newDemos, nil
+}
+
+func findDemoType(name string, demoTypes []accountApi.StoreDemoType) (*accountApi.StoreDemoType, error) {
+	for i, demoType := range demoTypes {
+		if demoType.Name == name {
+			return &demoTypes[i], nil
+		}
+	}
+
+	possible := make([]string, 0, len(demoTypes))
+	for _, demoType := range demoTypes {
+		possible = append(possible, demoType.Name)
+	}
+
+	return nil, fmt.Errorf("unknown demo shop type %q, possible values are: %s", name, strings.Join(possible, ", "))
+}
+
+func findLocale(name string, locales []accountApi.Locale) (*accountApi.Locale, error) {
+	for i, locale := range locales {
+		if locale.Name == name {
+			return &locales[i], nil
+		}
+	}
+
+	possible := make([]string, 0, len(locales))
+	for _, locale := range locales {
+		possible = append(possible, locale.Name)
+	}
+
+	return nil, fmt.Errorf("unknown demo shop localization %q, possible values are: %s", name, strings.Join(possible, ", "))
 }
 
 func getTranslation[T extension.Translatable](language string, config extension.ConfigTranslated[T]) *T {

--- a/cmd/account/account_producer_extension_info_push_test.go
+++ b/cmd/account/account_producer_extension_info_push_test.go
@@ -1,0 +1,131 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	accountApi "github.com/shopware/shopware-cli/internal/account-api"
+	"github.com/shopware/shopware-cli/internal/extension"
+)
+
+func demoGeneralInfo() *accountApi.ExtensionGeneralInformation {
+	return &accountApi.ExtensionGeneralInformation{
+		Locales: []accountApi.Locale{
+			{Id: 1, Name: "de_DE"},
+			{Id: 2, Name: "en_GB"},
+		},
+		DemoTypes: []accountApi.StoreDemoType{
+			{Id: 1, Name: "frontend", Description: "Frontend demo"},
+			{Id: 2, Name: "backend", Description: "Backend demo"},
+		},
+	}
+}
+
+func TestBuildExtensionDemos(t *testing.T) {
+	demos, err := buildExtensionDemos([]extension.ConfigStoreDemoShop{
+		{
+			Type:          "frontend",
+			Link:          "https://demo.example.com",
+			Localization:  "de_DE",
+			LoginName:     "demo",
+			LoginPassword: "secret",
+		},
+		{
+			Type:         "backend",
+			Link:         "https://demo.example.com/admin",
+			Localization: "en_GB",
+		},
+	}, demoGeneralInfo())
+
+	require.NoError(t, err)
+	assert.Equal(t, []accountApi.ExtensionDemo{
+		{
+			Type:          accountApi.StoreDemoType{Id: 1, Name: "frontend", Description: "Frontend demo"},
+			Link:          "https://demo.example.com",
+			Localization:  accountApi.Locale{Id: 1, Name: "de_DE"},
+			LoginName:     "demo",
+			LoginPassword: "secret",
+		},
+		{
+			Type:         accountApi.StoreDemoType{Id: 2, Name: "backend", Description: "Backend demo"},
+			Link:         "https://demo.example.com/admin",
+			Localization: accountApi.Locale{Id: 2, Name: "en_GB"},
+		},
+	}, demos)
+}
+
+func TestBuildExtensionDemosEmptyList(t *testing.T) {
+	demos, err := buildExtensionDemos([]extension.ConfigStoreDemoShop{}, demoGeneralInfo())
+
+	require.NoError(t, err)
+	assert.Empty(t, demos)
+	assert.NotNil(t, demos)
+}
+
+func TestBuildExtensionDemosUnknownType(t *testing.T) {
+	_, err := buildExtensionDemos([]extension.ConfigStoreDemoShop{
+		{Type: "storefront", Link: "https://demo.example.com", Localization: "de_DE"},
+	}, demoGeneralInfo())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown demo shop type \"storefront\"")
+	assert.Contains(t, err.Error(), "frontend, backend")
+}
+
+func TestBuildExtensionDemosUnknownLocalization(t *testing.T) {
+	_, err := buildExtensionDemos([]extension.ConfigStoreDemoShop{
+		{Type: "frontend", Link: "https://demo.example.com", Localization: "fr_FR"},
+	}, demoGeneralInfo())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown demo shop localization \"fr_FR\"")
+	assert.Contains(t, err.Error(), "de_DE, en_GB")
+}
+
+func TestUpdateStoreInfoKeepsDemosWhenNotConfigured(t *testing.T) {
+	ext := &accountApi.Extension{
+		Demos: []accountApi.ExtensionDemo{
+			{Id: 42, Type: accountApi.StoreDemoType{Id: 1, Name: "frontend"}, Link: "https://demo.example.com"},
+		},
+	}
+
+	require.NoError(t, updateStoreInfo(ext, nil, &extension.Config{}, demoGeneralInfo()))
+	assert.Len(t, ext.Demos, 1)
+	assert.Equal(t, 42, ext.Demos[0].Id)
+}
+
+func TestUpdateStoreInfoReplacesDemos(t *testing.T) {
+	ext := &accountApi.Extension{
+		Demos: []accountApi.ExtensionDemo{
+			{Id: 42, Type: accountApi.StoreDemoType{Id: 1, Name: "frontend"}, Link: "https://old.example.com"},
+		},
+	}
+
+	cfg := &extension.Config{}
+	cfg.Store.DemoShops = &[]extension.ConfigStoreDemoShop{
+		{Type: "backend", Link: "https://demo.example.com/admin", Localization: "en_GB"},
+	}
+
+	require.NoError(t, updateStoreInfo(ext, nil, cfg, demoGeneralInfo()))
+	require.Len(t, ext.Demos, 1)
+	assert.Equal(t, 0, ext.Demos[0].Id)
+	assert.Equal(t, "backend", ext.Demos[0].Type.Name)
+	assert.Equal(t, "https://demo.example.com/admin", ext.Demos[0].Link)
+	assert.Equal(t, "en_GB", ext.Demos[0].Localization.Name)
+}
+
+func TestUpdateStoreInfoClearsDemos(t *testing.T) {
+	ext := &accountApi.Extension{
+		Demos: []accountApi.ExtensionDemo{
+			{Id: 42, Type: accountApi.StoreDemoType{Id: 1, Name: "frontend"}, Link: "https://demo.example.com"},
+		},
+	}
+
+	cfg := &extension.Config{}
+	cfg.Store.DemoShops = &[]extension.ConfigStoreDemoShop{}
+
+	require.NoError(t, updateStoreInfo(ext, nil, cfg, demoGeneralInfo()))
+	assert.Empty(t, ext.Demos)
+}

--- a/internal/account-api/producer.go
+++ b/internal/account-api/producer.go
@@ -323,7 +323,7 @@ type Extension struct {
 	IconPath                            string            `json:"iconPath"`
 	IconIsSet                           bool              `json:"iconIsSet"`
 	ExamplePageUrl                      string            `json:"examplePageUrl"`
-	Demos                               []interface{}     `json:"demos"`
+	Demos                               []ExtensionDemo   `json:"demos"`
 	Localizations                       []Locale          `json:"localizations"`
 	LatestBinary                        interface{}       `json:"latestBinary"`
 	MigrationSupport                    bool              `json:"migrationSupport"`
@@ -466,6 +466,21 @@ type StoreFaq struct {
 	Position int    `json:"position"`
 }
 
+type StoreDemoType struct {
+	Id          int    `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type ExtensionDemo struct {
+	Id            int           `json:"id,omitempty"`
+	Type          StoreDemoType `json:"type"`
+	Link          string        `json:"link"`
+	Localization  Locale        `json:"localization"`
+	LoginName     string        `json:"loginName"`
+	LoginPassword string        `json:"loginPassword"`
+}
+
 type ExtensionGeneralInformation struct {
 	Categories       []StoreCategory `json:"categories"`
 	FutureCategories []StoreCategory `json:"futureCategories"`
@@ -504,7 +519,7 @@ type ExtensionGeneralInformation struct {
 	StoreAvailabilities  []StoreAvailablity  `json:"storeAvailabilities"`
 	PriceModels          []interface{}       `json:"priceModels"`
 	SoftwareVersions     SoftwareVersionList `json:"softwareVersions"`
-	DemoTypes            interface{}         `json:"demoTypes"`
+	DemoTypes            []StoreDemoType     `json:"demoTypes"`
 	Localizations        []Locale            `json:"localizations"`
 	ProductTypes         []StoreProductType  `json:"productTypes"`
 	ReleaseRequestStatus interface{}         `json:"releaseRequestStatus"`

--- a/internal/extension/config.go
+++ b/internal/extension/config.go
@@ -152,6 +152,21 @@ type ConfigStore struct {
 	Images *[]ConfigStoreImage `yaml:"images,omitempty"`
 	// Specifies the directory where the images are located.
 	ImageDirectory *string `yaml:"image_directory,omitempty"`
+	// Specifies the demo shops of the extension in the store.
+	DemoShops *[]ConfigStoreDemoShop `yaml:"demo_shops,omitempty"`
+}
+
+type ConfigStoreDemoShop struct {
+	// Specifies the type of the demo shop.
+	Type string `yaml:"type" jsonschema:"enum=frontend,enum=backend"`
+	// Specifies the URL to the demo shop.
+	Link string `yaml:"link"`
+	// Specifies the language of the demo shop.
+	Localization string `yaml:"localization" jsonschema:"enum=de_DE,enum=en_GB"`
+	// Specifies the login name to access the demo shop.
+	LoginName string `yaml:"login_name,omitempty"`
+	// Specifies the login password to access the demo shop.
+	LoginPassword string `yaml:"login_password,omitempty"`
 }
 
 type Translatable interface {

--- a/internal/extension/config_schema.json
+++ b/internal/extension/config_schema.json
@@ -384,6 +384,47 @@
         "image_directory": {
           "type": "string",
           "description": "Specifies the directory where the images are located."
+        },
+        "demo_shops": {
+          "items": {
+            "$ref": "#/$defs/ConfigStoreDemoShop"
+          },
+          "type": "array",
+          "description": "Specifies the demo shops of the extension in the store."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ConfigStoreDemoShop": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "frontend",
+            "backend"
+          ],
+          "description": "Specifies the type of the demo shop."
+        },
+        "link": {
+          "type": "string",
+          "description": "Specifies the URL to the demo shop."
+        },
+        "localization": {
+          "type": "string",
+          "enum": [
+            "de_DE",
+            "en_GB"
+          ],
+          "description": "Specifies the language of the demo shop."
+        },
+        "login_name": {
+          "type": "string",
+          "description": "Specifies the login name to access the demo shop."
+        },
+        "login_password": {
+          "type": "string",
+          "description": "Specifies the login password to access the demo shop."
         }
       },
       "additionalProperties": false,

--- a/internal/extension/config_test.go
+++ b/internal/extension/config_test.go
@@ -185,6 +185,44 @@ func TestConfigStore_IsInGermanStore(t *testing.T) {
 	})
 }
 
+func TestConfigStoreDemoShopsDecode(t *testing.T) {
+	cfg := `
+store:
+  demo_shops:
+    - type: frontend
+      link: https://demo.example.com
+      localization: de_DE
+      login_name: demo
+      login_password: secret
+    - type: backend
+      link: https://demo.example.com/admin
+      localization: en_GB
+`
+
+	tmpDir := t.TempDir()
+
+	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".shopware-extension.yaml"), []byte(cfg), 0o644))
+
+	ext, err := readExtensionConfig(t.Context(), tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, ext.Store.DemoShops)
+
+	assert.Equal(t, []ConfigStoreDemoShop{
+		{
+			Type:          "frontend",
+			Link:          "https://demo.example.com",
+			Localization:  "de_DE",
+			LoginName:     "demo",
+			LoginPassword: "secret",
+		},
+		{
+			Type:         "backend",
+			Link:         "https://demo.example.com/admin",
+			Localization: "en_GB",
+		},
+	}, *ext.Store.DemoShops)
+}
+
 func TestReadExtensionConfig(t *testing.T) {
 	t.Run("returns default config when no file exists", func(t *testing.T) {
 		tmpDir := t.TempDir()


### PR DESCRIPTION
## What changed?

Adds demo shop support to `extension info push` / `extension info pull`.

New `store.demo_shops` key in `.shopware-extension.yml`:

```yaml
store:
  demo_shops:
    - type: frontend          # frontend | backend
      link: https://demo.example.com
      localization: en_GB     # de_DE | en_GB
    - type: backend
      link: https://demo.example.com/admin
      localization: de_DE
      login_name: demo        # optional
      login_password: demo    # optional
```

- **pull** writes the demos from the account API into the config.
- **push** sends them back. Omitting the key leaves existing demos untouched; `demo_shops: []` clears them.
- The config carries `type` and `localization` by name only, so both are resolved against `/pluginstatics/all`. An unresolvable name fails with the valid values rather than sending a bad payload:
  ```
  unknown demo shop type "storefront", possible values are: frontend, backend
  unknown demo shop localization "fr_FR", possible values are: de_DE, en_GB
  ```
- `Extension.Demos` and `ExtensionGeneralInformation.DemoTypes` were `interface{}` and are now typed (`[]ExtensionDemo`, `[]StoreDemoType`).
- `internal/extension/config_schema.json` regenerated via `go run ./scripts/schema.go`.

## Why?

Demo shop links were the last part of the store listing that could not be managed from the extension repository — they had to be maintained by hand in the account UI, so they drifted and were not reviewable alongside the rest of the store config.

## How was this tested?

Unit tests for the mapping and both error paths, plus a config decode test.

Verified end-to-end against the **production** account API using `FroshAdminDashboard` (id 21865):

1. Confirmed the payload shapes rather than assuming them. `/pluginstatics/all` returns exactly:
   ```json
   "demoTypes": [{"id":1,"name":"frontend","description":"Frontend demo"},
                 {"id":2,"name":"backend","description":"Backend demo"}]
   "locales":   [{"id":1,"name":"de_DE"},{"id":2,"name":"en_GB"}]
   ```
   The `locales` ids confirm that list (not `localizations`) is the right one for resolving a demo's localization.
2. **Pushed** two demo shops — API assigned ids, correct type/locale ids, optional login fields carried through.
3. **Pulled** them back — byte-identical to the pushed YAML, including one entry with login credentials and one without.
4. **Restored** to `demo_shops: []`; prod is back to its original state.

At each step all 61 other top-level fields were diffed against a pre-push snapshot: zero changes, store images stayed at 10.

`go test ./...` and `golangci-lint run` are clean.

## Related issue or discussion

None.

---

### Note: two pre-existing `info push` behaviours found while testing

Not addressed here (out of scope), but worth flagging:

1. **Push is not field-scoped for images.** If `store.icon`, `store.images` or `store.image_directory` is set, push deletes every store image and re-uploads them — and the config `info pull` writes *always* sets `image_directory`. So the natural `pull` → edit → `push` loop wipes and re-uploads all store images as a side effect of changing an unrelated field. I had to push a minimal demo-only config to avoid churning FroshAdminDashboard's 10 images.
2. **Push always overwrites the localized store name and short description** from `composer.json`'s `extra.label` / `extra.description`, regardless of config. Harmless when they already match, but it silently reverts a listing edited in the account UI.

Happy to open a follow-up for either.
