### PR TITLE
fix(system): ignore already_exists when saving to GitHub Actions cache

### DIFF
--- a/internal/system/cache_github_actions.go
+++ b/internal/system/cache_github_actions.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,9 +17,17 @@ import (
 	actionscache "github.com/tonistiigi/go-actions-cache"
 )
 
+// actionsCacheClient is the subset of the GitHub Actions cache client used by
+// GitHubActionsCache. It exists so the save/load behaviour can be tested without
+// talking to the real API.
+type actionsCacheClient interface {
+	Load(ctx context.Context, keys ...string) (*actionscache.Entry, error)
+	Save(ctx context.Context, key string, b actionscache.Blob) error
+}
+
 // GitHubActionsCache implements Cache interface using GitHub Actions cache
 type GitHubActionsCache struct {
-	client    *actionscache.Cache
+	client    actionsCacheClient
 	prefix    string
 	tempFiles []string
 	mu        sync.Mutex
@@ -78,6 +87,11 @@ func (c *GitHubActionsCache) Set(ctx context.Context, key string, data io.Reader
 
 	err = c.client.Save(ctx, cacheKey, blob)
 	if err != nil {
+		// Another job stored the same key first, the content is identical so this is not an error
+		if errors.Is(err, os.ErrExist) {
+			return nil
+		}
+
 		return fmt.Errorf("failed to save to GitHub Actions cache: %w", err)
 	}
 
@@ -199,6 +213,11 @@ func (c *GitHubActionsCache) StoreFolderCache(ctx context.Context, key string, f
 	// Store the archive in cache
 	blob := actionscache.NewBlob(buf.Bytes())
 	if err := c.client.Save(ctx, cacheKey, blob); err != nil {
+		// Another job stored the same key first, the content is identical so this is not an error
+		if errors.Is(err, os.ErrExist) {
+			return nil
+		}
+
 		return fmt.Errorf("failed to save folder to GitHub Actions cache: %w", err)
 	}
 

--- a/internal/system/cache_github_actions_test.go
+++ b/internal/system/cache_github_actions_test.go
@@ -1,0 +1,95 @@
+package system
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	actionscache "github.com/tonistiigi/go-actions-cache"
+)
+
+// fakeActionsCacheClient records Save calls and returns a canned error.
+type fakeActionsCacheClient struct {
+	saveErr   error
+	savedKeys []string
+}
+
+// Load is only present to satisfy actionsCacheClient; these tests exercise the save paths.
+func (f *fakeActionsCacheClient) Load(ctx context.Context, keys ...string) (*actionscache.Entry, error) {
+	return nil, ErrCacheNotFound
+}
+
+func (f *fakeActionsCacheClient) Save(ctx context.Context, key string, b actionscache.Blob) error {
+	f.savedKeys = append(f.savedKeys, key)
+	return f.saveErr
+}
+
+// alreadyExistsError mimics what the GitHub Actions cache API returns when an
+// entry for the key was already uploaded, wrapped the same way the library does.
+func alreadyExistsError() error {
+	return actionscache.HTTPError{
+		StatusCode: 409,
+		Err: actionscache.GithubAPIError{
+			Message: "409 Conflict",
+			TypeKey: "ArtifactCacheItemAlreadyExistsException",
+		},
+	}
+}
+
+func TestGitHubActionsCacheSetIgnoresAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeActionsCacheClient{saveErr: alreadyExistsError()}
+	cache := &GitHubActionsCache{client: client, prefix: "sw-cli"}
+
+	err := cache.Set(t.Context(), "some-key", strings.NewReader("content"))
+
+	require.NoError(t, err, "already existing cache entry must not fail the build")
+	assert.Len(t, client.savedKeys, 1)
+}
+
+func TestGitHubActionsCacheSetReturnsOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeActionsCacheClient{saveErr: assert.AnError}
+	cache := &GitHubActionsCache{client: client, prefix: "sw-cli"}
+
+	err := cache.Set(t.Context(), "some-key", strings.NewReader("content"))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestGitHubActionsCacheStoreFolderCacheIgnoresAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	folder := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "app.js"), []byte("console.log(1)"), 0o644))
+
+	client := &fakeActionsCacheClient{saveErr: alreadyExistsError()}
+	cache := &GitHubActionsCache{client: client, prefix: "sw-cli"}
+
+	err := cache.StoreFolderCache(t.Context(), "sw-cli-6.7.0.0-abc", folder)
+
+	require.NoError(t, err, "already existing folder cache entry must not fail the build")
+	assert.Len(t, client.savedKeys, 1)
+}
+
+func TestGitHubActionsCacheStoreFolderCacheReturnsOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	folder := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "app.js"), []byte("console.log(1)"), 0o644))
+
+	client := &fakeActionsCacheClient{saveErr: assert.AnError}
+	cache := &GitHubActionsCache{client: client, prefix: "sw-cli"}
+
+	err := cache.StoreFolderCache(t.Context(), "sw-cli-6.7.0.0-abc", folder)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}


### PR DESCRIPTION
## Problem

Builds using the GitHub Actions cache can fail with:

```
ERROR	building assets: failed to save folder to GitHub Actions cache: already_exists
```

Real-world occurrence: [FriendsOfShopware/FroshAdminDashboard run #30348425342](https://github.com/FriendsOfShopware/FroshAdminDashboard/actions/runs/30348425342/job/90239983961), where `shopware-cli extension zip` exited 1 and took down the whole e2e job.

## Cause

The GH Actions cache v2 API returns `already_exists` when an entry for a key has already been uploaded. The asset cache key is deterministic — `sw-cli-<shopware-version>-<content-hash>` — so this is hit whenever the same commit is re-run, or two jobs build the same extension concurrently.

`go-actions-cache` maps that response to an error matching `os.ErrExist`, but `Set` and `StoreFolderCache` wrapped every `Save` error unconditionally. A benign "this is already cached" response therefore propagated up through `storeAssetCache` → `building assets` and failed the command.

Worth noting: the cache store runs *after* the assets are already built successfully, so this aborted builds that had completed all their real work.

## Fix

Treat `os.ErrExist` as success in both save paths, matching the idiom the upstream library already uses internally ([`cache.go:451`](https://github.com/tonistiigi/go-actions-cache/blob/master/cache.go)).

To make this testable, the `client` field becomes a small `actionsCacheClient` interface covering the two methods used. `*actionscache.Cache` satisfies it as-is, so `NewGitHubActionsCache` is unchanged and there is no production behaviour change.

## Tests

Four new cases in `internal/system/cache_github_actions_test.go`, using a fake client that returns the exact error shape the library builds from a v2 `already_exists` response (`HTTPError{409, GithubAPIError{TypeKey: "ArtifactCacheItemAlreadyExistsException"}}`):

| Test | Asserts |
|---|---|
| `SetIgnoresAlreadyExists` | `Set` swallows already-exists |
| `SetReturnsOtherErrors` | `Set` still propagates real failures |
| `StoreFolderCacheIgnoresAlreadyExists` | folder save swallows already-exists |
| `StoreFolderCacheReturnsOtherErrors` | folder save still propagates real failures |

The negative cases pin down that the guard is narrow and genuine cache failures still fail the build.

Verified the tests actually catch the regression: with the `errors.Is` guards temporarily removed, both positive tests fail with the same message as the CI log, while the two negative tests keep passing.

`go build ./...`, the full `go test ./...` suite, and `golangci-lint run ./internal/system/...` (0 issues) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)