### PR TITLE
Fix component name for Gitlab deployment.

### DIFF
--- a/internal/shop/project_scaffold_static/gitlab-ci.yml.tmpl
+++ b/internal/shop/project_scaffold_static/gitlab-ci.yml.tmpl
@@ -9,7 +9,7 @@ include:
     inputs:
       php_version: "8.4"
 {{- if .Deployer }}
-  - component: gitlab.com/shopware/ci-components/project-deploy@main
+  - component: gitlab.com/shopware/ci-components/project-deployer@main
     inputs:
       php_version: "8.4"
 {{- end }}


### PR DESCRIPTION
The component name for Gitlab was wrong since it got changed in https://gitlab.com/shopware/ci-components/-/commit/b9f682b2ed95e7de98a6973b33a289f53b89ea0a